### PR TITLE
refactor: magic bytes to constant op codes

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
     InvalidExportDesc(u8),
     InvalidImportDesc(u8),
     ExprMissingEnd,
-    InvalidInstr(u8),
+    InvalidInstr(u16),
     EndInvalidValueStack,
     InvalidLocalIdx,
     InvalidValueStackType(Option<ValType>),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod error;
 
 pub mod indices;
+pub mod opcodes;
 pub mod reader;

--- a/src/core/opcodes.rs
+++ b/src/core/opcodes.rs
@@ -1,0 +1,21 @@
+pub const NOP: u8 = 0x01;
+pub const END: u8 = 0x0B;
+pub const LOCAL_GET: u8 = 0x20;
+pub const LOCAL_SET: u8 = 0x21;
+pub const GLOBAL_GET: u8 = 0x23;
+pub const GLOBAL_SET: u8 = 0x24;
+pub const I32_LOAD: u8 = 0x28;
+pub const I32_STORE: u8 = 0x36;
+pub const I32_CONST: u8 = 0x41;
+pub const I32_ADD: u8 = 0x6A;
+pub const I32_MUL: u8 = 0x6C;
+pub const I32_DIV_S: u8 = 0x6D;
+pub const I32_DIV_U: u8 = 0x6E;
+pub const FB_INSTRUCTIONS: u8 = 0xFB;
+pub const FC_INSTRUCTIONS: u8 = 0xFC;
+pub const FD_INSTRUCTIONS: u8 = 0xFD;
+pub const FE_INSTRUCTIONS: u8 = 0xFE;
+
+pub mod fc_opcodes {
+    pub const I32_TRUNC_SAT_F32S: u8 = 0x00;
+}

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use value_stack::Stack;
 
 use crate::core::indices::{FuncIdx, GlobalIdx, LocalIdx};
+use crate::core::opcodes::*;
 use crate::core::reader::types::memarg::MemArg;
 use crate::core::reader::types::{FuncType, NumType, ValType};
 use crate::core::reader::{WasmReadable, WasmReader};
@@ -12,7 +13,7 @@ use crate::execution::store::{FuncInst, GlobalInst, MemInst, Store};
 use crate::execution::value::Value;
 use crate::validation::code::read_declared_locals;
 use crate::value::InteropValueList;
-use crate::Error::RuntimeError;
+use crate::Error::{self, RuntimeError};
 use crate::RuntimeError::{DivideBy0, UnrepresentableResult};
 use crate::{Result, ValidationInfo};
 
@@ -111,20 +112,26 @@ impl<'b> RuntimeInstance<'b> {
         wasm.move_start_to(inst.code_expr);
 
         loop {
-            match wasm.read_u8().unwrap_validated() {
+            let instr = &wasm.full_contents[wasm.pc..];
+            if instr.is_empty() {
+                return Err(Error::Eof);
+            }
+            wasm.strip_bytes::<1>()?;
+            trace!("Read instruction byte {:#x?}", instr.first().unwrap());
+            match instr {
                 // end
-                0x0B => {
+                [NOP, ..] | [END, ..] => {
                     break;
                 }
                 // local.get: [] -> [t]
-                0x20 => {
+                [LOCAL_GET, ..] => {
                     let local_idx = wasm.read_var_u32().unwrap_validated() as LocalIdx;
                     let local = locals.get(local_idx);
                     trace!("Instruction: local.get [] -> [{local:?}]");
                     stack.push_value(local.clone());
                 }
                 // local.set [t] -> []
-                0x21 => {
+                [LOCAL_SET, ..] => {
                     let local_idx = wasm.read_var_u32().unwrap_validated() as LocalIdx;
                     let local = locals.get_mut(local_idx);
                     let value = stack.pop_value(local.to_ty());
@@ -132,21 +139,21 @@ impl<'b> RuntimeInstance<'b> {
                     *local = value;
                 }
                 // global.get [] -> [t]
-                0x23 => {
+                [GLOBAL_GET, ..] => {
                     let global_idx = wasm.read_var_u32().unwrap_validated() as GlobalIdx;
                     let global = self.store.globals.get(global_idx).unwrap_validated();
 
                     stack.push_value(global.value.clone());
                 }
                 // global.set [t] -> []
-                0x24 => {
+                [GLOBAL_SET, ..] => {
                     let global_idx = wasm.read_var_u32().unwrap_validated() as GlobalIdx;
                     let global = self.store.globals.get_mut(global_idx).unwrap_validated();
 
                     global.value = stack.pop_value(global.global.ty.ty)
                 }
                 // i32.load [i32] -> [i32]
-                0x28 => {
+                [I32_LOAD, ..] => {
                     let memarg = MemArg::read_unvalidated(&mut wasm);
                     let relative_address: u32 =
                         stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -174,7 +181,7 @@ impl<'b> RuntimeInstance<'b> {
                     trace!("Instruction: i32.load [{relative_address}] -> [{data}]");
                 }
                 // i32.store [i32] -> [i32]
-                0x36 => {
+                [I32_STORE, ..] => {
                     let memarg = MemArg::read_unvalidated(&mut wasm);
 
                     let data_to_store: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -197,13 +204,13 @@ impl<'b> RuntimeInstance<'b> {
                     trace!("Instruction: i32.store [{relative_address} {data_to_store}] -> []");
                 }
                 // i32.const: [] -> [i32]
-                0x41 => {
+                [I32_CONST, ..] => {
                     let constant = wasm.read_var_i32().unwrap_validated();
                     trace!("Instruction: i32.const [] -> [{constant}]");
                     stack.push_value(constant.into());
                 }
                 // i32.add: [i32 i32] -> [i32]
-                0x6A => {
+                [I32_ADD, ..] => {
                     let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                     let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                     let res = v1.wrapping_add(v2);
@@ -212,7 +219,7 @@ impl<'b> RuntimeInstance<'b> {
                     stack.push_value(res.into());
                 }
                 // i32.mul: [i32 i32] -> [i32]
-                0x6C => {
+                [I32_MUL, ..] => {
                     let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                     let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                     let res = v1.wrapping_mul(v2);
@@ -221,7 +228,7 @@ impl<'b> RuntimeInstance<'b> {
                     stack.push_value(res.into());
                 }
                 // i32.div_s: [i32 i32] -> [i32]
-                0x6D => {
+                [I32_DIV_S, ..] => {
                     let dividend: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                     let divisor: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
@@ -238,7 +245,7 @@ impl<'b> RuntimeInstance<'b> {
                     stack.push_value(res.into());
                 }
                 // i32.div_u: [i32 i32] -> [i32]
-                0x6E => {
+                [I32_DIV_U, ..] => {
                     let dividend: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                     let divisor: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
@@ -254,8 +261,27 @@ impl<'b> RuntimeInstance<'b> {
                     trace!("Instruction: i32.div_u [{divisor} {dividend}] -> [{res}]");
                     stack.push_value(res.into());
                 }
-                other => {
+                [FB_INSTRUCTIONS, _, ..] => {
+                    wasm.strip_bytes::<1>()?;
+                    unimplemented!()
+                }
+                [FC_INSTRUCTIONS, _, ..] => {
+                    wasm.strip_bytes::<1>()?;
+                    unimplemented!()
+                }
+                [FD_INSTRUCTIONS, _, ..] => {
+                    wasm.strip_bytes::<1>()?;
+                    unimplemented!()
+                }
+                [FE_INSTRUCTIONS, _, ..] => {
+                    wasm.strip_bytes::<1>()?;
+                    unimplemented!()
+                }
+                [other, ..] => {
                     trace!("Unknown instruction {other:#x}, skipping..");
+                }
+                &[] => {
+                    unreachable!()
                 }
             }
         }


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the way we handle opcodes: from using magic bytes to using constants.

### Testing Strategy

This pull request was tested locally.

### TODO or Help Wanted

N/A

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [ ] Ran `nix fmt`
- [ ] Ran `treefmt`

### Github Issue

N/A

### Author

Signed-off-by: Popescu Adrian <adrian.popescu@oxidos.io>
