### PR TITLE
refactor(validation): value- to unified-stack

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,4 +1,5 @@
 use crate::core::indices::GlobalIdx;
+use crate::validation_stack::LabelKind;
 use core::fmt::{Display, Formatter};
 use core::str::Utf8Error;
 
@@ -34,13 +35,14 @@ pub enum Error {
     InvalidMultiByteInstr(u8, u8),
     EndInvalidValueStack,
     InvalidLocalIdx,
-    InvalidValueStackType(Option<ValType>),
+    InvalidValidationStackValType(Option<ValType>),
     InvalidLimitsType(u8),
     InvalidMutType(u8),
     MoreThanOneMemory,
     InvalidGlobalIdx(GlobalIdx),
     GlobalIsConst,
     RuntimeError(RuntimeError),
+    FoundLabel(LabelKind),
 }
 
 impl Display for Error {
@@ -94,7 +96,7 @@ impl Display for Error {
                 "Different value stack types were expected at the end of a block/function.",
             ),
             Error::InvalidLocalIdx => f.write_str("An invalid localidx was used"),
-            Error::InvalidValueStackType(ty) => f.write_fmt(format_args!(
+            Error::InvalidValidationStackValType(ty) => f.write_fmt(format_args!(
                 "An unexpected type was found on the stack when trying to pop another: `{ty:?}`"
             )),
             Error::InvalidLimitsType(ty) => {
@@ -111,6 +113,9 @@ impl Display for Error {
             )),
             Error::GlobalIsConst => f.write_str("A const global cannot be written to"),
             Error::RuntimeError(err) => err.fmt(f),
+            Error::FoundLabel(lk) => f.write_fmt(format_args!(
+                "Expecting a ValType, a Label was found: {lk:?}"
+            )),
         }
     }
 }

--- a/src/core/reader/types/opcode.rs
+++ b/src/core/reader/types/opcode.rs
@@ -1,3 +1,4 @@
+pub const UNREACHABLE: u8 = 0x00;
 pub const NOP: u8 = 0x01;
 pub const END: u8 = 0x0B;
 pub const RETURN: u8 = 0x0F;

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -6,8 +6,9 @@ use crate::core::reader::section_header::{SectionHeader, SectionTy};
 use crate::core::reader::span::Span;
 use crate::core::reader::types::global::Global;
 use crate::core::reader::types::memarg::MemArg;
-use crate::core::reader::types::{FuncType, NumType, ResultType, ValType};
+use crate::core::reader::types::{FuncType, NumType, ValType};
 use crate::core::reader::{WasmReadable, WasmReader};
+use crate::validation_stack::ValidationStack;
 use crate::{Error, Result};
 
 pub fn validate_code_section(
@@ -23,8 +24,11 @@ pub fn validate_code_section(
         let ty_idx = type_idx_of_fn[idx];
         let func_ty = fn_types[ty_idx].clone();
 
+        debug!("{:x?}", wasm.full_wasm_binary);
+
         let func_size = wasm.read_var_u32()?;
         let func_block = wasm.make_span(func_size as usize)?;
+        let previous_pc = wasm.pc;
 
         let locals = {
             let params = func_ty.params.valtypes.iter().cloned();
@@ -32,17 +36,24 @@ pub fn validate_code_section(
             params.chain(declared_locals).collect::<Vec<ValType>>()
         };
 
-        validate_value_stack(func_ty.returns, |value_stack| {
-            read_instructions(
-                idx,
-                wasm,
-                value_stack,
-                &locals,
-                globals,
-                fn_types,
-                type_idx_of_fn,
+        let mut stack = ValidationStack::new();
+
+        read_instructions(
+            idx,
+            wasm,
+            &mut stack,
+            &locals,
+            globals,
+            fn_types,
+            type_idx_of_fn,
+        )?;
+
+        // Check if there were unread trailing instructions after the last END
+        if previous_pc + func_size as usize != wasm.pc {
+            todo!(
+                "throw error because there are trailing unreachable instructions in the code block"
             )
-        })?;
+        }
 
         Ok(func_block)
     })?;
@@ -75,23 +86,13 @@ pub fn read_declared_locals(wasm: &mut WasmReader) -> Result<Vec<ValType>> {
 fn read_instructions(
     this_function_idx: usize,
     wasm: &mut WasmReader,
-    value_stack: &mut Vec<ValType>,
+    stack: &mut ValidationStack,
     locals: &[ValType],
     globals: &[Global],
     fn_types: &[FuncType],
     type_idx_of_fn: &[usize],
 ) -> Result<()> {
-    let assert_pop_value_stack = |value_stack: &mut Vec<ValType>, expected_ty: ValType| {
-        value_stack
-            .pop()
-            .ok_or(Error::InvalidValueStackType(None))
-            .and_then(|ty| {
-                (ty == expected_ty)
-                    .then_some(())
-                    .ok_or(Error::InvalidValueStackType(Some(ty)))
-            })
-    };
-
+    // TODO we must terminate only if both we saw the final `end` and when we consumed all of the code span
     loop {
         let Ok(first_instr_byte) = wasm.read_u8() else {
             return Err(Error::ExprMissingEnd);
@@ -104,22 +105,57 @@ fn read_instructions(
             NOP => {}
             // end
             END => {
-                return Ok(());
+                // TODO check if there are labels on the stack.
+                // If there are none (i.e. this is the implicit end of the function and not a jump to the end of a function), the stack must only contain the valid return values, no other junk.
+                //
+                // Else, anything may remain on the stack, as long as the top of the stack matche the current blocks return value.
+
+                if stack.has_remaining_label() {
+                    // This is the END of a block.
+
+                    // We check the valtypes on top of the stack
+
+                    let _block_return_ty: &[ValType] = todo!("get return types for current block");
+                    // stack.assert_val_types_on_top(block_return_ty)?;
+
+                    // Clear the stack until the next label
+                    // stack.clear_until_next_label();
+
+                    // And push the blocks return types onto the stack again
+                    // for valtype in block_return_ty {
+                    // stack.push_valtype(*valtype);
+                    // }
+                } else {
+                    // This is the last end of a function
+
+                    // The stack must only contain the functions return valtypes
+                    let this_func_ty = &fn_types[type_idx_of_fn[this_function_idx]];
+                    stack.assert_val_types(&this_func_ty.returns.valtypes)?;
+                    return Ok(());
+                }
             }
             RETURN => {
                 let this_func_ty = &fn_types[type_idx_of_fn[this_function_idx]];
 
-                if value_stack.len() < this_func_ty.returns.valtypes.len() {
-                    return Err(Error::EndInvalidValueStack);
-                }
+                stack
+                    .assert_val_types_on_top(&this_func_ty.returns.valtypes)
+                    .map_err(|_| Error::EndInvalidValueStack)?;
 
-                let ret_vals_start = value_stack.len() - this_func_ty.returns.valtypes.len();
-                let _remaining_locals = value_stack.drain(..ret_vals_start);
+                stack.make_unspecified();
 
                 // TODO(george-cosma): a `return Ok(());` should probably be introduced here, but since we don't have
                 // controls flows implemented, the only way to test `return` is to place it at the end of function.
                 // However, an `end` is introduced after it, which is invalid. Compilation for this test case should
                 // probably fail.
+
+                // TODO(wucke13) I believe we must not drain the validation stack here; only if we
+                // know this return is actually taken during execution we may drain the stack. This
+                // could however be a conditional return (return in an `if`), and the other side
+                // past the `else` might need the values on the `ValidationStack` that do belong
+                // to the current function (but not the current block), so draining would make
+                // continued validation of the current function impossible. We should most
+                // definitely not `return Ok(())` here, because there might be still more of the
+                // current function to validate.
             }
             // call [t1*] -> [t2*]
             CALL => {
@@ -127,36 +163,34 @@ fn read_instructions(
                 let func_ty = &fn_types[type_idx_of_fn[func_to_call_idx]];
 
                 for typ in func_ty.params.valtypes.iter().rev() {
-                    assert_pop_value_stack(value_stack, *typ)?;
+                    stack.assert_pop_val_type(*typ)?;
                 }
 
                 for typ in func_ty.returns.valtypes.iter() {
-                    value_stack.push(*typ);
+                    stack.push_valtype(*typ);
                 }
+            }
+            // unreachable: [t1*] -> [t2*]
+            UNREACHABLE => {
+                stack.make_unspecified();
             }
             // local.get: [] -> [t]
             LOCAL_GET => {
                 let local_idx = wasm.read_var_u32()? as LocalIdx;
                 let local_ty = locals.get(local_idx).ok_or(Error::InvalidLocalIdx)?;
-                value_stack.push(*local_ty);
+                stack.push_valtype(*local_ty);
             }
             // local.set [t] -> [0]
             LOCAL_SET => {
                 let local_idx = wasm.read_var_u32()? as LocalIdx;
                 let local_ty = locals.get(local_idx).ok_or(Error::InvalidLocalIdx)?;
-                let popped = value_stack.pop();
-                if popped.as_ref() != Some(local_ty) {
-                    return Err(Error::InvalidValueStackType(popped));
-                }
+                stack.assert_pop_val_type(*local_ty)?;
             }
             // local.set [t] -> [t]
             LOCAL_TEE => {
                 let local_idx = wasm.read_var_u32()? as LocalIdx;
                 let local_ty = locals.get(local_idx).ok_or(Error::InvalidLocalIdx)?;
-                let back = value_stack.last();
-                if back != Some(local_ty) {
-                    return Err(Error::InvalidValueStackType(back.cloned()));
-                }
+                stack.assert_pop_val_type(*local_ty)?;
             }
             // global.get [] -> [t]
             GLOBAL_GET => {
@@ -165,7 +199,7 @@ fn read_instructions(
                     .get(global_idx)
                     .ok_or(Error::InvalidGlobalIdx(global_idx))?;
 
-                value_stack.push(global.ty.ty);
+                stack.push_valtype(global.ty.ty);
             }
             // global.set [t] -> []
             GLOBAL_SET => {
@@ -178,13 +212,7 @@ fn read_instructions(
                     return Err(Error::GlobalIsConst);
                 }
 
-                let ty_on_stack = value_stack
-                    .pop()
-                    .ok_or(Error::InvalidValueStackType(None))?;
-
-                if ty_on_stack != global.ty.ty {
-                    return Err(Error::InvalidValueStackType(Some(ty_on_stack)));
-                }
+                stack.assert_pop_val_type(global.ty.ty)?;
             }
             // i32.load [i32] -> [i32]
             I32_LOAD => {
@@ -193,27 +221,27 @@ fn read_instructions(
                 // TODO check correct `memarg.align`
                 // TODO check if memory[0] exists
 
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             // f32.load [f32] -> [f32]
             F32_LOAD => {
                 let _memarg = MemArg::read_unvalidated(wasm);
 
                 // Check for I32 because that's the address where we find our value
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::F32));
+                stack.push_valtype(ValType::NumType(NumType::F32));
             }
             // f32.load [f32] -> [f32]
             F64_LOAD => {
                 let _memarg = MemArg::read_unvalidated(wasm);
 
                 // Check for I32 because that's the address where we find our value
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::F64));
+                stack.push_valtype(ValType::NumType(NumType::F64));
             }
             // i32.store [i32] -> [i32]
             I32_STORE => {
@@ -223,167 +251,148 @@ fn read_instructions(
                 // TODO check if memory[0] exists
 
                 // Value to store
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 // Address
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
             }
             // f32.store [f32] -> [f32]
             F32_STORE => {
                 let _memarg = MemArg::read_unvalidated(wasm);
 
                 // Value to store
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F32))?;
                 // Address
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
             }
             F64_STORE => {
                 let _memarg = MemArg::read_unvalidated(wasm);
 
                 // Value to store
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F64))?;
                 // Address
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
             }
             // i32.const: [] -> [i32]
             I32_CONST => {
                 let _num = wasm.read_var_i32()?;
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             I64_CONST => {
                 let _num = wasm.read_var_i64()?;
-                value_stack.push(ValType::NumType(NumType::I64));
+                stack.push_valtype(ValType::NumType(NumType::I64));
             }
             F32_CONST => {
                 let _num = wasm.read_var_f32()?;
-                value_stack.push(ValType::NumType(NumType::F32));
+                stack.push_valtype(ValType::NumType(NumType::F32));
             }
             F64_CONST => {
                 let _num = wasm.read_var_f64()?;
-                value_stack.push(ValType::NumType(NumType::F64));
+                stack.push_valtype(ValType::NumType(NumType::F64));
             }
             I32_EQZ => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             I32_EQ | I32_NE | I32_LT_S | I32_LT_U | I32_GT_S | I32_GT_U | I32_LE_S | I32_LE_U
             | I32_GE_S | I32_GE_U => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             I64_EQZ => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             I64_EQ | I64_NE | I64_LT_S | I64_LT_U | I64_GT_S | I64_GT_U | I64_LE_S | I64_LE_U
             | I64_GE_S | I64_GE_U => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I64))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             F32_EQ | F32_NE | F32_LT | F32_GT | F32_LE | F32_GE => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F32))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F32))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             F64_EQ | F64_NE | F64_LT | F64_GT | F64_LE | F64_GE => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F64))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F64))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             F32_ABS | F32_NEG | F32_CEIL | F32_FLOOR | F32_TRUNC | F32_NEAREST | F32_SQRT => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F32))?;
 
-                value_stack.push(ValType::NumType(NumType::F32));
+                stack.push_valtype(ValType::NumType(NumType::F32));
             }
             F32_ADD | F32_SUB | F32_MUL | F32_DIV | F32_MIN | F32_MAX | F32_COPYSIGN => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F32))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F32))?;
 
-                value_stack.push(ValType::NumType(NumType::F32));
+                stack.push_valtype(ValType::NumType(NumType::F32));
             }
             F64_ABS | F64_NEG | F64_CEIL | F64_FLOOR | F64_TRUNC | F64_NEAREST | F64_SQRT => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F64))?;
 
-                value_stack.push(ValType::NumType(NumType::F64));
+                stack.push_valtype(ValType::NumType(NumType::F64));
             }
             F64_ADD | F64_SUB | F64_MUL | F64_DIV | F64_MIN | F64_MAX | F64_COPYSIGN => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F64))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::F64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::F64))?;
 
-                value_stack.push(ValType::NumType(NumType::F64));
+                stack.push_valtype(ValType::NumType(NumType::F64));
             }
             I32_ADD | I32_SUB | I32_MUL | I32_DIV_S | I32_DIV_U | I32_REM_S => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             // i32.clz: [i32] -> [i32]
             I32_CLZ | I32_CTZ | I32_POPCNT => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             I32_REM_U | I32_AND | I32_OR | I32_XOR | I32_SHL | I32_SHR_S | I32_SHR_U | I32_ROTL
             | I32_ROTR => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::I32));
+                stack.push_valtype(ValType::NumType(NumType::I32));
             }
             I64_CLZ | I64_CTZ | I64_POPCNT => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
 
-                value_stack.push(ValType::NumType(NumType::I64));
+                stack.push_valtype(ValType::NumType(NumType::I64));
             }
 
             I64_ADD | I64_SUB | I64_MUL | I64_DIV_S | I64_DIV_U | I64_REM_S | I64_REM_U
             | I64_AND | I64_OR | I64_XOR | I64_SHL | I64_SHR_S | I64_SHR_U | I64_ROTL
             | I64_ROTR => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I64))?;
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
 
-                value_stack.push(ValType::NumType(NumType::I64));
+                stack.push_valtype(ValType::NumType(NumType::I64));
             }
 
             F32_CONVERT_I32_S | F32_CONVERT_I32_U | F32_REINTERPRET_I32 => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I32))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
 
-                value_stack.push(ValType::NumType(NumType::F32));
+                stack.push_valtype(ValType::NumType(NumType::F32));
             }
 
             F32_CONVERT_I64_S | F32_CONVERT_I64_U => {
-                assert_pop_value_stack(value_stack, ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
 
-                value_stack.push(ValType::NumType(NumType::F32));
+                stack.push_valtype(ValType::NumType(NumType::F32));
             }
             _ => return Err(Error::InvalidInstr(first_instr_byte)),
         }
     }
-}
-
-fn validate_value_stack<F>(return_ty: ResultType, f: F) -> Result<()>
-where
-    F: FnOnce(&mut Vec<ValType>) -> Result<()>,
-{
-    let mut value_stack: Vec<ValType> = Vec::new();
-
-    f(&mut value_stack)?;
-
-    // TODO also check here if correct order
-    if value_stack != return_ty.valtypes {
-        error!(
-            "Expected types {:?} on stack, got {:?}",
-            return_ty.valtypes, value_stack
-        );
-        return Err(Error::EndInvalidValueStack);
-    }
-    Ok(())
 }

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -116,7 +116,12 @@ fn read_instructions(
 
                     // We check the valtypes on top of the stack
 
-                    let _block_return_ty: &[ValType] = todo!("get return types for current block");
+                    // TODO remove the ugly hack for the todo!(..)!
+                    #[allow(clippy::diverging_sub_expression)]
+                    {
+                        let _block_return_ty: &[ValType] =
+                            todo!("get return types for current block");
+                    }
                     // stack.assert_val_types_on_top(block_return_ty)?;
 
                     // Clear the stack until the next label

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -95,9 +95,10 @@ fn read_instructions(
     // TODO we must terminate only if both we saw the final `end` and when we consumed all of the code span
     loop {
         let Ok(first_instr_byte) = wasm.read_u8() else {
+            // TODO only do this if EOF
             return Err(Error::ExprMissingEnd);
         };
-        trace!("Read instruction byte {first_instr_byte:#X?} ({first_instr_byte})");
+        trace!("Read instruction byte {first_instr_byte:#04X?} ({first_instr_byte}) at wasm_binary[{}]", wasm.pc);
 
         use crate::core::reader::types::opcode::*;
         match first_instr_byte {
@@ -180,7 +181,7 @@ fn read_instructions(
                 let local_ty = locals.get(local_idx).ok_or(Error::InvalidLocalIdx)?;
                 stack.push_valtype(*local_ty);
             }
-            // local.set [t] -> [0]
+            // local.set [t] -> []
             LOCAL_SET => {
                 let local_idx = wasm.read_var_u32()? as LocalIdx;
                 let local_ty = locals.get(local_idx).ok_or(Error::InvalidLocalIdx)?;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -11,6 +11,7 @@ use crate::core::reader::{WasmReadable, WasmReader};
 use crate::{Error, Result};
 
 pub(crate) mod code;
+pub(crate) mod validation_stack;
 
 /// Information collected from validating a module.
 /// This can be used to create a [crate::RuntimeInstance].

--- a/src/validation/validation_stack.rs
+++ b/src/validation/validation_stack.rs
@@ -1,0 +1,227 @@
+//! This module contains the [`ValidationStack`] data structure
+//!
+//! The [`ValidationStack`] is a unified stack, in the sense that it unifies both
+//! [`ValidationStackEntry::Val`] and [`ValidationStackEntry::Label`]. It therefore mixes type
+//! information with structured control flow information.
+#![allow(unused)] // TODO remove this once sidetable implementation lands
+use super::Result;
+use alloc::vec::Vec;
+
+use crate::{Error, ValType};
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ValidationStack {
+    stack: Vec<ValidationStackEntry>,
+}
+
+impl ValidationStack {
+    /// Initialize a new ValidationStack
+    pub(super) fn new() -> Self {
+        Self { stack: Vec::new() }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.stack.len()
+    }
+
+    pub(super) fn push_valtype(&mut self, valtype: ValType) {
+        self.stack.push(ValidationStackEntry::Val(valtype));
+    }
+
+    pub(super) fn push_label(&mut self, label_info: LabelInfo) {
+        self.stack.push(ValidationStackEntry::Label(label_info));
+    }
+
+    /// This puts an unspecified element on top of the stack.
+    /// While the top of the stack is unspecified, arbitrary value types can be popped.
+    /// To remove this, a new label has to be pushed or an existing one has to be popped.
+    pub(super) fn make_unspecified(&mut self) {
+        // Pop everything until next label or until the stack is empty.
+        // This is okay, because these values cannot be accessed during execution ever again.
+        while let Some(entry) = self.stack.last() {
+            match entry {
+                ValidationStackEntry::Val(_) | ValidationStackEntry::UnspecifiedValTypes => {
+                    self.stack.pop();
+                }
+                ValidationStackEntry::Label(_) => break,
+            }
+        }
+
+        self.stack.push(ValidationStackEntry::UnspecifiedValTypes)
+    }
+
+    /// Pop a [`ValidationStackEntry`] from the [`ValidationStack`]
+    ///
+    /// # Returns
+    ///
+    /// - Returns `Ok(_)` with the former top-most [`ValidationStackEntry`] inside, if the stack had
+    ///   at least one element.
+    /// - Returns `Err(_)` if the stack was already empty.
+    fn pop(&mut self) -> Result<ValidationStackEntry> {
+        self.stack
+            .pop()
+            .ok_or(Error::InvalidValidationStackValType(None))
+    }
+
+    /// Assert the top-most [`ValidationStackEntry`] is a specific [`ValType`], after popping it from the [`ValidationStack`]
+    ///
+    /// # Returns
+    ///
+    /// - Returns `Ok(())` if the top-most [`ValidationStackEntry`] is a [`ValType`] identical to
+    ///   `expected_ty`.
+    /// - Returns `Err(_)` otherwise.
+    pub(super) fn assert_pop_val_type(&mut self, expected_ty: ValType) -> Result<()> {
+        if let Some(ValidationStackEntry::UnspecifiedValTypes) = self.stack.last() {
+            // An unspecified value is always correct, and will never disappear by popping.
+            return Ok(());
+        }
+
+        match self.pop()? {
+            ValidationStackEntry::Val(ty) => (ty == expected_ty)
+                .then_some(())
+                .ok_or(Error::InvalidValidationStackValType(Some(ty))),
+            ValidationStackEntry::Label(li) => Err(Error::FoundLabel(li.kind)),
+            ValidationStackEntry::UnspecifiedValTypes => {
+                unreachable!("we just checked if the topmost entry is of this type")
+            }
+        }
+    }
+
+    /// Asserts that the values on top of the stack match those of a value iterator
+    ///
+    /// The last element of the `val_types` [`Iterator`] is compared to the top-most
+    /// [`ValidationStackEntry`], the second last `val_types` element to the second top-most
+    /// [`ValidationStackEntry`] etc.
+    ///
+    /// Any occurence of the [`ValidationStackEntry::Label`] variant in the stack tail will cause an
+    /// error. This method does not mutate the [`ValidationStack::stack`] in any way.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(_)`, the tail of the stack matches the `expected_val_types`
+    /// - `Err(_)` otherwise
+    pub(super) fn assert_val_types_on_top(&self, expected_val_types: &[ValType]) -> Result<()> {
+        let stack_tail = self
+            .stack
+            .get(self.stack.len() - expected_val_types.len()..)
+            .ok_or(Error::InvalidValType)?;
+
+        // Now we check the valtypes in reverse.
+        // That way we can stop checking if we encounter an `UnspecifiedValTypes`.
+
+        let mut current_expected_valtype = expected_val_types.iter().rev();
+        for entry in stack_tail.iter().rev() {
+            match entry {
+                ValidationStackEntry::Label(label) => return Err(Error::EndInvalidValueStack),
+                ValidationStackEntry::Val(valtype) => {
+                    if Some(valtype) != current_expected_valtype.next() {
+                        return Err(Error::EndInvalidValueStack);
+                    }
+                }
+                ValidationStackEntry::UnspecifiedValTypes => {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn assert_val_types(&self, expected_val_types: &[ValType]) -> Result<()> {
+        let topmost_label_index = self.find_topmost_label_idx();
+
+        let first_valtype = topmost_label_index.map(|idx| idx + 1).unwrap_or(0);
+
+        // Now we check the valtypes in reverse.
+        // That way we can stop checking if we encounter an `UnspecifiedValTypes`.
+
+        let mut current_expected_valtype = expected_val_types.iter().rev();
+        for entry in self.stack[first_valtype..].iter().rev() {
+            match entry {
+                ValidationStackEntry::Label(_) => unreachable!(
+                    "we started at the top-most label so we cannot find any more labels"
+                ),
+                ValidationStackEntry::Val(valtype) => {
+                    if Some(valtype) != current_expected_valtype.next() {
+                        return Err(Error::EndInvalidValueStack);
+                    }
+                }
+                ValidationStackEntry::UnspecifiedValTypes => {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Finds the index of the topmost label that is currently on the stack.
+    fn find_topmost_label_idx(&self) -> Option<usize> {
+        self.stack
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_idx, entry)| matches!(entry, ValidationStackEntry::Label(_)))
+            .map(|(idx, _entry)| idx)
+    }
+
+    /// Removes all valtypes until the next lower label.
+    /// If a label is found and popped, its info is returned.
+    fn pop_label_and_above(&mut self) -> Option<LabelInfo> {
+        /// Delete all the values until the topmost label or until the stack is empty
+        match self.find_topmost_label_idx() {
+            Some(idx) => {
+                if self.stack.len() > idx + 1 {
+                    self.stack.drain((idx + 1)..);
+                }
+            }
+            None => self.stack.clear(),
+        }
+
+        // Pop the label itself
+        match self.pop() {
+            Ok(ValidationStackEntry::Label(info)) => Some(info),
+            Ok(_) => unreachable!(
+                "we just removed everything until the next label, thus new topmost entry must be a label"
+            ),
+            Err(_) => None,
+        }
+    }
+
+    /// Return true if the stack has at least one remaining label
+    pub(super) fn has_remaining_label(&self) -> bool {
+        self.stack
+            .iter()
+            .any(|e| matches!(e, ValidationStackEntry::Label(_)))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ValidationStackEntry {
+    /// A value
+    Val(ValType),
+
+    /// A label
+    Label(LabelInfo),
+
+    /// Special variant to encode that any possible number of ValTypes could be here
+    ///
+    /// Caused by `return` and `unreachable, as both can push an arbitrary number of values
+    /// from/to the stack.
+    ///
+    /// When this variant is popped onto the stack, all valtypes until the next lower label are deleted.
+    /// They are not needed anymore because this variant can expand to all of them.
+    UnspecifiedValTypes,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LabelInfo {
+    pub(crate) kind: LabelKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LabelKind {
+    Block,
+    Loop,
+    If,
+}


### PR DESCRIPTION
### Pull Request Overview

This change introduces a unified stack (containing both control flow labels and value types) for the validation. This is a preparation for the introduction of structured control flow.

### Testing Strategy

This pull request was tested `cargo test`

### TODO or Help Wanted

This pull request still needs to fix the one failing test case.

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [ ] Ran `cargo doc`
- [ ] Ran `nix fmt`

### Github Issue

This pull request closes <GITHUB_ISSUE>
