### PR TITLE
Fix panic for functions with identical types

### DIFF
--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -21,7 +21,6 @@ pub fn validate_code_section(
     assert_eq!(section_header.ty, SectionTy::Code);
 
     let code_block_spans = wasm.read_vec_enumerated(|wasm, idx| {
-        // TODO maybe offset idx by number of imported functions?
         let ty_idx = type_of_fn[idx];
         let func_ty = fn_types[ty_idx].clone();
 

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -15,13 +15,15 @@ pub fn validate_code_section(
     wasm: &mut WasmReader,
     section_header: SectionHeader,
     fn_types: &[FuncType],
+    type_of_fn: &[usize],
     globals: &[Global],
 ) -> Result<Vec<Span>> {
     assert_eq!(section_header.ty, SectionTy::Code);
 
     let code_block_spans = wasm.read_vec_enumerated(|wasm, idx| {
         // TODO maybe offset idx by number of imported functions?
-        let func_ty = fn_types[idx].clone();
+        let ty_idx = type_of_fn[idx];
+        let func_ty = fn_types[ty_idx].clone();
 
         let func_size = wasm.read_var_u32()?;
         let func_block = wasm.make_span(func_size as usize);

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -133,7 +133,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
     let func_blocks = handle_section(&mut wasm, &mut header, SectionTy::Code, |wasm, h| {
-        code::validate_code_section(wasm, h, &types, &globals)
+        code::validate_code_section(wasm, h, &types, &functions, &globals)
     })?
     .unwrap_or_default();
 

--- a/tests/same_type_fn.rs
+++ b/tests/same_type_fn.rs
@@ -1,0 +1,26 @@
+/// This test checks if we can validate and executa a module which has two functions with the same signature.
+#[test_log::test]
+fn same_type_fn() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = r#"
+    (module
+        (func (export "add_one") (param $x i32) (result i32)
+            local.get $x
+            i32.const 1
+            i32.add)
+
+        (func (export "add_two") (param $x i32) (result i32)
+            local.get $x
+            i32.const 2
+            i32.add)
+    )
+    "#;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(-5, instance.invoke_func(0, -6).unwrap());
+    assert_eq!(-4, instance.invoke_func(1, -6).unwrap());
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes an issue where the validator would cause a panic due to an index-out-of-bounds problem. For more details see issue #25 

To implement the fix, I passed the [functions section](https://webassembly.github.io/spec/core/binary/modules.html#function-section) to the code responsible for validating the instructions blocks.

### Testing Strategy

This pull request was tested by creating a new testcase that would cover this issue.

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [ ] Ran `nix fmt`
- [ ] Ran `treefmt`

### Author

Signed-off-by: George Cosma [george.cosma@oxidos.io](mailto:george.cosma@oxidos.io)
