### PR TITLE
 Convert panics to errors

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,4 +1,4 @@
-use crate::core::indices::GlobalIdx;
+use crate::core::indices::{FuncIdx, GlobalIdx};
 use core::fmt::{Display, Formatter};
 use core::str::Utf8Error;
 
@@ -38,8 +38,12 @@ pub enum Error {
     InvalidMutType(u8),
     MoreThanOneMemory,
     InvalidGlobalIdx(GlobalIdx),
+    InvalidFunctionIdx(FuncIdx),
     GlobalIsConst,
     RuntimeError(RuntimeError),
+    NotYetImplemented(&'static str),
+    InvalidParameterTypes,
+    InvalidResultTypes,
 }
 
 impl Display for Error {
@@ -108,12 +112,24 @@ impl Display for Error {
             Error::InvalidGlobalIdx(idx) => f.write_fmt(format_args!(
                 "An invalid global index `{idx}` was specified"
             )),
+            Error::InvalidFunctionIdx(idx) => f.write_fmt(format_args!(
+                "An invalid function index `{idx}` was specified"
+            )),
             Error::GlobalIsConst => f.write_str("A const global cannot be written to"),
             Error::RuntimeError(err) => match err {
                 RuntimeError::DivideBy0 => f.write_str("Divide by zero is not permitted"),
                 RuntimeError::UnrepresentableResult => f.write_str("Result is unrepresentable"),
                 RuntimeError::FunctionNotFound => f.write_str("Function not found"),
             },
+            Error::NotYetImplemented(msg) => {
+                f.write_fmt(format_args!("Not yet implemented: {msg}"))
+            }
+            Error::InvalidParameterTypes => {
+                f.write_str("The given parameter types do not match the function's signature")
+            }
+            Error::InvalidResultTypes => {
+                f.write_str("The given result types do not match the function's signature")
+            }
         }
     }
 }

--- a/src/core/reader/mod.rs
+++ b/src/core/reader/mod.rs
@@ -89,7 +89,7 @@ impl<'a> WasmReader<'a> {
         let bytes = &self.full_wasm_binary[self.pc..(self.pc + N)];
         self.pc += N;
 
-        Ok(bytes.try_into().expect("the slice length to be exactly N"))
+        bytes.try_into().map_err(|_err| Error::Eof)
     }
 
     /// Read the current byte without advancing the [`pc`](Self::pc)

--- a/src/core/reader/section_header.rs
+++ b/src/core/reader/section_header.rs
@@ -87,7 +87,7 @@ impl WasmReadable for SectionHeader {
         let size: u32 = wasm.read_var_u32().unwrap_validated();
         let contents_span = wasm
             .make_span(size as usize)
-            .expect("TODO remove this expect");
+            .expect("Expected to be able to read section due to prior validation");
 
         SectionHeader {
             ty,

--- a/src/core/reader/types/import.rs
+++ b/src/core/reader/types/import.rs
@@ -60,9 +60,9 @@ impl WasmReadable for ImportDesc {
     fn read(wasm: &mut WasmReader) -> Result<Self> {
         let desc = match wasm.read_u8()? {
             0x00 => Self::Func(wasm.read_var_u32()? as TypeIdx),
-            0x01 => todo!("read TableType"),
-            0x02 => todo!("read MemType"),
-            0x03 => todo!("read GlobalType"),
+            0x01 => return Err(Error::NotYetImplemented("read TableType")),
+            0x02 => return Err(Error::NotYetImplemented("read MemType")),
+            0x03 => return Err(Error::NotYetImplemented("read GlobalType")),
             other => return Err(Error::InvalidImportDesc(other)),
         };
 

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -121,13 +121,17 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
     let _: Option<()> = handle_section(&mut wasm, &mut header, SectionTy::Element, |_, _| {
-        todo!("element section not yet supported")
+        Err(Error::NotYetImplemented(
+            "element section not yet supported",
+        ))
     })?;
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
     let _: Option<()> = handle_section(&mut wasm, &mut header, SectionTy::DataCount, |_, _| {
-        todo!("data count section not yet supported")
+        Err(Error::NotYetImplemented(
+            "data count section not yet supported",
+        ))
     })?;
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
@@ -142,7 +146,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
     let _: Option<()> = handle_section(&mut wasm, &mut header, SectionTy::Data, |_, _| {
-        todo!("data section not yet supported")
+        Err(Error::NotYetImplemented("data section not yet supported"))
     })?;
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
@@ -183,6 +187,8 @@ fn handle_section<T, F: FnOnce(&mut WasmReader, SectionHeader) -> Result<T>>(
 ) -> Result<Option<T>> {
     match &header {
         Some(SectionHeader { ty, .. }) if *ty == section_ty => {
+            // We just checked that the header is of type "Some", so
+            // it is safe to unwrap here.
             let h = header.take().unwrap();
             trace!("Handling section {:?}", h.ty);
             let ret = handler(wasm, h)?;


### PR DESCRIPTION
### Pull Request Overview

This pull request attempts to convert most panics into errors.

### Testing Strategy

This pull request was tested by running `cargo test`

### TODO or Help Wanted

There are some `.expects()` that I'm unsure HOW to turn to errors, or if we should. I'm also a bit afraid that our `Error` type is becoming "too precise" or "over-specific" (i.e. An error variant is ever created only once). I'd like some input on this.

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `cargo doc`
- [ ] Ran `nix fmt`
- [ ] Ran `treefmt`

