### PR TITLE
Function recursion (stackless)

### DIFF
--- a/src/core/reader/types/opcode.rs
+++ b/src/core/reader/types/opcode.rs
@@ -1,5 +1,6 @@
 pub const NOP: u8 = 0x01;
 pub const END: u8 = 0x0B;
+pub const CALL: u8 = 0x10;
 pub const LOCAL_GET: u8 = 0x20;
 pub const LOCAL_SET: u8 = 0x21;
 pub const GLOBAL_GET: u8 = 0x23;
@@ -43,3 +44,56 @@ pub const I64_SHR_S: u8 = 0x87;
 pub const I64_SHR_U: u8 = 0x88;
 pub const I64_ROTL: u8 = 0x89;
 pub const I64_ROTR: u8 = 0x8A;
+
+/// Returns the name of a single-byte opcode.
+pub fn opcode_name(opcode: u8) -> &'static str {
+    match opcode {
+        NOP => "nop",
+        END => "end",
+        CALL => "call",
+        LOCAL_GET => "local.get",
+        LOCAL_SET => "local.set",
+        GLOBAL_GET => "global.get",
+        GLOBAL_SET => "global.set",
+        I32_LOAD => "i32.load",
+        I32_STORE => "i32.store",
+        I32_CONST => "i32.const",
+        I64_CONST => "i64.const",
+        I32_ADD => "i32.add",
+        I32_MUL => "i32.mul",
+        I32_DIV_S => "i32.div_s",
+        I32_DIV_U => "i32.div_u",
+        I32_REM_S => "i32.rem_s",
+        I32_CLZ => "i32.clz",
+        I32_CTZ => "i32.ctz",
+        I32_POPCNT => "i32.popcnt",
+        I32_REM_U => "i32.rem_u",
+        I32_AND => "i32.and",
+        I32_OR => "i32.or",
+        I32_XOR => "i32.xor",
+        I32_SHL => "i32.shl",
+        I32_SHR_S => "i32.shr_s",
+        I32_SHR_U => "i32.shr_u",
+        I32_ROTL => "i32.rotl",
+        I32_ROTR => "i32.rotr",
+        I64_CLZ => "i64.clz",
+        I64_CTZ => "i64.ctz",
+        I64_POPCNT => "i64.popcnt",
+        I64_ADD => "i64.add",
+        I64_SUB => "i64.sub",
+        I64_MUL => "i64.mul",
+        I64_DIV_S => "i64.div_s",
+        I64_DIV_U => "i64.div_u",
+        I64_REM_S => "i64.rem_s",
+        I64_REM_U => "i64.rem_u",
+        I64_AND => "i64.and",
+        I64_OR => "i64.or",
+        I64_XOR => "i64.xor",
+        I64_SHL => "i64.shl",
+        I64_SHR_S => "i64.shr_s",
+        I64_SHR_U => "i64.shr_u",
+        I64_ROTL => "i64.rotl",
+        I64_ROTR => "i64.rotr",
+        _ => "<unknown>",
+    }
+}

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -220,6 +220,10 @@ where
                 END => {
                     break;
                 }
+                CALL => {
+                    let func_idx = wasm.read_var_u32().unwrap_validated() as FuncIdx;
+                    self.function(func_idx, stack)?;
+                }
                 LOCAL_GET => {
                     let local_idx = wasm.read_var_u32().unwrap_validated() as LocalIdx;
                     let local = locals.get(local_idx);

--- a/tests/recursion.rs
+++ b/tests/recursion.rs
@@ -1,0 +1,57 @@
+/// A simple function to add 2 to an i32 using a recusive call to "add_one" and return the result
+#[test_log::test]
+fn recursion_valid() {
+    use wasm::{validate, RuntimeInstance};
+
+    let wat = r#"
+    (module
+        (func $add_one (export "add_one") (param $x i32) (result i32)
+            local.get $x
+            i32.const 1
+            i32.add
+        )
+        (func (export "add_two") (param $x i32) (result i32)
+            local.get $x
+            call $add_one
+            call $add_one
+        )
+    )
+    "#;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    assert_eq!(12, instance.invoke_named("add_two", 10).unwrap());
+    assert_eq!(2, instance.invoke_named("add_two", 0).unwrap());
+    assert_eq!(-4, instance.invoke_named("add_two", -6).unwrap());
+}
+
+#[test_log::test]
+fn recursion_busted_stack() {
+    use wasm::{validate, Error};
+
+    let wat = r#"
+    (module
+        (func $add_one (export "add_one") (param $x i32) (result i32 i32)
+            local.get $x
+            i32.const 1
+            i32.add
+            local.get $x
+            i32.const 1
+            i32.add
+        )
+        (func (export "add_two") (param $x i32) (result i32)
+            local.get $x
+            call $add_one
+            call $add_one
+        )
+    )
+    "#;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    assert!(
+        matches!(validate(&wasm_bytes), Err(Error::EndInvalidValueStack)),
+        "validation incorrectly passed"
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds function recursion in (hopefully) a stackless way. To accomplish this I've added a vector of `CallStack`s, and split the `function` function into three parts: 
- `function_prepare` which pushes a new `CallStack`
- `function_run` which executes the code until it finishes, or a `call` instruction is encountered
- `function` which attempts to run the code until "call stacks" are consumed (aka the code reaches its logical end, including all recursion calls).

### Testing Strategy

This pull request was tested by implementing two new tests, one where recursion is tested and expected to succeed, and one where the stack is messed up by a `call` instruction.

### TODO or Help Wanted

I'd like to get a review if my implementation respect the requirements. I personally think I do respect them, but I'd like a double-check.

How should we handle run-away code which never finishes?

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check` ->a param in `CallStack` is deadcode. Parameter might be useless, but I am unsure.
- [x] Ran `cargo build`
- [x] Ran `cargo doc`
- [ ] Ran `nix fmt`
- [ ] Ran `treefmt`

### Github Issue

This pull request closes #39 
