### PR TITLE
Fix: Update coverage action to trigger on (un)labeled events

### DIFF
--- a/.github/workflows/pages_coverage_preview.yaml
+++ b/.github/workflows/pages_coverage_preview.yaml
@@ -9,6 +9,7 @@ on:
       - synchronize
       - closed
       - labeled
+      - unlabeled
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -20,16 +21,21 @@ concurrency: preview-cov-${{ github.ref }}
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'coverage')
     steps:
       - uses: actions/checkout@v4
-      # -=-=-=-= Coverage test =-=-=-=-
+      # -=-=-=-= Coverage test (if labeled) =-=-=-=-
       - name: Install coverage test tooling
+        if: |
+          (github.event.action == 'labeled' &&  github.event.label.name == 'coverage') ||
+          (github.event.action != 'labeled' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'coverage'))
         run: |
           rustup toolchain install nightly &&
           rustup component add llvm-tools-preview &&
           cargo install cargo-binutils
       - name: Run & compile coverage test
+        if: |
+          (github.event.action == 'labeled' &&  github.event.label.name == 'coverage') ||
+          (github.event.action != 'labeled' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'coverage'))
         run: |
           cargo clean &&
           RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run &&
@@ -38,8 +44,26 @@ jobs:
           RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests -- --test-threads=1 &&
           cargo profdata -- merge -sparse *.profraw -o default.profdata &&
           cargo cov -- show -show-line-counts-or-regions -output-dir=cov_out -format=html --ignore-filename-regex='.*cargo.*' --instr-profile=default.profdata $OBJS
-      # -=-=-=-= Deploy =-=-=-=-
-      - name: Deploy Preview
+
+      # -=-=-=-= Deploy (when labeled) =-=-=-=-
+      - name: Deploy Preview (labeled)
+        if: ${{ github.event.action == 'labeled' &&  github.event.label.name == 'coverage' }}
+        uses: rossjrw/pr-preview-action@v1.4.7
+        with:
+          source-dir: cov_out/
+          umbrella-dir: coverage/pr-preview
+          action: deploy # force deployment since, by default, this actions does nothing on the 'labeled' event
+      # -=-=-=-= Deploy (when unlabeled) =-=-=-=-
+      - name: Deploy Preview (unlabeled)
+        if: ${{ github.event.action == 'unlabeled' &&  github.event.label.name == 'coverage' }}
+        uses: rossjrw/pr-preview-action@v1.4.7
+        with:
+          source-dir: cov_out/
+          umbrella-dir: coverage/pr-preview
+          action: remove # force removal since, by default, this actions does nothing on the 'labeled' event
+      # -=-=-=-= Deploy (default) =-=-=-=-
+      - name: Deploy Preview (default)
+        if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'coverage') }}
         uses: rossjrw/pr-preview-action@v1.4.7
         with:
           source-dir: cov_out/


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes an issue in the coverage PR preview workflow. Previously, if the PR was labeled then the preview would only deploy if a commit was made. More so, removing the designated label only disabled new updates, but did not remove the old coverage report.

### Testing Strategy

This pull request was tested on https://github.com/george-cosma/wasm-interpreter/pull/6. See the comments.

### TODO or Help Wanted

~~This pull request still has an issue: If the `coverage` label is applied AND if the user labels/unlabels a PR with any other label, then the workflow will run the coverage check, but will not deploy.~~

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [ ] Ran `cargo doc`
- [x] Ran `nix fmt`
- [ ] Ran `treefmt`

### Github Issue

This pull request helps close #45 
