### PR TITLE
Implementation + Tests for i32.div_s and i32.div_u. Runtime Errors

### DIFF
--- a/examples/stuff/main.rs
+++ b/examples/stuff/main.rs
@@ -53,15 +53,15 @@ fn main() -> ExitCode {
         }
     };
 
-    let twelve: i32 = instance.invoke_func(1, (5, 7));
+    let twelve: i32 = instance.invoke_func(1, (5, 7)).unwrap();
     assert_eq!(twelve, 12);
 
-    let twelve_plus_one: i32 = instance.invoke_func(0, twelve);
+    let twelve_plus_one: i32 = instance.invoke_func(0, twelve).unwrap();
     assert_eq!(twelve_plus_one, 13);
 
-    instance.invoke_func::<_, ()>(2, 42_i32);
+    instance.invoke_func::<_, ()>(2, 42_i32).unwrap();
 
-    assert_eq!(instance.invoke_func::<(), i32>(3, ()), 42_i32);
+    assert_eq!(instance.invoke_func::<(), i32>(3, ()).unwrap(), 42_i32);
 
     ExitCode::SUCCESS
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -6,6 +6,12 @@ use crate::core::reader::section_header::SectionTy;
 use crate::core::reader::types::ValType;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub enum RuntimeError {
+    DivideBy0,
+    UnrepresentableResult,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Error {
     /// The magic number at the very start of the given WASM file is invalid.
     InvalidMagic,
@@ -31,6 +37,7 @@ pub enum Error {
     MoreThanOneMemory,
     InvalidGlobalIdx(GlobalIdx),
     GlobalIsConst,
+    RuntimeError(RuntimeError),
 }
 
 impl Display for Error {
@@ -97,6 +104,10 @@ impl Display for Error {
                 "An invalid global index `{idx}` was specified"
             )),
             Error::GlobalIsConst => f.write_str("A const global cannot be written to"),
+            Error::RuntimeError(err) => match err {
+                RuntimeError::DivideBy0 => f.write_str("Divide by zero is not permitted"),
+                RuntimeError::UnrepresentableResult => f.write_str("Result is unrepresentable"),
+            },
         }
     }
 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -239,6 +239,25 @@ impl<'b> RuntimeInstance<'b> {
                     trace!("Instruction: i32.div_s [{divisor} {dividend}] -> [{res}]");
                     stack.push_value(res.into());
                 }
+                // i32.div_u: [i32 i32] -> [i32]
+                0x6E => {
+                    let dividend: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let divisor: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    let dividend = dividend as u32;
+                    let divisor = divisor as u32;
+
+                    if dividend == 0 {
+                      return Err(crate::Error::RuntimeError(
+                        crate::core::error::RuntimeError::DivideBy0,
+                    ));
+                    }
+
+                    let res = (divisor / dividend) as i32;
+
+                    trace!("Instruction: i32.div_u [{divisor} {dividend}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
                 other => {
                     trace!("Unknown instruction {other:#x}, skipping..");
                 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -216,6 +216,23 @@ impl<'b> RuntimeInstance<'b> {
                   trace!("Instruction: i32.mul [{v1} {v2}] -> [{res}]");
                   stack.push_value(res.into());
                 }
+                // i32.div_s: [i32 i32] -> [i32]
+                0x6D => {
+                    let dividend: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let divisor: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    if dividend == 0 {
+                        panic!("RuntimeError: divide by zero");
+                    }
+                    if divisor == i32::MIN && dividend == -1 {
+                        panic!("RuntimeError: divide result unrepresentable");
+                    }
+
+                    let res = divisor / dividend;
+
+                    trace!("Instruction: i32.div_s [{divisor} {dividend}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
                 other => {
                     trace!("Unknown instruction {other:#x}, skipping..");
                 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -12,6 +12,8 @@ use crate::execution::store::{FuncInst, GlobalInst, MemInst, Store};
 use crate::execution::value::Value;
 use crate::validation::code::read_declared_locals;
 use crate::value::InteropValueList;
+use crate::Error::RuntimeError;
+use crate::RuntimeError::{DivideBy0, UnrepresentableResult};
 use crate::{Result, ValidationInfo};
 
 // TODO
@@ -224,14 +226,10 @@ impl<'b> RuntimeInstance<'b> {
                     let divisor: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                     if dividend == 0 {
-                        return Err(crate::Error::RuntimeError(
-                            crate::core::error::RuntimeError::DivideBy0,
-                        ));
+                        return Err(RuntimeError(DivideBy0));
                     }
                     if divisor == i32::MIN && dividend == -1 {
-                        return Err(crate::Error::RuntimeError(
-                            crate::core::error::RuntimeError::UnrepresentableResult,
-                        ));
+                        return Err(RuntimeError(UnrepresentableResult));
                     }
 
                     let res = divisor / dividend;
@@ -248,9 +246,7 @@ impl<'b> RuntimeInstance<'b> {
                     let divisor = divisor as u32;
 
                     if dividend == 0 {
-                        return Err(crate::Error::RuntimeError(
-                            crate::core::error::RuntimeError::DivideBy0,
-                        ));
+                        return Err(RuntimeError(DivideBy0));
                     }
 
                     let res = (divisor / dividend) as i32;

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -248,9 +248,9 @@ impl<'b> RuntimeInstance<'b> {
                     let divisor = divisor as u32;
 
                     if dividend == 0 {
-                      return Err(crate::Error::RuntimeError(
-                        crate::core::error::RuntimeError::DivideBy0,
-                    ));
+                        return Err(crate::Error::RuntimeError(
+                            crate::core::error::RuntimeError::DivideBy0,
+                        ));
                     }
 
                     let res = (divisor / dividend) as i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 #[macro_use]
 extern crate log;
 
-pub use core::error::{Error, Result};
+pub use core::error::{Error, Result, RuntimeError};
 pub use execution::*;
 pub use validation::*;
 

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -176,6 +176,13 @@ fn read_instructions(
 
                 value_stack.push_back(ValType::NumType(NumType::I32));
             }
+            // i32.div_s: [i32 i32] -> [i32]
+            0x6D => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
             // i32.const: [] -> [i32]
             0x41 => {
                 let _num = wasm.read_var_i32()?;

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -183,6 +183,13 @@ fn read_instructions(
 
                 value_stack.push_back(ValType::NumType(NumType::I32));
             }
+            // i32.div_u: [i32 i32] -> [i32]
+            0x6E => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
             // i32.const: [] -> [i32]
             0x41 => {
                 let _num = wasm.read_var_i32()?;

--- a/tests/add_one.rs
+++ b/tests/add_one.rs
@@ -16,7 +16,7 @@ fn add_one() {
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    assert_eq!(12, instance.invoke_func(0, 11));
-    assert_eq!(1, instance.invoke_func(0, 0));
-    assert_eq!(-5, instance.invoke_func(0, -6));
+    assert_eq!(12, instance.invoke_func(0, 11).unwrap());
+    assert_eq!(1, instance.invoke_func(0, 0).unwrap());
+    assert_eq!(-5, instance.invoke_func(0, -6).unwrap());
 }

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -1,3 +1,6 @@
+use wasm::Error::RuntimeError;
+use wasm::RuntimeError::{DivideBy0, UnrepresentableResult};
+
 /// A simple function to test signed division
 #[test_log::test]
 pub fn division_signed_simple() {
@@ -47,10 +50,7 @@ pub fn division_signed_panic_dividend_0() {
 
     let result = instance.invoke_func::<(i32, i32), i32>(0, (222, 0));
 
-    assert_eq!(
-        result.unwrap_err(),
-        wasm::Error::RuntimeError(wasm::RuntimeError::DivideBy0)
-    );
+    assert_eq!(result.unwrap_err(), RuntimeError(DivideBy0));
 }
 
 /// A simple function to test signed division's RuntimeError when we are dividing the i32 minimum by -1 (which gives an unrepresentable result - overflow)
@@ -75,10 +75,7 @@ pub fn division_signed_panic_result_unrepresentable() {
 
     let result = instance.invoke_func::<(i32, i32), i32>(0, (i32::MIN, -1));
 
-    assert_eq!(
-        result.unwrap_err(),
-        wasm::Error::RuntimeError(wasm::RuntimeError::UnrepresentableResult)
-    );
+    assert_eq!(result.unwrap_err(), RuntimeError(UnrepresentableResult));
 }
 
 /// A simple function to test unsigned division
@@ -134,8 +131,5 @@ pub fn division_unsigned_panic_dividend_0() {
 
     let result = instance.invoke_func::<(i32, i32), i32>(0, (222, 0));
 
-    assert_eq!(
-        result.unwrap_err(),
-        wasm::Error::RuntimeError(wasm::RuntimeError::DivideBy0)
-    );
+    assert_eq!(result.unwrap_err(), RuntimeError(DivideBy0));
 }

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -80,3 +80,65 @@ pub fn division_signed_panic_result_unrepresentable() {
         wasm::Error::RuntimeError(wasm::RuntimeError::UnrepresentableResult)
     );
 }
+
+
+/// A simple function to test unsigned division
+#[test_log::test]
+pub fn division_unsigned_simple() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = r#"
+    (module
+        (func (export "unsigned_division") (param $divisor i32) (param $dividend i32) (result i32)
+            local.get $divisor
+            local.get $dividend
+            i32.div_u)
+    )
+    "#;
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(10, instance.invoke_func(0, (20, 2)).unwrap());
+    assert_eq!(9_001, instance.invoke_func(0, (81_018_001, 9_001)).unwrap());
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, -1)).unwrap());
+
+
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, -1)).unwrap());
+    assert_eq!(-20, instance.invoke_func(0, (-20, 1)).unwrap());
+    assert_eq!(2147483638, instance.invoke_func(0, (-20, 2)).unwrap());
+    assert_eq!(1431655758, instance.invoke_func(0, (-20, 3)).unwrap());
+    assert_eq!(1073741819, instance.invoke_func(0, (-20, 4)).unwrap());
+
+}
+
+/// A simple function to test unsigned division's RuntimeError when dividing by 0
+#[test_log::test]
+pub fn division_unsigned_panic_dividend_0() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = r#"
+    (module
+        (func (export "unsigned_division") (param $divisor i32) (param $dividend i32) (result i32)
+            local.get $divisor
+            local.get $dividend
+            i32.div_u)
+    )
+    "#;
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    let result = instance.invoke_func::<(i32, i32), i32>(0, (222, 0));
+
+    assert_eq!(
+        result.unwrap_err(),
+        wasm::Error::RuntimeError(wasm::RuntimeError::DivideBy0)
+    );
+}

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -81,7 +81,6 @@ pub fn division_signed_panic_result_unrepresentable() {
     );
 }
 
-
 /// A simple function to test unsigned division
 #[test_log::test]
 pub fn division_unsigned_simple() {
@@ -106,13 +105,11 @@ pub fn division_unsigned_simple() {
     assert_eq!(9_001, instance.invoke_func(0, (81_018_001, 9_001)).unwrap());
     assert_eq!(0, instance.invoke_func(0, (i32::MIN, -1)).unwrap());
 
-
     assert_eq!(0, instance.invoke_func(0, (i32::MIN, -1)).unwrap());
     assert_eq!(-20, instance.invoke_func(0, (-20, 1)).unwrap());
     assert_eq!(2147483638, instance.invoke_func(0, (-20, 2)).unwrap());
     assert_eq!(1431655758, instance.invoke_func(0, (-20, 3)).unwrap());
     assert_eq!(1073741819, instance.invoke_func(0, (-20, 4)).unwrap());
-
 }
 
 /// A simple function to test unsigned division's RuntimeError when dividing by 0

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -1,0 +1,71 @@
+/// A simple function to test signed division
+#[test_log::test]
+pub fn division_signed_simple() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = r#"
+    (module
+        (func (export "signed_division") (param $divisor i32) (param $dividend i32) (result i32)
+            local.get $divisor
+            local.get $dividend
+            i32.div_s)
+    )
+    "#;
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(10, instance.invoke_func(0, (20, 2)));
+    assert_eq!(9_001, instance.invoke_func(0, (81_018_001, 9_001)));
+}
+
+/// A simple function to test signed division's RuntimeError when dividing by 0
+#[test_log::test]
+#[should_panic(expected = "RuntimeError: divide by zero")]
+pub fn division_signed_panic_dividend_0() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = r#"
+  (module
+      (func (export "signed_division") (param $divisor i32) (param $dividend i32) (result i32)
+          local.get $divisor
+          local.get $dividend
+          i32.div_s)
+  )
+  "#;
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    instance.invoke_func::<(i32, i32), i32>(0, (222, 0));
+}
+
+/// A simple function to test signed division's RuntimeError when we are dividing the i32 minimum by -1 (which gives an unrepresentable result - overflow)
+#[test_log::test]
+#[should_panic(expected = "RuntimeError: divide result unrepresentable")]
+pub fn division_signed_panic_result_unrepresentable() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = r#"
+  (module
+      (func (export "signed_division") (param $divisor i32) (param $dividend i32) (result i32)
+          local.get $divisor
+          local.get $dividend
+          i32.div_s)
+  )
+  "#;
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    instance.invoke_func::<(i32, i32), i32>(0, (-(2_i32.pow(31)), -1));
+}

--- a/tests/arithmetic/mod.rs
+++ b/tests/arithmetic/mod.rs
@@ -1,1 +1,2 @@
+mod division;
 mod multiply;

--- a/tests/arithmetic/multiply.rs
+++ b/tests/arithmetic/multiply.rs
@@ -18,10 +18,10 @@ pub fn multiply() {
 
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    assert_eq!(33, instance.invoke_func(0, 11));
-    assert_eq!(0, instance.invoke_func(0, 0));
-    assert_eq!(-30, instance.invoke_func(0, -10));
+    assert_eq!(33, instance.invoke_func(0, 11).unwrap());
+    assert_eq!(0, instance.invoke_func(0, 0).unwrap());
+    assert_eq!(-30, instance.invoke_func(0, -10).unwrap());
 
-    assert_eq!(i32::MAX - 5, instance.invoke_func(0, i32::MAX-1));
-    assert_eq!(i32::MIN + 3, instance.invoke_func(0, i32::MIN+1));
+    assert_eq!(i32::MAX - 5, instance.invoke_func(0, i32::MAX - 1).unwrap());
+    assert_eq!(i32::MIN + 3, instance.invoke_func(0, i32::MIN + 1).unwrap());
 }

--- a/tests/basic_memory.rs
+++ b/tests/basic_memory.rs
@@ -20,6 +20,6 @@ fn basic_memory() {
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let () = instance.invoke_func(0, 42);
-    assert_eq!(42, instance.invoke_func(1, ()));
+    let _ = instance.invoke_func::<i32, ()>(0, 42);
+    assert_eq!(42, instance.invoke_func(1, ()).unwrap());
 }

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -28,8 +28,8 @@ fn globals() {
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     // Set global to 17. 3 is returned as previous (default) value.
-    assert_eq!(3, instance.invoke_func(0, 17));
+    assert_eq!(3, instance.invoke_func(0, 17).unwrap());
 
     // Now 17 will be returned when getting the global
-    assert_eq!(17, instance.invoke_func(1, ()));
+    assert_eq!(17, instance.invoke_func(1, ()).unwrap());
 }

--- a/tests/start_function.rs
+++ b/tests/start_function.rs
@@ -25,5 +25,5 @@ fn start_function() {
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    assert_eq!(42, instance.invoke_func(1, ()));
+    assert_eq!(42, instance.invoke_func(1, ()).unwrap());
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request:
- adds the `i32.div_s` operation
- adds test cases for the `i32.div_s` operation
- adds the `i32.div_u` operation
- adds test cases for the `i32.div_u` operation
- refactors the `invoke_func` and `function` functions to be able to return an error through the Result return type - to add runtime errors


### Testing Strategy

This pull request was tested locally on the added test case and all others.


### TODO or Help Wanted

This pull request still needs a review.


### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`


### Github Issue

This pull request partially implements #2


### Author

Signed-off-by: Popescu Adrian <adrian.popescu@oxidos.io>
