### PR TITLE
fix: codecov not counting trace! calls

### DIFF
--- a/pkgs/wasm-interpreter.nix
+++ b/pkgs/wasm-interpreter.nix
@@ -67,6 +67,7 @@ rustPlatform.buildRustPackage rec {
     mv target/criterion "$out/bench-html"
 
     # coverage stuff
+    export RUST_LOG=trace
     cargo llvm-cov --no-report nextest
     cargo llvm-cov report --lcov --output-path lcov.info
     cargo llvm-cov report --json --output-path lcov.json


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes an issue where trace! calls were not being counted by Codecov. (Many thanks to George)

### Testing Strategy

This pull request was tested on a fork.

### TODO or Help Wanted

N/A

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [ ] Ran `cargo doc`
- [ ] Ran `nix fmt`

### Github Issue

N/A
