### PR TITLE
Feature + Test: i32 bitwise operations

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -225,6 +225,30 @@ where
                     trace!("Instruction: i32.const [] -> [{constant}]");
                     stack.push_value(constant.into());
                 }
+                // i32.clz: [i32] -> [i32]
+                0x67 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let res = v1.leading_zeros() as i32;
+
+                    trace!("Instruction: i32.clz [{v1}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.ctz: [i32] -> [i32]
+                0x68 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let res = v1.trailing_zeros() as i32;
+
+                    trace!("Instruction: i32.ctz [{v1}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.popcnt: [i32] -> [i32]
+                0x69 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let res = v1.count_ones() as i32;
+
+                    trace!("Instruction: i32.popcnt [{v1}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
                 // i32.add: [i32 i32] -> [i32]
                 0x6A => {
                     let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -308,6 +332,82 @@ where
                     let res = res.unwrap_or_default() as i32;
 
                     trace!("Instruction: i32.rem_u [{divisor} {dividend}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.and: [i32 i32] -> [i32]
+                0x71 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let res = v1 & v2;
+
+                    trace!("Instruction: i32.and [{v1} {v2}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.or: [i32 i32] -> [i32]
+                0x72 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let res = v1 | v2;
+
+                    trace!("Instruction: i32.or [{v1} {v2}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.xor: [i32 i32] -> [i32]
+                0x73 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let res = v1 ^ v2;
+
+                    trace!("Instruction: i32.xor [{v1} {v2}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.shl: [i32 i32] -> [i32]
+                0x74 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let res = v2.wrapping_shl(v1 as u32);
+
+                    trace!("Instruction: i32.shl [{v2} {v1}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.shr_s: [i32 i32] -> [i32]
+                0x75 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    let res = v2.wrapping_shr(v1 as u32);
+
+                    trace!("Instruction: i32.shr_s [{v2} {v1}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.shr_u: [i32 i32] -> [i32]
+                0x76 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    let res = (v2 as u32).wrapping_shr(v1 as u32) as i32;
+
+                    trace!("Instruction: i32.shr_u [{v2} {v1}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.rotl: [i32 i32] -> [i32]
+                0x77 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    let res = v2.rotate_left(v1 as u32);
+
+                    trace!("Instruction: i32.rotl [{v2} {v1}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.rotr: [i32 i32] -> [i32]
+                0x78 => {
+                    let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    let res = v2.rotate_right(v1 as u32);
+
+                    trace!("Instruction: i32.rotr [{v2} {v1}] -> [{res}]");
                     stack.push_value(res.into());
                 }
                 other => {

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -210,6 +210,80 @@ fn read_instructions(
                 let _num = wasm.read_var_i32()?;
                 value_stack.push_back(ValType::NumType(NumType::I32));
             }
+            // i32.clz: [i32] -> [i32]
+            0x67 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.ctz: [i32] -> [i32]
+            0x68 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.popcnt: [i32] -> [i32]
+            0x69 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.and: [i32 i32] -> [i32]
+            0x71 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.or: [i32 i32] -> [i32]
+            0x72 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.xor: [i32 i32] -> [i32]
+            0x73 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.shl: [i32 i32] -> [i32]
+            0x74 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.shr_s: [i32 i32] -> [i32]
+            0x75 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.shr_u: [i32 i32] -> [i32]
+            0x76 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.rotl: [i32 i32] -> [i32]
+            0x77 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.rotr: [i32 i32] -> [i32]
+            0x78 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
             other => {
                 return Err(Error::InvalidInstr(other));
             }

--- a/tests/arithmetic/bitwise.rs
+++ b/tests/arithmetic/bitwise.rs
@@ -1,0 +1,422 @@
+const BASE_WAT: &'static str = r#"
+    (module
+      (func (export "template") (param $x i32) (param $y i32) (result i32)
+          local.get $x
+          local.get $y
+          i32.{{0}})
+    )
+"#;
+/// A simple function to test the i32.and bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_and() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "and");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(1, instance.invoke_func(0, (33, 11)).unwrap());
+    assert_eq!(5, instance.invoke_func(0, (77, 23)).unwrap());
+    assert_eq!(180244, instance.invoke_func(0, (192534, 1231412)).unwrap());
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap());
+}
+
+/// A simple function to test the i32.or bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_or() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "or");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(43, instance.invoke_func(0, (33, 11)).unwrap());
+    assert_eq!(95, instance.invoke_func(0, (77, 23)).unwrap());
+    assert_eq!(1243702, instance.invoke_func(0, (192534, 1231412)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap());
+}
+
+/// A simple function to test the i32.xor bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_xor() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "xor");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(42, instance.invoke_func(0, (33, 11)).unwrap());
+    assert_eq!(90, instance.invoke_func(0, (77, 23)).unwrap());
+    assert_eq!(1063458, instance.invoke_func(0, (192534, 1231412)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap());
+}
+
+/// A simple function to test the i32.shl bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_shl() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "shl");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(67584, instance.invoke_func(0, (33, 11)).unwrap());
+    assert_eq!(645922816, instance.invoke_func(0, (77, 23)).unwrap());
+    assert_eq!(
+        23068672,
+        instance.invoke_func(0, (192534, 1231412)).unwrap()
+    );
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap());
+}
+
+/// A simple function to test the i32.shr_s bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_shr_s() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "shr_s");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(8881445, instance.invoke_func(0, (142_103_123, 4)).unwrap());
+    assert_eq!(23879, instance.invoke_func(0, (391_248_921, 14)).unwrap());
+    assert_eq!(
+        601955006,
+        instance.invoke_func(0, (1_203_910_012, 33)).unwrap()
+    );
+    assert_eq!(
+        1056594615,
+        instance.invoke_func(0, (2_113_189_231, 33)).unwrap()
+    );
+    assert_eq!(-1, instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap());
+
+    // Basic positive number
+    assert_eq!(4, instance.invoke_func(0, (8, 1)).unwrap());
+
+    // Shifting by 0 (no shift)
+    assert_eq!(-1, instance.invoke_func(0, (-1, 0)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 0)).unwrap());
+
+    // Shifting negative numbers
+    assert_eq!(-4, instance.invoke_func(0, (-8, 1)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (-1, 1)).unwrap());
+
+    // Shifting by 31 (maximum shift for 32-bit int)
+    assert_eq!(-1, instance.invoke_func(0, (-1, 31)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (i32::MIN, 31)).unwrap());
+    assert_eq!(0, instance.invoke_func(0, (i32::MAX, 31)).unwrap());
+
+    // Shifting by more than 31
+    assert_eq!(-1, instance.invoke_func(0, (-1, 32)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 32)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (-1, 100)).unwrap());
+
+    // Minimum and maximum 32-bit integers
+    assert_eq!(
+        i32::MIN / 2,
+        instance.invoke_func(0, (i32::MIN, 1)).unwrap()
+    );
+    assert_eq!(
+        i32::MAX / 2,
+        instance.invoke_func(0, (i32::MAX, 1)).unwrap()
+    );
+
+    // Shifting out all bits except sign
+    assert_eq!(-2, instance.invoke_func(0, (i32::MIN, 30)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (i32::MAX, 30)).unwrap());
+}
+
+/// A simple function to test the i32.shr_u bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_shr_u() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "shr_u");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(8881445, instance.invoke_func(0, (142_103_123, 4)).unwrap());
+    assert_eq!(23879, instance.invoke_func(0, (391_248_921, 14)).unwrap());
+    assert_eq!(
+        601955006,
+        instance.invoke_func(0, (1_203_910_012, 33)).unwrap()
+    );
+    assert_eq!(
+        1056594615,
+        instance.invoke_func(0, (2_113_189_231, 33)).unwrap()
+    );
+    assert_eq!(1, instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap());
+
+    // Basic positive number
+    assert_eq!(4, instance.invoke_func(0, (8, 1)).unwrap());
+
+    // Shifting by 0 (no shift)
+    assert_eq!(-1, instance.invoke_func(0, (-1, 0)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 0)).unwrap());
+
+    // Shifting negative numbers
+    assert_eq!(i32::MAX - 3, instance.invoke_func(0, (-8, 1)).unwrap());
+    assert_eq!(i32::MAX, instance.invoke_func(0, (-1, 1)).unwrap());
+
+    // Shifting by 31 (maximum shift for 32-bit int)
+    assert_eq!(1, instance.invoke_func(0, (-1, 31)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (i32::MIN, 31)).unwrap());
+    assert_eq!(0, instance.invoke_func(0, (i32::MAX, 31)).unwrap());
+
+    // Shifting by more than 31
+    assert_eq!(-1, instance.invoke_func(0, (-1, 32)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 32)).unwrap());
+    assert_eq!(268435455, instance.invoke_func(0, (-1, 100)).unwrap());
+
+    // Minimum and maximum 32-bit integers
+    assert_eq!(
+        (i32::MIN / 2) * (-1),
+        instance.invoke_func(0, (i32::MIN, 1)).unwrap()
+    );
+    assert_eq!(
+        i32::MAX / 2,
+        instance.invoke_func(0, (i32::MAX, 1)).unwrap()
+    );
+
+    // Shifting out all bits except sign
+    assert_eq!(2, instance.invoke_func(0, (i32::MIN, 30)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (i32::MAX, 30)).unwrap());
+}
+
+/// A simple function to test the i32.rotl bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_rotl() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "rotl");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(
+        -2021317328,
+        instance.invoke_func(0, (142_103_123, 4)).unwrap()
+    );
+    assert_eq!(
+        2131117524,
+        instance.invoke_func(0, (391_248_921, 14)).unwrap()
+    );
+    assert_eq!(
+        -1887147272,
+        instance.invoke_func(0, (1_203_910_012, 33)).unwrap()
+    );
+    assert_eq!(
+        -68588834,
+        instance.invoke_func(0, (2_113_189_231, 33)).unwrap()
+    );
+    assert_eq!(
+        1073741824,
+        instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap()
+    );
+
+    // Basic positive number
+    assert_eq!(16, instance.invoke_func(0, (8, 1)).unwrap());
+
+    // Rotating by 0 (no shift)
+    assert_eq!(-1, instance.invoke_func(0, (-1, 0)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 0)).unwrap());
+
+    // Shifting negative numbers
+    assert_eq!(-15, instance.invoke_func(0, (-8, 1)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (-1, 1)).unwrap());
+
+    // Rotating by 31
+    assert_eq!(-1, instance.invoke_func(0, (-1, 31)).unwrap());
+    assert_eq!(
+        i32::MAX / 2 + 1,
+        instance.invoke_func(0, (i32::MIN, 31)).unwrap()
+    );
+    assert_eq!(
+        i32::MIN / 2 - 1,
+        instance.invoke_func(0, (i32::MAX, 31)).unwrap()
+    );
+
+    // Rotating by more than 31
+    assert_eq!(-1, instance.invoke_func(0, (-1, 32)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 32)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (-1, 100)).unwrap());
+
+    // Minimum and maximum 32-bit integers
+    assert_eq!(1, instance.invoke_func(0, (i32::MIN, 1)).unwrap());
+    assert_eq!(-2, instance.invoke_func(0, (i32::MAX, 1)).unwrap());
+
+    // Shifting out all bits except sign
+    assert_eq!(
+        i32::MAX / 4 + 1,
+        instance.invoke_func(0, (i32::MIN, 30)).unwrap()
+    );
+    assert_eq!(
+        i32::MIN / 4 - 1,
+        instance.invoke_func(0, (i32::MAX, 30)).unwrap()
+    );
+}
+
+/// A simple function to test the i32.rotr bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_rotr() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_WAT).replace("{{0}}", "rotr");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(
+        814187813,
+        instance.invoke_func(0, (142_103_123, 4)).unwrap()
+    );
+    assert_eq!(
+        -261857977,
+        instance.invoke_func(0, (391_248_921, 14)).unwrap()
+    );
+    assert_eq!(
+        601955006,
+        instance.invoke_func(0, (1_203_910_012, 33)).unwrap()
+    );
+    assert_eq!(
+        -1090889033,
+        instance.invoke_func(0, (2_113_189_231, 33)).unwrap()
+    );
+    assert_eq!(1, instance.invoke_func(0, (i32::MIN, i32::MAX)).unwrap());
+
+    // Basic positive number
+    assert_eq!(4, instance.invoke_func(0, (8, 1)).unwrap());
+
+    // Rotating by 0 (no shift)
+    assert_eq!(-1, instance.invoke_func(0, (-1, 0)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 0)).unwrap());
+
+    // Shifting negative numbers
+    assert_eq!(i32::MAX - 3, instance.invoke_func(0, (-8, 1)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (-1, 1)).unwrap());
+
+    // Rotating by 31
+    assert_eq!(-1, instance.invoke_func(0, (-1, 31)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (i32::MIN, 31)).unwrap());
+    assert_eq!(-2, instance.invoke_func(0, (i32::MAX, 31)).unwrap());
+
+    // Rotating by more than 31
+    assert_eq!(-1, instance.invoke_func(0, (-1, 32)).unwrap());
+    assert_eq!(1, instance.invoke_func(0, (1, 32)).unwrap());
+    assert_eq!(-1, instance.invoke_func(0, (-1, 100)).unwrap());
+
+    // Minimum and maximum 32-bit integers
+    assert_eq!(
+        i32::MAX / 2 + 1,
+        instance.invoke_func(0, (i32::MIN, 1)).unwrap()
+    );
+    assert_eq!(
+        i32::MIN / 2 - 1,
+        instance.invoke_func(0, (i32::MAX, 1)).unwrap()
+    );
+
+    // Shifting out all bits except sign
+    assert_eq!(2, instance.invoke_func(0, (i32::MIN, 30)).unwrap());
+    assert_eq!(-3, instance.invoke_func(0, (i32::MAX, 30)).unwrap());
+}
+
+const BASE_COUNT_WAT: &'static str = r#"
+    (module
+      (func (export "template") (param $x i32) (result i32)
+          local.get $x
+          i32.{{0}})
+    )
+"#;
+
+/// A simple function to test the i32.clz bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_clz() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_COUNT_WAT).replace("{{0}}", "clz");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(26, instance.invoke_func(0, 33).unwrap());
+    assert_eq!(25, instance.invoke_func(0, 77).unwrap());
+    assert_eq!(14, instance.invoke_func(0, 192534).unwrap());
+    assert_eq!(0, instance.invoke_func(0, i32::MIN).unwrap());
+    assert_eq!(1, instance.invoke_func(0, i32::MAX).unwrap());
+    assert_eq!(32, instance.invoke_func(0, 0).unwrap());
+}
+
+/// A simple function to test the i32.ctz bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_ctz() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_COUNT_WAT).replace("{{0}}", "ctz");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(0, instance.invoke_func(0, 33).unwrap());
+    assert_eq!(0, instance.invoke_func(0, 77).unwrap());
+    assert_eq!(1, instance.invoke_func(0, 192534).unwrap());
+    assert_eq!(31, instance.invoke_func(0, i32::MIN).unwrap());
+    assert_eq!(0, instance.invoke_func(0, i32::MAX).unwrap());
+    assert_eq!(32, instance.invoke_func(0, 0).unwrap());
+}
+
+/// A simple function to test the i32.popcnt bitwise operation
+#[test_log::test]
+pub fn i32_bitwise_popcnt() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = String::from(BASE_COUNT_WAT).replace("{{0}}", "popcnt");
+
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(2, instance.invoke_func(0, 33).unwrap());
+    assert_eq!(4, instance.invoke_func(0, 77).unwrap());
+    assert_eq!(8, instance.invoke_func(0, 192534).unwrap());
+    assert_eq!(1, instance.invoke_func(0, i32::MIN).unwrap());
+    assert_eq!(31, instance.invoke_func(0, i32::MAX).unwrap());
+    assert_eq!(0, instance.invoke_func(0, 0).unwrap());
+}

--- a/tests/arithmetic/mod.rs
+++ b/tests/arithmetic/mod.rs
@@ -1,3 +1,4 @@
+mod bitwise;
 mod division;
 mod multiply;
 mod remainder;


### PR DESCRIPTION
### Pull Request Overview

This pull request:
- adds the next bitwise operations (along with test cases): `i32.and`, `i32.or`, `i32.xor`, `i32.shl`, `i32.shr_s`, `i32.shr_u`, `i32.rotl`, `i32.rotr`, `i32.clz`, `i32.ctz`, `i32.popcnt`


### Testing Strategy

This pull request was tested locally using the provided test cases.


### TODO or Help Wanted

N/A


### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`


### Github Issue

This pull request partially implements #2.


### Author

Signed-off-by: Popescu Adrian <adrian.popescu@oxidos.io>
