### PR TITLE
Feature + Test: i32 rem operations

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -45,6 +45,8 @@ impl<'b> RuntimeInstance<'b> {
         if let Some(start) = validation_info.start {
             let result = instance.invoke_func::<(), ()>(start, ());
             result?;
+            let result = instance.invoke_func::<(), ()>(start, ());
+            result?;
         }
 
         Ok(instance)
@@ -252,6 +254,39 @@ impl<'b> RuntimeInstance<'b> {
                     let res = (divisor / dividend) as i32;
 
                     trace!("Instruction: i32.div_u [{divisor} {dividend}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.rem_s: [i32 i32] -> [i32]
+                0x6F => {
+                    let dividend: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let divisor: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    if dividend == 0 {
+                        return Err(RuntimeError(DivideBy0));
+                    }
+
+                    let res = divisor.checked_rem(dividend);
+                    let res = res.unwrap_or_default();
+
+                    trace!("Instruction: i32.rem_s [{divisor} {dividend}] -> [{res}]");
+                    stack.push_value(res.into());
+                }
+                // i32.rem_u: [i32 i32] -> [i32]
+                0x70 => {
+                    let dividend: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                    let divisor: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                    let dividend = dividend as u32;
+                    let divisor = divisor as u32;
+
+                    if dividend == 0 {
+                        return Err(RuntimeError(DivideBy0));
+                    }
+
+                    let res = divisor.checked_rem(dividend);
+                    let res = res.unwrap_or_default() as i32;
+
+                    trace!("Instruction: i32.rem_u [{divisor} {dividend}] -> [{res}]");
                     stack.push_value(res.into());
                 }
                 other => {

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -190,6 +190,20 @@ fn read_instructions(
 
                 value_stack.push_back(ValType::NumType(NumType::I32));
             }
+            // i32.rem_s: [i32 i32] -> [i32]
+            0x6F => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
+            // i32.rem_u: [i32 i32] -> [i32]
+            0x70 => {
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+
+                value_stack.push_back(ValType::NumType(NumType::I32));
+            }
             // i32.const: [] -> [i32]
             0x41 => {
                 let _num = wasm.read_var_i32()?;

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -26,6 +26,11 @@ pub fn division_signed_simple() {
     assert_eq!(-10, instance.invoke_func(0, (20, -2)).unwrap());
     assert_eq!(10, instance.invoke_func(0, (-20, -2)).unwrap());
     assert_eq!(-10, instance.invoke_func(0, (-20, 2)).unwrap());
+    assert_eq!(10, instance.invoke_func(0, (20, 2)).unwrap());
+    assert_eq!(9_001, instance.invoke_func(0, (81_018_001, 9_001)).unwrap());
+    assert_eq!(-10, instance.invoke_func(0, (20, -2)).unwrap());
+    assert_eq!(10, instance.invoke_func(0, (-20, -2)).unwrap());
+    assert_eq!(-10, instance.invoke_func(0, (-20, 2)).unwrap());
 }
 
 /// A simple function to test signed division's RuntimeError when dividing by 0

--- a/tests/arithmetic/mod.rs
+++ b/tests/arithmetic/mod.rs
@@ -1,2 +1,3 @@
 mod division;
 mod multiply;
+mod remainder;

--- a/tests/arithmetic/remainder.rs
+++ b/tests/arithmetic/remainder.rs
@@ -1,0 +1,105 @@
+const REM_S_WAT: &'static str = r#"
+    (module
+        (func (export "rem_s") (param $divisor i32) (param $dividend i32) (result i32)
+            local.get $divisor
+            local.get $dividend
+            i32.rem_s)
+    )
+"#;
+
+const REM_U_WAT: &'static str = r#"
+    (module
+        (func (export "rem_u") (param $divisor i32) (param $dividend i32) (result i32)
+            local.get $divisor
+            local.get $dividend
+            i32.rem_u)
+    )
+"#;
+
+/// A simple function to test signed remainder
+#[test_log::test]
+pub fn remainder_signed_simple() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = REM_S_WAT;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(0, instance.invoke_func(0, (20, 2)).unwrap());
+    assert_eq!(999, instance.invoke_func(0, (10_000, 9_001)).unwrap());
+    assert_eq!(-2, instance.invoke_func(0, (-20, 3)).unwrap());
+    assert_eq!(-2, instance.invoke_func(0, (-20, -3)).unwrap());
+    assert_eq!(2, instance.invoke_func(0, (20, -3)).unwrap());
+    assert_eq!(2, instance.invoke_func(0, (20, 3)).unwrap());
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, -1)).unwrap());
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, 2)).unwrap());
+}
+
+/// A simple function to test signed remainder's RuntimeError when dividing by 0
+#[test_log::test]
+pub fn remainder_signed_panic_dividend_0() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = REM_S_WAT;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    let result = instance.invoke_func::<(i32, i32), i32>(0, (222, 0));
+
+    assert_eq!(
+        result.unwrap_err(),
+        wasm::Error::RuntimeError(wasm::RuntimeError::DivideBy0)
+    );
+}
+
+/// A simple function to test unsigned remainder
+#[test_log::test]
+pub fn remainder_unsigned_simple() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = REM_U_WAT;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, 2)).unwrap());
+    assert_eq!(i32::MIN, instance.invoke_func(0, (i32::MIN, -2)).unwrap());
+    assert_eq!(
+        (i32::MIN + 2) * (-1),
+        instance.invoke_func(0, (-2, i32::MIN)).unwrap()
+    );
+    assert_eq!(2, instance.invoke_func(0, (2, i32::MIN)).unwrap());
+    assert_eq!(
+        i32::MAX,
+        instance.invoke_func(0, (i32::MAX, i32::MIN)).unwrap()
+    );
+
+    assert_eq!(0, instance.invoke_func(0, (20, 2)).unwrap());
+    assert_eq!(999, instance.invoke_func(0, (10_000, 9_001)).unwrap());
+    assert_eq!(2, instance.invoke_func(0, (-20, 3)).unwrap());
+    assert_eq!(-20, instance.invoke_func(0, (-20, -3)).unwrap());
+    assert_eq!(20, instance.invoke_func(0, (20, -3)).unwrap());
+    assert_eq!(2, instance.invoke_func(0, (20, 3)).unwrap());
+    assert_eq!(i32::MIN, instance.invoke_func(0, (i32::MIN, -1)).unwrap());
+    assert_eq!(0, instance.invoke_func(0, (i32::MIN, 2)).unwrap());
+}
+
+/// A simple function to test signed remainder's RuntimeError when dividing by 0
+#[test_log::test]
+pub fn remainder_unsigned_panic_dividend_0() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = REM_U_WAT;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    let result = instance.invoke_func::<(i32, i32), i32>(0, (222, 0));
+
+    assert_eq!(
+        result.unwrap_err(),
+        wasm::Error::RuntimeError(wasm::RuntimeError::DivideBy0)
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the next i32 operations, with test cases: `i32.rem_s`, `i32.rem_u`.

### Testing Strategy

This pull request was tested using the provided test cases, locally.

### TODO or Help Wanted

N/A

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [ ] Ran `nix fmt`
- [ ] Ran `treefmt`

### Github Issue

This pull request partially implements #2.

### Author

Signed-off-by: Popescu Adrian <adrian.popescu@oxidos.io>
