### PR TITLE
Dynamic types for function invokation

### DIFF
--- a/src/execution/value.rs
+++ b/src/execution/value.rs
@@ -11,7 +11,7 @@ use crate::unreachable_validated;
 /// See <https://webassembly.github.io/spec/core/exec/runtime.html#values>
 // TODO implement missing variants
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum Value {
+pub enum Value {
     I32(u32),
     I64(u64),
     // F32,
@@ -21,7 +21,7 @@ pub(crate) enum Value {
 
 #[derive(Clone, Debug, PartialEq)]
 #[allow(dead_code)]
-pub(crate) enum Ref {
+pub enum Ref {
     Null,
     // Func,
     // Extern,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ extern crate alloc;
 extern crate log;
 
 pub use core::error::{Error, Result, RuntimeError};
+pub use core::reader::types::{NumType, RefType, ValType};
+pub use execution::value::Value;
 pub use execution::*;
 pub use validation::*;
 

--- a/tests/dynamic.rs
+++ b/tests/dynamic.rs
@@ -1,0 +1,40 @@
+use wasm::NumType;
+
+/// A simple function to add two numbers and return the result, using [invoke_dynamic](wasm::RuntimeInstance::invoke_dynamic)
+/// instead of [invoke_named](wasm::RuntimeInstance::invoke_named).
+#[test_log::test]
+fn dynamic_add() {
+    use wasm::{validate, RuntimeInstance};
+    use wasm::{ValType, Value};
+
+    let wat = r#"
+    (module
+        (func (export "add") (param $x i32) (param $y i32) (result i32)
+            local.get $x
+            local.get $y
+            i32.add)
+    )
+    "#;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    let res = instance
+        .invoke_dynamic(
+            0,
+            vec![Value::I32(11), Value::I32(1)],
+            &[ValType::NumType(NumType::I32)],
+        )
+        .expect("invocation failed");
+    assert_eq!(vec![Value::I32(12)], res);
+
+    let res = instance
+        .invoke_dynamic(
+            0,
+            vec![Value::I32(-6i32 as u32), Value::I32(1)],
+            &[ValType::NumType(NumType::I32)],
+        )
+        .expect("invocation failed");
+    assert_eq!(vec![Value::I32(-5i32 as u32)], res);
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds function invocation with parameter & return type only known at runtime.

### Testing Strategy

This pull request was tested by only running `cargo test`.

### TODO or Help Wanted

I need help to stabilize the API for this. A notable missing feature is dynamic invocation by name. As it is, I would need to double the amount of functions. This isn't a big issue, the code repetition isn't that bad, but I want to hear your thoughts.

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `cargo doc`
- [ ] Ran `nix fmt`
- [ ] Ran `treefmt`

### Github Issue

This pull request closes #43 
