### PR TITLE
feat: add additional error for multi-byte opcodes

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -29,7 +29,8 @@ pub enum Error {
     InvalidExportDesc(u8),
     InvalidImportDesc(u8),
     ExprMissingEnd,
-    InvalidInstr(u16),
+    InvalidInstr(u8),
+    InvalidMultiByteInstr(u8, u8),
     EndInvalidValueStack,
     InvalidLocalIdx,
     InvalidValueStackType(Option<ValType>),
@@ -84,6 +85,9 @@ impl Display for Error {
             Error::ExprMissingEnd => f.write_str("An expr is missing an end byte"),
             Error::InvalidInstr(byte) => f.write_fmt(format_args!(
                 "An invalid instruction opcode was found: `{byte:#x?}`"
+            )),
+            Error::InvalidMultiByteInstr(byte1, byte2) => f.write_fmt(format_args!(
+                "An invalid multi-byte instruction opcode was found: `{byte1:#x?} {byte2:#x?}`"
             )),
             Error::EndInvalidValueStack => f.write_str(
                 "Different value stack types were expected at the end of a block/function.",

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -204,7 +204,7 @@ fn read_instructions(
 
                 value_stack.push_back(ValType::NumType(NumType::I64));
             }
-            _ => return Err(Error::InvalidInstr(first_instr_byte as u16)),
+            _ => return Err(Error::InvalidInstr(first_instr_byte)),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request refactors the error type `InvalidInstr(u16)`, which is used for invalid instructions.
Currently it stores the invalid byte(s) for single- or multi-byte instruction in a `u16`.
However this API is not very intuitive for invalid single-byte instructions.

In this PR the error type was changed to `InvalidInstr(u8)` and another error type `InvalidMultiByteInstr(u8, u8)` was added for multi-byte instructions.

### Testing Strategy

This pull request was not tested.

### Formatting

- [X] Ran `cargo fmt`
- [X] Ran `cargo check`
- [X] Ran `cargo build`
- [X] Ran `cargo doc`
- [X] Ran `nix fmt`
- [X] Ran `treefmt`
