### PR TITLE
fix all cargo doc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: "-D warnings"
+      RUSTDOCFLAGS: "-D warnings"
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +26,9 @@ jobs:
       - name: Run clippy
         # for CI we can treat errors as warnings
         # for reference see: https://doc.rust-lang.org/clippy/usage.html
-        run: cargo clippy -- -Dwarnings
+        run: cargo clippy
+      - name: Build docs
+        run: cargo doc --document-private-items --verbose
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,13 @@
               '';
               help = "start the requirements editor web-ui";
             }
+            {
+              name = "cargo-watch-doc";
+              command = ''
+                cargo watch --shell 'cargo doc --document-private-items'
+              '';
+              help = "start cargo watch loop for documentation";
+            }
           ];
         });
 

--- a/src/core/reader/types/mod.rs
+++ b/src/core/reader/types/mod.rs
@@ -1,4 +1,4 @@
-//! Methods to read WASM Types from a [Wasm] object.
+//! Methods to read WASM Types from a [WasmReader] object.
 //!
 //! See: <https://webassembly.github.io/spec/core/binary/types.html>
 
@@ -18,7 +18,7 @@ pub mod memarg;
 pub mod opcode;
 pub mod values;
 
-/// https://webassembly.github.io/spec/core/binary/types.html#number-types
+/// <https://webassembly.github.io/spec/core/binary/types.html#number-types>
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NumType {
     I32,
@@ -55,7 +55,7 @@ impl WasmReadable for NumType {
     }
 }
 
-/// https://webassembly.github.io/spec/core/binary/types.html#vector-types
+/// <https://webassembly.github.io/spec/core/binary/types.html#vector-types>
 struct VecType;
 
 impl WasmReadable for VecType {
@@ -77,7 +77,7 @@ impl WasmReadable for VecType {
     }
 }
 
-/// https://webassembly.github.io/spec/core/binary/types.html#reference-types
+/// <https://webassembly.github.io/spec/core/binary/types.html#reference-types>
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RefType {
     FuncRef,
@@ -105,7 +105,7 @@ impl WasmReadable for RefType {
     }
 }
 
-/// https://webassembly.github.io/spec/core/binary/types.html#reference-types
+/// <https://webassembly.github.io/spec/core/binary/types.html#reference-types>
 /// TODO flatten [NumType] and [RefType] enums, as they are not used individually and `wasmparser` also does it.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(clippy::all)]
@@ -147,7 +147,7 @@ impl WasmReadable for ValType {
     }
 }
 
-/// https://webassembly.github.io/spec/core/binary/types.html#value-types
+/// <https://webassembly.github.io/spec/core/binary/types.html#value-types>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResultType {
     pub valtypes: Vec<ValType>,
@@ -169,7 +169,7 @@ impl WasmReadable for ResultType {
     }
 }
 
-/// https://webassembly.github.io/spec/core/binary/types.html#function-types
+/// <https://webassembly.github.io/spec/core/binary/types.html#function-types>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuncType {
     pub params: ResultType,

--- a/src/core/reader/types/values.rs
+++ b/src/core/reader/types/values.rs
@@ -1,8 +1,8 @@
-//! Methods to read basic WASM Values from a [Wasm] object.
+//! Methods to read basic WASM Values from a [WasmReader] object.
 //!
 //! See: <https://webassembly.github.io/spec/core/binary/values.html>
 //!
-//! Note: If any of these methods return `Err`, they may have consumed some bytes from the [Wasm] object and thus consequent calls may result in unexpected behaviour.
+//! Note: If any of these methods return `Err`, they may have consumed some bytes from the [WasmReader] object and thus consequent calls may result in unexpected behaviour.
 //! This is due to the fact that these methods read elemental types which cannot be split.
 
 use alloc::vec::Vec;
@@ -12,7 +12,7 @@ use crate::core::reader::WasmReader;
 use crate::{Error, Result};
 
 impl WasmReader<'_> {
-    /// Note: If `Err`, the [Wasm] object is no longer guaranteed to be in a valid state
+    /// Note: If `Err`, the [WasmReader] object is no longer guaranteed to be in a valid state
     pub fn read_u8(&mut self) -> Result<u8> {
         let value = *self.current.first().ok_or(Error::Eof)?;
 
@@ -25,7 +25,7 @@ impl WasmReader<'_> {
     }
 
     /// Parses a variable-length `u32` as specified by [LEB128](https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128).
-    /// Note: If `Err`, the [Wasm] object is no longer guaranteed to be in a valid state
+    /// Note: If `Err`, the [WasmReader] object is no longer guaranteed to be in a valid state
     pub fn read_var_u32(&mut self) -> Result<u32> {
         let mut result: u32 = 0;
         let mut shift: u32 = 0;
@@ -62,7 +62,7 @@ impl WasmReader<'_> {
         Ok(result)
     }
 
-    /// Note: If `Err`, the [Wasm] object is no longer guaranteed to be in a valid state
+    /// Note: If `Err`, the [WasmReader] object is no longer guaranteed to be in a valid state
     pub fn read_name(&mut self) -> Result<&str> {
         let len = self.read_var_u32()? as usize;
 
@@ -87,7 +87,7 @@ impl WasmReader<'_> {
         })
     }
 
-    /// Note: If `Err`, the [Wasm] object is no longer guaranteed to be in a valid state
+    /// Note: If `Err`, the [WasmReader] object is no longer guaranteed to be in a valid state
     pub fn read_vec<T, F>(&mut self, mut read_element: F) -> Result<Vec<T>>
     where
         F: FnMut(&mut WasmReader) -> Result<T>,

--- a/tests/start_function.rs
+++ b/tests/start_function.rs
@@ -1,5 +1,5 @@
-/// The WASM program stores 42 into linear memory upon instantiation through a start function.
-/// Then it reads the same value and checks its value.
+//! The WASM program stores 42 into linear memory upon instantiation through a start function.
+//! Then it reads the same value and checks its value.
 #[test_log::test]
 fn start_function() {
     use wasm::{validate, RuntimeInstance};


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes all warnings in the cargo doc departement

### Testing Strategy

`nix flake check`

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [x] Ran `nix fmt`
- [ ] Ran `treefmt`


### Author

Signed-off-by: wucke13 wucke13@gmail.com
