### PR TITLE
Add deployment for rustdoc and strictdoc on main and preview deployment for requirements (attempt #2)

### DIFF
--- a/.github/workflows/pages_coverage_preview.yaml
+++ b/.github/workflows/pages_coverage_preview.yaml
@@ -1,0 +1,46 @@
+name: Coverage Preview Deploy
+
+on:
+  # When a PR is merged (or force push to main)
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+      - labeled
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: preview-cov-${{ github.ref }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'coverage')
+    steps:
+      - uses: actions/checkout@v4
+      # -=-=-=-= Coverage test =-=-=-=-
+      - name: Install coverage test tooling
+        run: |
+          rustup toolchain install nightly &&
+          rustup component add llvm-tools-preview &&
+          cargo install cargo-binutils
+      - name: Run & compile coverage test
+        run: |
+          cargo clean &&
+          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run &&
+          OBJS=$(RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run -- --test-threads=1 2>&1 | grep -oP '(?<=\()[^ ]+[\\\/][^ \)]+' | sed 's/^/--object /' | sed 's/\r//' | tr '\n' ' ') &&
+          rm -rf *.profraw &&
+          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests -- --test-threads=1 &&
+          cargo profdata -- merge -sparse *.profraw -o default.profdata &&
+          cargo cov -- show -show-line-counts-or-regions -output-dir=cov_out -format=html --ignore-filename-regex='.*cargo.*' --instr-profile=default.profdata $OBJS
+      # -=-=-=-= Deploy =-=-=-=-
+      - name: Deploy Preview
+        uses: rossjrw/pr-preview-action@v1.4.7
+        with:
+          source-dir: cov_out/
+          umbrella-dir: coverage/pr-preview

--- a/.github/workflows/pages_deploy_main.yaml
+++ b/.github/workflows/pages_deploy_main.yaml
@@ -1,0 +1,78 @@
+name: Documentation Deploy
+
+on:
+  # When a PR is merged (or force push to main)
+  push:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Enable cargo logs to be in colour
+env:
+  CARGO_TERM_COLOR: always
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # -=-=-=-= Rustdocs =-=-=-=-
+      - name: Build rustdocs
+        run: cargo doc
+
+      # -=-=-=-= Strictdoc =-=-=-=-
+      - name: Install python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.12
+      - name: Install strictdoc & requirements
+        run: pip install strictdoc setuptools # Note: we need setuptools for strictdoc to work. Installing just strictdoc is not enough
+      - name: Export requirements
+        run: strictdoc export ./requirements/requirements.sdoc
+
+      # -=-=-=-= Preparation (1/2) =-=-=-=-
+      - name: Prepare web files (1/2)
+        run: mkdir -p web && mv ./target/doc/ ./web/rustdocs/ && mv ./output/html/ ./web/strictdoc/
+
+      # -=-=-=-= Coverage test =-=-=-=-
+      - name: Install coverage test tooling
+        run: |
+          rustup toolchain install nightly &&
+          rustup component add llvm-tools-preview &&
+          cargo install cargo-binutils
+      - name: Run & compile coverage test
+        run: |
+          cargo clean &&
+          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run &&
+          OBJS=$(RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run -- --test-threads=1 2>&1 | grep -oP '(?<=\()[^ ]+[\\\/][^ \)]+' | sed 's/^/--object /' | sed 's/\r//' | tr '\n' ' ') &&
+          rm -rf *.profraw &&
+          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests -- --test-threads=1 &&
+          cargo profdata -- merge -sparse *.profraw -o default.profdata &&
+          cargo cov -- show -show-line-counts-or-regions -output-dir=cov_out -format=html --ignore-filename-regex='.*cargo.*' --instr-profile=default.profdata $OBJS
+
+      # -=-=-=-= Preparation (2/2) =-=-=-=-
+      - name: Prepare web files (2/2)
+        run: mv ./cov_out/ ./web/coverage
+
+      # -=-=-=-= Deploy =-=-=-=-
+      - name: Deploy to Github Pages
+        uses: peaceiris/actions-gh-pages@v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./web
+          publish_branch: gh-pages
+          destination_dir: ./main/

--- a/.github/workflows/pages_requirement_preview.yaml
+++ b/.github/workflows/pages_requirement_preview.yaml
@@ -1,0 +1,42 @@
+name: Requirement Preview Deploy
+
+on:
+  # When a PR is merged (or force push to main)
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - "requirements/**/"
+      - ".github/workflows/pages_requirement_preview.yaml"
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # -=-=-=-= Strictdoc =-=-=-=-
+      - name: Install python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.12
+      - name: Install strictdoc & requirements
+        run: pip install strictdoc setuptools # Note: we need setuptools for strictdoc to work. Installing just strictdoc is not enough
+      - name: Export requirements
+        run: strictdoc export ./requirements/requirements.sdoc
+
+      # -=-=-=-= Deploy =-=-=-=-
+      - name: Deploy Preview
+        uses: rossjrw/pr-preview-action@v1.4.7
+        with:
+          source-dir: output/html/
+          umbrella-dir: requirements/pr-preview

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 name = "wasm"
 path = "src/lib.rs"
 
+[build]
+profiler = true
+
 [dependencies]
 log = "0.4.20"
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a two new github actions:
- `pages_deploy_main` which deploys both the rustdoc and the strictdoc sites to github pages on commit to main.
- `pages_requirement_preview` which deploys only the strictdoc site to github pages on all PRs which modify the requirements. 

Note: this pr is the successor to #24 , which has been closed due to the workflows failing. The reason they were failing were because the branch was coming from a personal fork rather than this repo.

### Testing Strategy

This pull request was tested on a [seperate repo](https://github.com/george-cosma/rustdoc-deploy/). For the preview script, two PRs were created - [one which modifies requirements.sdoc](https://github.com/george-cosma/rustdoc-deploy/pull/1) and [one which doesn't](https://github.com/george-cosma/rustdoc-deploy/pull/3).

Result for the example repo [can be found here](https://george-cosma.github.io/rustdoc-deploy/) and the PR1 preview [can be found here](https://george-cosma.github.io/rustdoc-deploy/requirements/pr-preview/pr-1/).

I've also tested the preview deployment on my own branch of this repo.
- PR: https://github.com/george-cosma/wasm-interpreter/pull/1
- Deployment: https://george-cosma.github.io/wasm-interpreter/requirements/pr-preview/pr-1/

One quirk was that I had to manually add a `.nojekyll` file to the root of `gh-pages`, otherwise the CSS/JS wouldn't load. Possible explanation on this [stackoverflow question](https://stackoverflow.com/questions/66764842/how-can-i-fix-404-error-importing-css-on-github-pages).

### Formatting
N/A

### Github Issue

This pull request will close #19 

### Author

Signed-off-by: George Cosma [george.cosma@oxidos.io](mailto:george.cosma@oxidos.io)
