### PR TITLE
feat: i32.sub + tests for i32.sub and i32.add

### DIFF
--- a/src/core/reader/types/opcode.rs
+++ b/src/core/reader/types/opcode.rs
@@ -38,6 +38,7 @@ pub const F64_GT: u8 = 0x64;
 pub const F64_LE: u8 = 0x65;
 pub const F64_GE: u8 = 0x66;
 pub const I32_ADD: u8 = 0x6A;
+pub const I32_SUB: u8 = 0x6B;
 pub const I32_MUL: u8 = 0x6C;
 pub const I32_DIV_S: u8 = 0x6D;
 pub const I32_DIV_U: u8 = 0x6E;

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -468,6 +468,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.add [{v1} {v2}] -> [{res}]");
                 stack.push_value(res.into());
             }
+            I32_SUB => {
+                let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+                let res = v1.wrapping_sub(v2);
+
+                trace!("Instruction: i32.sub [{v1} {v2}] -> [{res}]");
+                stack.push_value(res.into());
+            }
             I32_MUL => {
                 let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -259,7 +259,7 @@ fn read_instructions(
 
                 value_stack.push(ValType::NumType(NumType::F64));
             }
-            I32_ADD | I32_MUL | I32_DIV_S | I32_DIV_U | I32_REM_S => {
+            I32_ADD | I32_SUB | I32_MUL | I32_DIV_S | I32_DIV_U | I32_REM_S => {
                 assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
                 assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the `i32.sub` instruction and tests for both `i32.add` and `i32.sub` taken from the spec testsuite.

### Testing Strategy

This pull request was tested by running `cargo test` against the new tests

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [ ] Ran `cargo doc`
- [ ] Ran `nix fmt`
