### PR TITLE
feat: add conventional commit checker to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,10 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
+
+  conventional_commit_check:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webiny/action-conventional-commits@v1.3.0


### PR DESCRIPTION
### Pull Request Overview

This forces a more concise way of writing commit message. More information can be found here:
https://www.conventionalcommits.org/en/v1.0.0/

### Testing Strategy

By letting the CI run

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `nix fmt`
- [x] Ran `treefmt`


### Author

Signed-off-by: wucke13 wucke13@gmail.com