### PR TITLE
fix: rework github workflows to use nix

### DIFF
--- a/.github/workflows/pages_coverage_preview.yaml
+++ b/.github/workflows/pages_coverage_preview.yaml
@@ -23,34 +23,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # -=-=-=-= Coverage test (if labeled) =-=-=-=-
-      - name: Install coverage test tooling
+      # -=-=-=-= Create report =-=-=-=-
+      - uses: cachix/install-nix-action@v27
         if: |
           (github.event.action == 'labeled' &&  github.event.label.name == 'coverage') ||
           (github.event.action != 'labeled' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'coverage'))
-        run: |
-          rustup toolchain install nightly &&
-          rustup component add llvm-tools-preview &&
-          cargo install cargo-binutils
-      - name: Run & compile coverage test
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v14
         if: |
           (github.event.action == 'labeled' &&  github.event.label.name == 'coverage') ||
           (github.event.action != 'labeled' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'coverage'))
-        run: |
-          cargo clean &&
-          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run &&
-          OBJS=$(RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run -- --test-threads=1 2>&1 | grep -oP '(?<=\()[^ ]+[\\\/][^ \)]+' | sed 's/^/--object /' | sed 's/\r//' | tr '\n' ' ') &&
-          rm -rf *.profraw &&
-          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests -- --test-threads=1 &&
-          cargo profdata -- merge -sparse *.profraw -o default.profdata &&
-          cargo cov -- show -show-line-counts-or-regions -output-dir=cov_out -format=html --ignore-filename-regex='.*cargo.*' --instr-profile=default.profdata $OBJS
-
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Generate report(s)
+        if: |
+          (github.event.action == 'labeled' &&  github.event.label.name == 'coverage') ||
+          (github.event.action != 'labeled' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'coverage'))
+        run: nix build .#report --print-build-logs
       # -=-=-=-= Deploy (when labeled) =-=-=-=-
       - name: Deploy Preview (labeled)
         if: ${{ github.event.action == 'labeled' &&  github.event.label.name == 'coverage' }}
         uses: rossjrw/pr-preview-action@v1.4.7
         with:
-          source-dir: cov_out/
+          source-dir: result/coverage/html/
           umbrella-dir: coverage/pr-preview
           action: deploy # force deployment since, by default, this actions does nothing on the 'labeled' event
       # -=-=-=-= Deploy (when unlabeled) =-=-=-=-
@@ -58,7 +55,7 @@ jobs:
         if: ${{ github.event.action == 'unlabeled' &&  github.event.label.name == 'coverage' }}
         uses: rossjrw/pr-preview-action@v1.4.7
         with:
-          source-dir: cov_out/
+          source-dir: result/coverage/html/
           umbrella-dir: coverage/pr-preview
           action: remove # force removal since, by default, this actions does nothing on the 'labeled' event
       # -=-=-=-= Deploy (default) =-=-=-=-
@@ -66,5 +63,5 @@ jobs:
         if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'coverage') }}
         uses: rossjrw/pr-preview-action@v1.4.7
         with:
-          source-dir: cov_out/
+          source-dir: result/coverage/html/
           umbrella-dir: coverage/pr-preview

--- a/.github/workflows/pages_deploy_main.yaml
+++ b/.github/workflows/pages_deploy_main.yaml
@@ -22,57 +22,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  build-reports:
+    name: Build Reports using Nix
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # -=-=-=-= Rustdocs =-=-=-=-
-      - name: Build rustdocs
-        run: cargo doc
-
-      # -=-=-=-= Strictdoc =-=-=-=-
-      - name: Install python
-        uses: actions/setup-python@v5.1.0
+      - uses: cachix/install-nix-action@v27
         with:
-          python-version: 3.12
-      - name: Install strictdoc & requirements
-        run: pip install strictdoc setuptools # Note: we need setuptools for strictdoc to work. Installing just strictdoc is not enough
-      - name: Export requirements
-        run: strictdoc export ./requirements/requirements.sdoc
-
-      # -=-=-=-= Preparation (1/2) =-=-=-=-
-      - name: Prepare web files (1/2)
-        run: mkdir -p web && mv ./target/doc/ ./web/rustdocs/ && mv ./output/html/ ./web/strictdoc/
-
-      # -=-=-=-= Coverage test =-=-=-=-
-      - name: Install coverage test tooling
-        run: |
-          rustup toolchain install nightly &&
-          rustup component add llvm-tools-preview &&
-          cargo install cargo-binutils
-      - name: Run & compile coverage test
-        run: |
-          cargo clean &&
-          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run &&
-          OBJS=$(RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests --no-run -- --test-threads=1 2>&1 | grep -oP '(?<=\()[^ ]+[\\\/][^ \)]+' | sed 's/^/--object /' | sed 's/\r//' | tr '\n' ' ') &&
-          rm -rf *.profraw &&
-          RUSTFLAGS="-C instrument-coverage -Z coverage-options=branch,mcdc" cargo +nightly test --tests -- --test-threads=1 &&
-          cargo profdata -- merge -sparse *.profraw -o default.profdata &&
-          cargo cov -- show -show-line-counts-or-regions -output-dir=cov_out -format=html --ignore-filename-regex='.*cargo.*' --instr-profile=default.profdata $OBJS
-
-      # -=-=-=-= Preparation (2/2) =-=-=-=-
-      - name: Prepare web files (2/2)
-        run: mv ./cov_out/ ./web/coverage
-
-      # -=-=-=-= Deploy =-=-=-=-
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v14
+        with:
+          name: dlr-ft
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build .#wasm-interpreter --print-build-logs
+      - run: nix build .#report --print-build-logs
       - name: Deploy to Github Pages
         uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./web
+          publish_dir: ./result
           publish_branch: gh-pages
           destination_dir: ./main/


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the github workflows to use nix. The coverage preview was left unmodified since I believe it works well-enough as-is.

### Testing Strategy

This pull request was tested on my own fork. See https://github.com/george-cosma/wasm-interpreter/pull/9 for coverage-preview and https://github.com/george-cosma/wasm-interpreter/actions/runs/10161441119/job/28099916237 for main deployment

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [ ] Ran `cargo doc`
- [x] Ran `nix fmt`
- [ ] Ran `treefmt`

