### PR TITLE
rework WasmReader

### DIFF
--- a/src/core/reader/mod.rs
+++ b/src/core/reader/mod.rs
@@ -45,13 +45,6 @@ impl<'a> WasmReader<'a> {
         &self.full_wasm_binary[self.pc..]
     }
 
-    /// The current program counter
-    #[allow(dead_code)]
-    pub const fn current_pc(&self) -> usize {
-        self.pc
-        &self.full_wasm_binary[self.pc..]
-    }
-
     /// Create a [Span] starting from [pc](Self::pc) for the next `len` bytes
     ///
     /// Does **not** verify the span to fit the WASM binary, i.e. the span could exceed the WASM

--- a/src/core/reader/section_header.rs
+++ b/src/core/reader/section_header.rs
@@ -74,7 +74,7 @@ impl WasmReadable for SectionHeader {
     fn read(wasm: &mut WasmReader) -> Result<Self> {
         let ty = SectionTy::read(wasm)?;
         let size: u32 = wasm.read_var_u32()?;
-        let contents_span = wasm.make_span(size as usize);
+        let contents_span = wasm.make_span_unchecked(size as usize);
 
         Ok(SectionHeader {
             ty,
@@ -85,7 +85,7 @@ impl WasmReadable for SectionHeader {
     fn read_unvalidated(wasm: &mut WasmReader) -> Self {
         let ty = SectionTy::read_unvalidated(wasm);
         let size: u32 = wasm.read_var_u32().unwrap_validated();
-        let contents_span = wasm.make_span(size as usize);
+        let contents_span = wasm.make_span_unchecked(size as usize);
 
         SectionHeader {
             ty,

--- a/src/core/reader/section_header.rs
+++ b/src/core/reader/section_header.rs
@@ -74,7 +74,7 @@ impl WasmReadable for SectionHeader {
     fn read(wasm: &mut WasmReader) -> Result<Self> {
         let ty = SectionTy::read(wasm)?;
         let size: u32 = wasm.read_var_u32()?;
-        let contents_span = wasm.make_span_unchecked(size as usize);
+        let contents_span = wasm.make_span(size as usize)?;
 
         Ok(SectionHeader {
             ty,
@@ -85,7 +85,9 @@ impl WasmReadable for SectionHeader {
     fn read_unvalidated(wasm: &mut WasmReader) -> Self {
         let ty = SectionTy::read_unvalidated(wasm);
         let size: u32 = wasm.read_var_u32().unwrap_validated();
-        let contents_span = wasm.make_span_unchecked(size as usize);
+        let contents_span = wasm
+            .make_span(size as usize)
+            .expect("TODO remove this expect");
 
         SectionHeader {
             ty,

--- a/src/core/reader/types/values.rs
+++ b/src/core/reader/types/values.rs
@@ -14,7 +14,7 @@ use crate::{Error, Result};
 impl WasmReader<'_> {
     /// Note: If `Err`, the [WasmReader] object is no longer guaranteed to be in a valid state
     pub fn read_u8(&mut self) -> Result<u8> {
-        let value = self.full_contents.get(self.pc).ok_or(Error::Eof)?;
+        let value = self.full_wasm_binary.get(self.pc).ok_or(Error::Eof)?;
         self.pc += core::mem::size_of::<u8>();
 
         Ok(*value)
@@ -62,11 +62,11 @@ impl WasmReader<'_> {
     pub fn read_name(&mut self) -> Result<&str> {
         let len = self.read_var_u32()? as usize;
 
-        if len > self.full_contents.len() - self.pc {
+        if len > self.full_wasm_binary.len() - self.pc {
             return Err(Error::Eof);
         }
 
-        let utf8_str = &self.full_contents[self.pc..(self.pc + len)]; // Cannot panic because check is done above
+        let utf8_str = &self.full_wasm_binary[self.pc..(self.pc + len)]; // Cannot panic because check is done above
         self.pc += len;
 
         core::str::from_utf8(utf8_str).map_err(Error::MalformedUtf8String)

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -152,7 +152,7 @@ where
 
         // Start reading the function's instructions
         let mut wasm = WasmReader::new(self.wasm_bytecode);
-        wasm.move_start_to(inst.code_expr);
+        wasm.move_start_to(inst.code_expr)?;
 
         use crate::core::reader::types::opcode::*;
         loop {
@@ -431,13 +431,15 @@ where
             functions
                 .zip(func_blocks)
                 .map(|(ty, func)| {
-                    wasm_reader.move_start_to(*func);
+                    wasm_reader
+                        .move_start_to(*func)
+                        .expect("function index to be in the bounds of the WASM binary");
 
                     let (locals, bytes_read) = wasm_reader
                         .measure_num_read_bytes(read_declared_locals)
                         .unwrap_validated();
 
-                    let code_expr = wasm_reader.make_span(func.len() - bytes_read);
+                    let code_expr = wasm_reader.make_span_unchecked(func.len() - bytes_read);
 
                     FuncInst {
                         ty: *ty,

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -439,7 +439,9 @@ where
                         .measure_num_read_bytes(read_declared_locals)
                         .unwrap_validated();
 
-                    let code_expr = wasm_reader.make_span_unchecked(func.len() - bytes_read);
+                    let code_expr = wasm_reader
+                        .make_span(func.len() - bytes_read)
+                        .expect("TODO remove this expect");
 
                     FuncInst {
                         ty: *ty,

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -8,6 +8,10 @@ use crate::core::reader::types::global::Global;
 use crate::core::reader::types::{MemType, TableType, ValType};
 use crate::execution::value::{Ref, Value};
 
+/// The store represents all global state that can be manipulated by WebAssembly programs. It
+/// consists of the runtime representation of all instances of functions, tables, memories, and
+/// globals, element segments, and data segments that have been allocated during the life time of
+/// the abstract machine.
 /// <https://webassembly.github.io/spec/core/exec/runtime.html#store>
 pub struct Store {
     pub funcs: Vec<FuncInst>,

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -25,7 +25,7 @@ pub fn validate_code_section(
         let func_ty = fn_types[ty_idx].clone();
 
         let func_size = wasm.read_var_u32()?;
-        let func_block = wasm.make_span_unchecked(func_size as usize);
+        let func_block = wasm.make_span(func_size as usize)?;
 
         let locals = {
             let params = func_ty.params.valtypes.iter().cloned();

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -25,7 +25,7 @@ pub fn validate_code_section(
         let func_ty = fn_types[ty_idx].clone();
 
         let func_size = wasm.read_var_u32()?;
-        let func_block = wasm.make_span(func_size as usize);
+        let func_block = wasm.make_span_unchecked(func_size as usize);
 
         let locals = {
             let params = func_ty.params.valtypes.iter().cloned();


### PR DESCRIPTION
### Pull Request Overview

This pull request rework's the `WasmReader` module.

- Add documentation
- Replace the double slice construct by Slice + Index
- Add tests
- Mark functions const where possible
- Mark `make_span` as unchecked
- Make move_start failable

### Testing Strategy

This pull request was tested by `cargo test`

### TODO or Help Wanted

This pull request requires #35

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `nix fmt`
- [x] Ran `treefmt`


### Author

Signed-off-by: wucke13 <wucke13@gmail.com>
