### PR TITLE
refactor: remove Signed-off-by in favor of DCO

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,3 @@ This pull request still needs...
 ### Github Issue
 
 This pull request closes <GITHUB_ISSUE>
-
-### Author
-
-Signed-off-by: <YOUR_NAME> <YOUR_EMAIL_HERE@EXAMPLE.COM>


### PR DESCRIPTION
### Pull Request Overview

The PR template had a field for "Signed-off-by:", but that is only per PR. By instead using the DCO GitHub App [1], we can enforce this for every commit, which is more correct. Also, git offers and automated way of filling in the necessary details.

[1] https://probot.github.io/apps/dco/

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [x] Ran `nix fmt`
- [ ] Ran `treefmt`
