### PR TITLE
Add deployment for rustdoc and strictdoc on main and preview deployment for requirements

### DIFF
--- a/.github/workflows/pages_deploy_main.yaml
+++ b/.github/workflows/pages_deploy_main.yaml
@@ -1,0 +1,57 @@
+name: Documentation Deploy
+
+on:
+  # When a PR is merged (or force push to main)
+  push:
+    branches: [ "main" ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Enable cargo logs to be in colour
+env:
+  CARGO_TERM_COLOR: always
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # -=-=-=-= Rustdocs =-=-=-=-
+      - name: Build rustdocs
+        run: cargo doc
+
+      # -=-=-=-= Strictdoc =-=-=-=-
+      - name: Install python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.12
+      - name: Install strictdoc & requirements
+        run: pip install strictdoc setuptools # Note: we need setuptools for strictdoc to work. Installing just strictdoc is not enough
+      - name: Export requirements
+        run: strictdoc export ./requirements/requirements.sdoc
+
+      # -=-=-=-= Preparation =-=-=-=-
+      - name: Prepare web files
+        run: mv ./target/doc/ ./web/rustdocs/ && mv ./output/html/ ./web/strictdoc/
+
+      # -=-=-=-= Deploy =-=-=-=-
+      - name: Deploy to Github Pages
+        uses: peaceiris/actions-gh-pages@v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./web
+          publish_branch: gh-pages

--- a/.github/workflows/pages_requirement_preview.yaml
+++ b/.github/workflows/pages_requirement_preview.yaml
@@ -1,0 +1,35 @@
+name: Requirement Preview Deploy
+
+on:
+  # When a PR is merged (or force push to main)
+  pull_request:
+    paths:
+      - 'requirements/**/'
+      - '.github/workflows/pages_requirement_preview.yaml'
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # -=-=-=-= Strictdoc =-=-=-=-
+      - name: Install python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.12
+      - name: Install strictdoc & requirements
+        run: pip install strictdoc setuptools # Note: we need setuptools for strictdoc to work. Installing just strictdoc is not enough
+      - name: Export requirements
+        run: strictdoc export ./requirements/requirements.sdoc
+
+      # -=-=-=-= Deploy =-=-=-=-
+      - name: Deploy Preview
+        uses: rossjrw/pr-preview-action@v1.4.7
+        with:
+          source-dir: output/html/
+          umbrella-dir: requirements/pr-preview

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WASM Interpeter</title>
+</head>
+<body>
+    <a href="./rustdocs/rustdoc_deploy/">Rustdocs</a>
+    <br/>
+    <a href="./strictdoc/">Strictdoc</a>
+</body>
+</html>


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a two new github actions:
- `pages_deploy_main` which deploys both the rustdoc and the strictdoc sites to github pages on commit to main.
- `pages_requirement_preview` which deploys only the strictdoc site to github pages on all PRs which modify the requirements. 

### Testing Strategy

This pull request was tested on a [seperate repo](https://github.com/george-cosma/rustdoc-deploy/). For the preview script, two PRs were created - [one which modifies requirements.sdoc](https://github.com/george-cosma/rustdoc-deploy/pull/1) and [one which doesn't](https://github.com/george-cosma/rustdoc-deploy/pull/3).

Result for the example repo [can be found here](https://george-cosma.github.io/rustdoc-deploy/) and the PR1 preview [can be found here](https://george-cosma.github.io/rustdoc-deploy/requirements/pr-preview/pr-1/).

### TODO or Help Wanted

The landing page is extremely barebones. Although not entirely necessary until the MVP, it would still be nice to have something prettier, even if its only job is to contain two links. Should this be addressed in this PR?

### Formatting
N/A

### Github Issue

This pull request helps with #19. Coverage report not included in this PR.

### Author

Signed-off-by: George Cosma [george.cosma@oxidos.io](mailto:george.cosma@oxidos.io)
