### PR TITLE
feat: Linker

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -26,6 +26,8 @@ pub enum RuntimeError {
     UninitializedElement,
     SignatureMismatch,
     ExpectedAValueOnTheStack,
+    ModuleNotFound,
+    UnmetImport,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -247,6 +249,10 @@ impl Display for RuntimeError {
             RuntimeError::SignatureMismatch => f.write_str("Indirect call signature mismatch"),
             RuntimeError::ExpectedAValueOnTheStack => {
                 f.write_str("Expected a value on the stack, but None was found")
+            }
+            RuntimeError::ModuleNotFound => f.write_str("No such module exists"),
+            RuntimeError::UnmetImport => {
+                f.write_str("There is at least one import which has no corresponding export")
             }
         }
     }

--- a/src/core/sidetable.rs
+++ b/src/core/sidetable.rs
@@ -43,7 +43,7 @@ pub type Sidetable = Vec<SidetableEntry>;
 /// - else
 // TODO hide implementation
 // TODO Remove Clone trait from sidetables
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SidetableEntry {
     /// Δpc: the amount to adjust the instruction pointer by if the branch is taken
     pub delta_pc: isize,

--- a/src/execution/execution_info.rs
+++ b/src/execution/execution_info.rs
@@ -1,0 +1,29 @@
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::core::reader::types::FuncType;
+use crate::core::reader::WasmReader;
+use crate::execution::Store;
+
+/// ExecutionInfo is a compilation of relevant information needed by the [interpreter loop](
+/// crate::execution::interpreter_loop::run). The lifetime annotation `'r` represents that this structure needs to be
+/// valid at least as long as the [RuntimeInstance](crate::execution::RuntimeInstance) that creates it.
+pub struct ExecutionInfo<'r> {
+    pub name: String,
+    pub wasm_bytecode: &'r [u8],
+    pub wasm_reader: WasmReader<'r>,
+    pub fn_types: Vec<FuncType>,
+    pub store: Store,
+}
+
+impl<'r> ExecutionInfo<'r> {
+    pub fn new(name: &str, wasm_bytecode: &'r [u8], fn_types: Vec<FuncType>, store: Store) -> Self {
+        ExecutionInfo {
+            name: name.to_string(),
+            wasm_bytecode,
+            wasm_reader: WasmReader::new(wasm_bytecode),
+            fn_types,
+            store,
+        }
+    }
+}

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -44,7 +44,9 @@ pub(super) fn run<H: HookSet>(
     let func_inst = store
         .funcs
         .get(stack.current_stackframe().func_idx)
-        .unwrap_validated();
+        .unwrap_validated()
+        .try_into_local()
+        .expect("to start execution with local function");
 
     // Start reading the function's instructions
     let mut wasm = WasmReader::new(wasm_bytecode);
@@ -78,6 +80,8 @@ pub(super) fn run<H: HookSet>(
                     .funcs
                     .get(stack.current_stackframe().func_idx)
                     .unwrap_validated()
+                    .try_into_local()
+                    .expect("TODO: interpreter_loop")
                     .code_expr;
                 if wasm.pc != current_func_span.from() + current_func_span.len() {
                     continue;
@@ -100,6 +104,8 @@ pub(super) fn run<H: HookSet>(
                     .funcs
                     .get(stack.current_stackframe().func_idx)
                     .unwrap_validated()
+                    .try_into_local()
+                    .expect("TODO: interpreter_loop")
                     .sidetable;
             }
             IF => {
@@ -160,7 +166,12 @@ pub(super) fn run<H: HookSet>(
             CALL => {
                 let func_to_call_idx = wasm.read_var_u32().unwrap_validated() as FuncIdx;
 
-                let func_to_call_inst = store.funcs.get(func_to_call_idx).unwrap_validated();
+                let func_to_call_inst = store
+                    .funcs
+                    .get(func_to_call_idx)
+                    .unwrap_validated()
+                    .try_into_local()
+                    .expect("TODO: interpreter_loop");
                 let func_to_call_ty = types.get(func_to_call_inst.ty).unwrap_validated();
 
                 let params = stack.pop_tail_iter(func_to_call_ty.params.valtypes.len());
@@ -205,7 +216,9 @@ pub(super) fn run<H: HookSet>(
                 let func_to_call_inst = store
                     .funcs
                     .get(func_addr.unwrap_validated())
-                    .unwrap_validated();
+                    .unwrap_validated()
+                    .try_into_local()
+                    .expect("TODO: interpreter_loop");
 
                 let func_ty_actual_index = func_to_call_inst.ty;
 

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -18,13 +18,13 @@ use crate::{
     core::{
         indices::{DataIdx, FuncIdx, GlobalIdx, LabelIdx, LocalIdx, TableIdx, TypeIdx},
         reader::{
-            types::{memarg::MemArg, BlockType, FuncType},
+            types::{memarg::MemArg, BlockType},
             WasmReadable, WasmReader,
         },
         sidetable::Sidetable,
     },
     locals::Locals,
-    store::{DataInst, Store},
+    store::{DataInst, FuncInst},
     value::{self, FuncAddr, Ref},
     value_stack::Stack,
     Limits, NumType, RefType, RuntimeError, ValType, Value,
@@ -33,23 +33,26 @@ use crate::{
 #[cfg(feature = "hooks")]
 use crate::execution::hooks::HookSet;
 
+use super::{execution_info::ExecutionInfo, lut::Lut};
+
 /// Interprets a functions. Parameters and return values are passed on the stack.
 pub(super) fn run<H: HookSet>(
-    wasm_bytecode: &[u8],
-    types: &[FuncType],
-    store: &mut Store,
+    modules: &mut [ExecutionInfo],
+    current_module_idx: &mut usize,
+    lut: &Lut,
     stack: &mut Stack,
     mut hooks: H,
 ) -> Result<(), RuntimeError> {
-    let func_inst = store
+    let func_inst = modules[*current_module_idx]
+        .store
         .funcs
         .get(stack.current_stackframe().func_idx)
         .unwrap_validated()
         .try_into_local()
-        .expect("to start execution with local function");
+        .unwrap_validated();
 
     // Start reading the function's instructions
-    let mut wasm = WasmReader::new(wasm_bytecode);
+    let mut wasm = &mut modules[*current_module_idx].wasm_reader;
 
     // the sidetable and stp for this function, stp will reset to 0 every call
     // since function instances have their own sidetable.
@@ -63,7 +66,7 @@ pub(super) fn run<H: HookSet>(
     loop {
         // call the instruction hook
         #[cfg(feature = "hooks")]
-        hooks.instruction_hook(wasm_bytecode, wasm.pc);
+        hooks.instruction_hook(modules[*current_module_idx].wasm_bytecode, wasm.pc);
 
         let first_instr_byte = wasm.read_u8().unwrap_validated();
 
@@ -76,18 +79,23 @@ pub(super) fn run<H: HookSet>(
                 // just skip because it is a delimiter of a ctrl block
 
                 // TODO there is definitely a better to write this
-                let current_func_span = store
+                let current_func_span = modules[*current_module_idx]
+                    .store
                     .funcs
                     .get(stack.current_stackframe().func_idx)
                     .unwrap_validated()
                     .try_into_local()
-                    .expect("TODO: interpreter_loop")
+                    .unwrap_validated()
                     .code_expr;
+
+                // There might be multiple ENDs in a single function. We want to
+                // exit only when the outermost block (aka function block) ends.
                 if wasm.pc != current_func_span.from() + current_func_span.len() {
                     continue;
                 }
 
-                let (maybe_return_address, maybe_return_stp) = stack.pop_stackframe();
+                let (return_module, maybe_return_address, maybe_return_stp) =
+                    stack.pop_stackframe();
 
                 // We finished this entire invocation if there is no stackframe left. If there are
                 // one or more stack frames, we need to continue from where the callee was called
@@ -97,16 +105,20 @@ pub(super) fn run<H: HookSet>(
                 }
 
                 trace!("end of function reached, returning to previous stack frame");
+                wasm = &mut modules[return_module].wasm_reader;
                 wasm.pc = maybe_return_address;
                 stp = maybe_return_stp;
 
-                current_sidetable = &store
+                current_sidetable = &modules[return_module]
+                    .store
                     .funcs
                     .get(stack.current_stackframe().func_idx)
                     .unwrap_validated()
                     .try_into_local()
-                    .expect("TODO: interpreter_loop")
+                    .unwrap_validated()
                     .sidetable;
+
+                *current_module_idx = return_module;
             }
             IF => {
                 wasm.read_var_u32().unwrap_validated();
@@ -116,11 +128,11 @@ pub(super) fn run<H: HookSet>(
                 if test_val != 0 {
                     stp += 1;
                 } else {
-                    do_sidetable_control_transfer(&mut wasm, stack, &mut stp, current_sidetable);
+                    do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
                 }
             }
             ELSE => {
-                do_sidetable_control_transfer(&mut wasm, stack, &mut stp, current_sidetable);
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             BR_IF => {
                 wasm.read_var_u32().unwrap_validated();
@@ -128,7 +140,7 @@ pub(super) fn run<H: HookSet>(
                 let test_val: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 if test_val != 0 {
-                    do_sidetable_control_transfer(&mut wasm, stack, &mut stp, current_sidetable);
+                    do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
                 } else {
                     stp += 1;
                 }
@@ -149,49 +161,102 @@ pub(super) fn run<H: HookSet>(
                     stp += case_val;
                 }
 
-                do_sidetable_control_transfer(&mut wasm, stack, &mut stp, current_sidetable);
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             BR => {
                 //skip n of BR n
                 wasm.read_var_u32().unwrap_validated();
-                do_sidetable_control_transfer(&mut wasm, stack, &mut stp, current_sidetable);
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             BLOCK | LOOP => {
-                BlockType::read_unvalidated(&mut wasm);
+                BlockType::read_unvalidated(wasm);
             }
             RETURN => {
                 //same as BR, except no need to skip n of BR n
-                do_sidetable_control_transfer(&mut wasm, stack, &mut stp, current_sidetable);
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             CALL => {
                 let func_to_call_idx = wasm.read_var_u32().unwrap_validated() as FuncIdx;
 
-                let func_to_call_inst = store
+                let func_to_call_inst = modules[*current_module_idx]
+                    .store
                     .funcs
                     .get(func_to_call_idx)
-                    .unwrap_validated()
-                    .try_into_local()
-                    .expect("TODO: interpreter_loop");
-                let func_to_call_ty = types.get(func_to_call_inst.ty).unwrap_validated();
+                    .unwrap_validated();
+                let func_to_call_ty = modules[*current_module_idx]
+                    .fn_types
+                    .get(func_to_call_inst.ty())
+                    .unwrap_validated();
 
                 let params = stack.pop_tail_iter(func_to_call_ty.params.valtypes.len());
-                let remaining_locals = func_to_call_inst.locals.iter().cloned();
 
                 trace!("Instruction: call [{func_to_call_idx:?}]");
-                let locals = Locals::new(params, remaining_locals);
-                stack.push_stackframe(func_to_call_idx, func_to_call_ty, locals, wasm.pc, stp);
 
-                wasm.move_start_to(func_to_call_inst.code_expr)
-                    .unwrap_validated();
-                stp = 0;
-                current_sidetable = &func_to_call_inst.sidetable;
+                match func_to_call_inst {
+                    FuncInst::Local(local_func_inst) => {
+                        let remaining_locals = local_func_inst.locals.iter().cloned();
+                        let locals = Locals::new(params, remaining_locals);
+
+                        stack.push_stackframe(
+                            *current_module_idx,
+                            func_to_call_idx,
+                            func_to_call_ty,
+                            locals,
+                            wasm.pc,
+                            stp,
+                        );
+
+                        wasm.move_start_to(local_func_inst.code_expr)
+                            .unwrap_validated();
+
+                        stp = 0;
+                        current_sidetable = &local_func_inst.sidetable;
+                    }
+                    FuncInst::Imported(_imported_func_inst) => {
+                        let (next_module, next_func_idx) = lut
+                            .lookup(*current_module_idx, func_to_call_idx)
+                            .expect("invalid state for lookup");
+
+                        let local_func_inst = modules[next_module].store.funcs[next_func_idx]
+                            .try_into_local()
+                            .unwrap();
+
+                        let remaining_locals = local_func_inst.locals.iter().cloned();
+                        let locals = Locals::new(params, remaining_locals);
+
+                        stack.push_stackframe(
+                            *current_module_idx,
+                            func_to_call_idx,
+                            func_to_call_ty,
+                            locals,
+                            wasm.pc,
+                            stp,
+                        );
+
+                        wasm = &mut modules[next_module].wasm_reader;
+                        *current_module_idx = next_module;
+
+                        wasm.move_start_to(local_func_inst.code_expr)
+                            .unwrap_validated();
+
+                        stp = 0;
+                        current_sidetable = &local_func_inst.sidetable;
+                    }
+                }
             }
             CALL_INDIRECT => {
                 let type_idx = wasm.read_var_u32().unwrap_validated() as TypeIdx;
                 let table_idx = wasm.read_var_u32().unwrap_validated() as TableIdx;
 
-                let tab = store.tables.get(table_idx).unwrap_validated();
-                let func_ty = types.get(type_idx).unwrap_validated();
+                let tab = modules[*current_module_idx]
+                    .store
+                    .tables
+                    .get(table_idx)
+                    .unwrap_validated();
+                let func_ty = modules[*current_module_idx]
+                    .fn_types
+                    .get(type_idx)
+                    .unwrap_validated();
 
                 let i: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
@@ -213,12 +278,13 @@ pub(super) fn run<H: HookSet>(
                     Ref::Extern(_) => unreachable!(),
                 };
 
-                let func_to_call_inst = store
+                let func_to_call_inst = modules[*current_module_idx]
+                    .store
                     .funcs
                     .get(func_addr.unwrap_validated())
                     .unwrap_validated()
                     .try_into_local()
-                    .expect("TODO: interpreter_loop");
+                    .expect("TODO: handle call_indirect into import");
 
                 let func_ty_actual_index = func_to_call_inst.ty;
 
@@ -231,7 +297,14 @@ pub(super) fn run<H: HookSet>(
 
                 trace!("Instruction: call_indirect [{func_addr:?}]");
                 let locals = Locals::new(params, remaining_locals);
-                stack.push_stackframe(func_addr.unwrap_validated(), func_ty, locals, wasm.pc, stp);
+                stack.push_stackframe(
+                    *current_module_idx,
+                    func_addr.unwrap_validated(),
+                    func_ty,
+                    locals,
+                    wasm.pc,
+                    stp,
+                );
 
                 wasm.move_start_to(func_to_call_inst.code_expr)
                     .unwrap_validated();
@@ -250,20 +323,32 @@ pub(super) fn run<H: HookSet>(
             LOCAL_TEE => stack.tee_local(wasm.read_var_u32().unwrap_validated() as LocalIdx),
             GLOBAL_GET => {
                 let global_idx = wasm.read_var_u32().unwrap_validated() as GlobalIdx;
-                let global = store.globals.get(global_idx).unwrap_validated();
+                let global = modules[*current_module_idx]
+                    .store
+                    .globals
+                    .get(global_idx)
+                    .unwrap_validated();
 
                 stack.push_value(global.value);
             }
             GLOBAL_SET => {
                 let global_idx = wasm.read_var_u32().unwrap_validated() as GlobalIdx;
-                let global = store.globals.get_mut(global_idx).unwrap_validated();
+                let global = modules[*current_module_idx]
+                    .store
+                    .globals
+                    .get_mut(global_idx)
+                    .unwrap_validated();
 
                 global.value = stack.pop_value(global.global.ty.ty)
             }
             TABLE_GET => {
                 let table_idx = wasm.read_var_u32().unwrap_validated() as TableIdx;
 
-                let tab = store.tables.get(table_idx).unwrap_validated();
+                let tab = modules[*current_module_idx]
+                    .store
+                    .tables
+                    .get(table_idx)
+                    .unwrap_validated();
 
                 let i: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
@@ -283,7 +368,7 @@ pub(super) fn run<H: HookSet>(
             TABLE_SET => {
                 let table_idx = wasm.read_var_u32().unwrap_validated() as TableIdx;
 
-                let tab = &mut store.tables[table_idx];
+                let tab = &mut modules[*current_module_idx].store.tables[table_idx];
 
                 let val: Ref = stack.pop_value(ValType::RefType(tab.ty.et)).into();
                 let i: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -300,10 +385,14 @@ pub(super) fn run<H: HookSet>(
                 )
             }
             I32_LOAD => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: u32 = {
                     // The spec states that this should be a 33 bit integer
@@ -326,10 +415,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load [{relative_address}] -> [{data}]");
             }
             I64_LOAD => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated();
 
                 let data: u64 = {
                     // The spec states that this should be a 33 bit integer
@@ -353,10 +446,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load [{relative_address}] -> [{data}]");
             }
             F32_LOAD => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: f32 = {
                     // The spec states that this should be a 33 bit integer
@@ -379,10 +476,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f32.load [{relative_address}] -> [{data}]");
             }
             F64_LOAD => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated();
 
                 let data: f64 = {
                     // The spec states that this should be a 33 bit integer
@@ -406,10 +507,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f64.load [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_S => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: i8 = {
                     // The spec states that this should be a 33 bit integer
@@ -434,10 +539,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load8_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_U => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: u8 = {
                     // The spec states that this should be a 33 bit integer
@@ -461,10 +570,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load8_u [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_S => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: i16 = {
                     // The spec states that this should be a 33 bit integer
@@ -488,10 +601,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load16_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_U => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: u16 = {
                     // The spec states that this should be a 33 bit integer
@@ -515,10 +632,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_S => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: i8 = {
                     // The spec states that this should be a 33 bit integer
@@ -543,10 +664,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load8_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_U => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: u8 = {
                     // The spec states that this should be a 33 bit integer
@@ -571,10 +696,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load8_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_S => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: i16 = {
                     // The spec states that this should be a 33 bit integer
@@ -598,10 +727,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load16_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_U => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: u16 = {
                     // The spec states that this should be a 33 bit integer
@@ -625,10 +758,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_S => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: i32 = {
                     // The spec states that this should be a 33 bit integer
@@ -652,10 +789,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load32_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_U => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.first().unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .first()
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 let data: u32 = {
                     // The spec states that this should be a 33 bit integer
@@ -679,12 +820,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load32_u [{relative_address}] -> [{data}]");
             }
             I32_STORE => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -700,12 +845,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.store [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: u32 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -721,12 +870,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.store [{relative_address} {data_to_store}] -> []");
             }
             F32_STORE => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: f32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -742,12 +895,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f32.store [{relative_address} {data_to_store}] -> []");
             }
             F64_STORE => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: f64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated(); // there is only one memory allowed as of now
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated(); // there is only one memory allowed as of now
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -763,12 +920,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f64.store [{relative_address} {data_to_store}] -> []");
             }
             I32_STORE8 => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated();
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -785,12 +946,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.store8 [{relative_address} {data_to_store}] -> []");
             }
             I32_STORE16 => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated();
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -807,12 +972,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.store16 [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE8 => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated();
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -829,12 +998,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.store8 [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE16 => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated();
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -851,12 +1024,16 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.store16 [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE32 => {
-                let memarg = MemArg::read_unvalidated(&mut wasm);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let mem = store.mems.get_mut(0).unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(0)
+                    .unwrap_validated();
 
                 // The spec states that this should be a 33 bit integer
                 // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
@@ -874,14 +1051,22 @@ pub(super) fn run<H: HookSet>(
             }
             MEMORY_SIZE => {
                 let mem_idx = wasm.read_u8().unwrap_validated() as usize;
-                let mem = store.mems.get(mem_idx).unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get(mem_idx)
+                    .unwrap_validated();
                 let size = mem.size() as u32;
                 stack.push_value(Value::I32(size));
                 trace!("Instruction: memory.size [] -> [{}]", size);
             }
             MEMORY_GROW => {
                 let mem_idx = wasm.read_u8().unwrap_validated() as usize;
-                let mem = store.mems.get_mut(mem_idx).unwrap_validated();
+                let mem = modules[*current_module_idx]
+                    .store
+                    .mems
+                    .get_mut(mem_idx)
+                    .unwrap_validated();
                 let delta: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let upper_limit = mem.ty.limits.max.unwrap_or(Limits::MAX_MEM_BYTES);
@@ -2056,7 +2241,7 @@ pub(super) fn run<H: HookSet>(
                 stack.push_value(res.into());
             }
             REF_NULL => {
-                let reftype = RefType::read_unvalidated(&mut wasm);
+                let reftype = RefType::read_unvalidated(wasm);
 
                 stack.push_value(Value::Ref(reftype.to_null_ref()));
                 trace!("Instruction: ref.null '{:?}' -> [{:?}]", reftype, reftype);
@@ -2219,9 +2404,19 @@ pub(super) fn run<H: HookSet>(
                         //      s => starting pointer in the data segment
                         //      d => destination address to copy to
                         let data_idx = wasm.read_var_u32().unwrap_validated() as DataIdx;
-                        let data_init_len = store.data.get(data_idx).unwrap().data.len();
+                        let data_init_len = modules[*current_module_idx]
+                            .store
+                            .data
+                            .get(data_idx)
+                            .unwrap()
+                            .data
+                            .len();
                         let mem_idx = wasm.read_u8().unwrap_validated() as usize;
-                        let mem = store.mems.get(mem_idx).unwrap_validated();
+                        let mem = modules[*current_module_idx]
+                            .store
+                            .mems
+                            .get(mem_idx)
+                            .unwrap_validated();
                         let n: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                         let s: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                         let d: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -2236,9 +2431,14 @@ pub(super) fn run<H: HookSet>(
                             .filter(|&res| res <= mem.data.len())
                             .ok_or(RuntimeError::MemoryAccessOutOfBounds)?;
 
-                        let data =
-                            &store.data.get(data_idx).unwrap().data[(s as usize)..final_src_offset];
-                        store
+                        let data = &modules[*current_module_idx]
+                            .store
+                            .data
+                            .get(data_idx)
+                            .unwrap()
+                            .data[(s as usize)..final_src_offset];
+                        modules[*current_module_idx]
+                            .store
                             .mems
                             .get_mut(mem_idx)
                             .unwrap_validated()
@@ -2258,7 +2458,8 @@ pub(super) fn run<H: HookSet>(
 
                         // Also, we should set data to null here (empty), which we do using an empty init vec
                         let data_idx = wasm.read_var_u32().unwrap_validated() as DataIdx;
-                        store.data[data_idx] = DataInst { data: Vec::new() };
+                        modules[*current_module_idx].store.data[data_idx] =
+                            DataInst { data: Vec::new() };
                     }
                     // See https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-copy
                     MEMORY_COPY => {
@@ -2274,20 +2475,38 @@ pub(super) fn run<H: HookSet>(
                         let s: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                         let d: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
+                        let len_src = modules[*current_module_idx]
+                            .store
+                            .mems
+                            .get(src)
+                            .unwrap_validated()
+                            .data
+                            .len();
                         let final_src_offset = (n as usize)
                             .checked_add(s as usize)
-                            .filter(|&res| res <= store.mems.get(src).unwrap_validated().data.len())
+                            .filter(|&res| res <= len_src)
                             .ok_or(RuntimeError::MemoryAccessOutOfBounds)?;
 
+                        let len_dest = modules[*current_module_idx]
+                            .store
+                            .mems
+                            .get(dst)
+                            .unwrap_validated()
+                            .data
+                            .len();
                         // let final_dst_offset =
                         (n as usize)
                             .checked_add(d as usize)
-                            .filter(|&res| res <= store.mems.get(dst).unwrap_validated().data.len())
+                            .filter(|&res| res <= len_dest)
                             .ok_or(RuntimeError::MemoryAccessOutOfBounds)?;
 
                         if dst == src {
                             // we copy from memory X to memory X
-                            let mem = store.mems.get_mut(src).unwrap_validated();
+                            let mem = modules[*current_module_idx]
+                                .store
+                                .mems
+                                .get_mut(src)
+                                .unwrap_validated();
                             mem.data
                                 .copy_within(s as usize..final_src_offset, d as usize);
                         } else {
@@ -2295,11 +2514,13 @@ pub(super) fn run<H: HookSet>(
                             use core::cmp::Ordering::*;
                             let (src_mem, dst_mem) = match dst.cmp(&src) {
                                 Greater => {
-                                    let (left, right) = store.mems.split_at_mut(dst);
+                                    let (left, right) =
+                                        modules[*current_module_idx].store.mems.split_at_mut(dst);
                                     (&left[src], &mut right[0])
                                 }
                                 Less => {
-                                    let (left, right) = store.mems.split_at_mut(src);
+                                    let (left, right) =
+                                        modules[*current_module_idx].store.mems.split_at_mut(src);
                                     (&right[0], &mut left[dst])
                                 }
                                 Equal => unreachable!(),
@@ -2317,7 +2538,11 @@ pub(super) fn run<H: HookSet>(
                         //      val => the value to set each byte to (must be < 256)
                         //      d => the pointer to the region to update
                         let mem_idx = wasm.read_u8().unwrap_validated() as usize;
-                        let mem = store.mems.get(mem_idx).unwrap_validated();
+                        let mem = modules[*current_module_idx]
+                            .store
+                            .mems
+                            .get(mem_idx)
+                            .unwrap_validated();
                         let n: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                         let val: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
@@ -2333,7 +2558,8 @@ pub(super) fn run<H: HookSet>(
                             .ok_or(RuntimeError::MemoryAccessOutOfBounds)?;
 
                         let data: Vec<u8> = vec![val as u8; (n - d) as usize];
-                        store
+                        modules[*current_module_idx]
+                            .store
                             .mems
                             .get_mut(mem_idx)
                             .unwrap_validated()
@@ -2356,11 +2582,29 @@ pub(super) fn run<H: HookSet>(
                         let s: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into(); // offset
                         let d: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into(); // dst
 
-                        let tab_len = store.tables.get(table_idx).unwrap_validated().len();
-                        let tab = store.tables.get_mut(table_idx).unwrap_validated();
+                        let tab_len = modules[*current_module_idx]
+                            .store
+                            .tables
+                            .get(table_idx)
+                            .unwrap_validated()
+                            .len();
+                        let tab = modules[*current_module_idx]
+                            .store
+                            .tables
+                            .get_mut(table_idx)
+                            .unwrap_validated();
 
-                        let elem_len = if store.passive_elem_indexes.contains(&elem_idx) {
-                            store.elements.get(elem_idx).unwrap_validated().len()
+                        let elem_len = if modules[*current_module_idx]
+                            .store
+                            .passive_elem_indexes
+                            .contains(&elem_idx)
+                        {
+                            modules[*current_module_idx]
+                                .store
+                                .elements
+                                .get(elem_idx)
+                                .unwrap_validated()
+                                .len()
                         } else {
                             0
                         };
@@ -2384,7 +2628,11 @@ pub(super) fn run<H: HookSet>(
                             .filter(|&res| res <= tab_len)
                             .ok_or(RuntimeError::TableAccessOutOfBounds)?;
 
-                        let elem = store.elements.get(elem_idx).unwrap_validated();
+                        let elem = modules[*current_module_idx]
+                            .store
+                            .elements
+                            .get(elem_idx)
+                            .unwrap_validated();
 
                         let dest = &mut tab.elem[d as usize..];
                         let src = &elem.references[s as usize..final_src_offset];
@@ -2394,7 +2642,8 @@ pub(super) fn run<H: HookSet>(
                         let elem_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
                         // WARN: i'm not sure if this is okay or not
-                        store
+                        modules[*current_module_idx]
+                            .store
                             .elements
                             .get_mut(elem_idx)
                             .unwrap_validated()
@@ -2405,8 +2654,12 @@ pub(super) fn run<H: HookSet>(
                         let table_x_idx = wasm.read_var_u32().unwrap_validated() as usize;
                         let table_y_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
-                        let tab_x_elem_len = store.tables[table_x_idx].elem.len();
-                        let tab_y_elem_len = store.tables[table_y_idx].elem.len();
+                        let tab_x_elem_len = modules[*current_module_idx].store.tables[table_x_idx]
+                            .elem
+                            .len();
+                        let tab_y_elem_len = modules[*current_module_idx].store.tables[table_y_idx]
+                            .elem
+                            .len();
 
                         let n: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into(); // size
                         let s: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into(); // source
@@ -2438,18 +2691,20 @@ pub(super) fn run<H: HookSet>(
                         let src = table_y_idx;
 
                         if table_x_idx == table_y_idx {
-                            store.tables[table_x_idx]
+                            modules[*current_module_idx].store.tables[table_x_idx]
                                 .elem
                                 .copy_within(s as usize..src_res, d as usize); // }
                         } else {
                             use core::cmp::Ordering::*;
                             let (src_table, dst_table) = match dst.cmp(&src) {
                                 Greater => {
-                                    let (left, right) = store.tables.split_at_mut(dst);
+                                    let (left, right) =
+                                        modules[*current_module_idx].store.tables.split_at_mut(dst);
                                     (&left[src], &mut right[0])
                                 }
                                 Less => {
-                                    let (left, right) = store.tables.split_at_mut(src);
+                                    let (left, right) =
+                                        modules[*current_module_idx].store.tables.split_at_mut(src);
                                     (&right[0], &mut left[dst])
                                 }
                                 Equal => unreachable!(),
@@ -2470,7 +2725,11 @@ pub(super) fn run<H: HookSet>(
                     TABLE_GROW => {
                         let table_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
-                        let tab = store.tables.get_mut(table_idx).unwrap_validated();
+                        let tab = modules[*current_module_idx]
+                            .store
+                            .tables
+                            .get_mut(table_idx)
+                            .unwrap_validated();
 
                         let sz = tab.elem.len() as u32;
 
@@ -2497,7 +2756,11 @@ pub(super) fn run<H: HookSet>(
                     TABLE_SIZE => {
                         let table_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
-                        let tab = store.tables.get(table_idx).unwrap_validated();
+                        let tab = modules[*current_module_idx]
+                            .store
+                            .tables
+                            .get(table_idx)
+                            .unwrap_validated();
 
                         let sz = tab.elem.len() as u32;
 
@@ -2508,7 +2771,11 @@ pub(super) fn run<H: HookSet>(
                     TABLE_FILL => {
                         let table_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
-                        let tab = store.tables.get_mut(table_idx).unwrap_validated();
+                        let tab = modules[*current_module_idx]
+                            .store
+                            .tables
+                            .get_mut(table_idx)
+                            .unwrap_validated();
                         let ty = tab.ty.et;
 
                         let n: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into(); // len

--- a/src/execution/lut.rs
+++ b/src/execution/lut.rs
@@ -38,8 +38,8 @@ impl Lut {
                 })
                 .collect::<Option<Vec<_>>>()?;
 
-            // TODO: what do we want to do if there is a missing import/export pair? Currently we fail the entire
-            // operation. Should it be a RuntimeError if said missing pair is called?
+            // If there is a missing import/export pair,  we fail the entire
+            // operation. Better safe than sorry...
 
             function_lut.push(module_lut);
         }

--- a/src/execution/lut.rs
+++ b/src/execution/lut.rs
@@ -1,0 +1,113 @@
+use crate::{core::reader::types::export::ExportDesc, execution::execution_info::ExecutionInfo};
+use alloc::{collections::btree_map::BTreeMap, string::String, vec::Vec};
+
+pub struct Lut {
+    /// function_lut\[local_module_idx\]\[function_local_idx\] = (foreign_module_idx, function_foreign_idx)
+    ///
+    /// - Module A imports a function "foo". Inside module A, the function has the index "function_local_idx". Module A
+    ///   is assigned the index "local_module_idx".
+    /// - Module B exports a function "foo". Inside module B, the function has the index "function_foreign_idx". Module
+    ///   B is assigned the index "foreign_module_idx".
+    function_lut: Vec<Vec<(usize, usize)>>,
+}
+
+impl Lut {
+    /// Create a new linker lookup-table.
+    ///
+    /// # Arguments
+    /// - `modules`: The modules to link together.
+    /// - `module_map`: A map from module name to module index within the `modules` array.
+    ///
+    /// # Returns
+    /// A new linker lookup-table. Can return `None` if there are import directives that cannot be resolved.
+    pub fn new(modules: &[ExecutionInfo], module_map: &BTreeMap<String, usize>) -> Option<Self> {
+        let mut function_lut = Vec::new();
+        for module in modules {
+            let module_lut = module
+                .store
+                .funcs
+                .iter()
+                .filter_map(|f| f.try_into_imported())
+                .map(|import| {
+                    Self::manual_lookup(
+                        modules,
+                        module_map,
+                        &import.module_name,
+                        &import.function_name,
+                    )
+                })
+                .collect::<Option<Vec<_>>>()?;
+
+            // TODO: what do we want to do if there is a missing import/export pair? Currently we fail the entire
+            // operation. Should it be a RuntimeError if said missing pair is called?
+
+            function_lut.push(module_lut);
+        }
+
+        Some(Self { function_lut })
+    }
+
+    /// Lookup a function by its module and function index.
+    ///
+    /// # Arguments
+    /// - `module_idx`: The index of the module within the `modules` array passed in [Lut::new].
+    /// - `function_idx`: The index of the function within the module. This index is considered in-bounds only if it is
+    ///   an index of an imported function.
+    ///
+    /// # Returns
+    /// - `None`, if the indicies are out of bound
+    /// - `Some(export_module_idx, export_function_idx)`, where the new indicies are the indicies of the module which
+    ///   contains the implementation of the imported function, and the implementation has the returned index within.
+    pub fn lookup(&self, module_idx: usize, function_idx: usize) -> Option<(usize, usize)> {
+        self.function_lut
+            .get(module_idx)?
+            .get(function_idx)
+            .copied()
+    }
+
+    /// Manually lookup a function by its module and function name.
+    ///
+    /// This function is used to resolve import directives before the [Lut] is created, and can be used to resolve
+    /// imports even after the [Lut] is created at the cost of speed.
+    ///
+    /// # Arguments
+    /// - `modules`: The modules to link together.
+    /// - `module_map`: A map from module name to module index within the `modules` array.
+    /// - `module_name`: The name of the module which imports the function.
+    /// - `function_name`: The name of the function to import.
+    ///
+    /// # Returns
+    /// - `None`, if the module or function is not found.
+    /// - `Some(export_module_idx, export_function_idx)`, where the new indicies are the indicies of the module which
+    ///    contains the implementation of the imported function, and the implementation has the returned index within.
+    ///    Note that this function returns the first matching function, if there are multiple functions with the same
+    ///    name.
+    pub fn manual_lookup(
+        modules: &[ExecutionInfo],
+        module_map: &BTreeMap<String, usize>,
+        module_name: &str,
+        function_name: &str,
+    ) -> Option<(usize, usize)> {
+        let module_idx = module_map.get(module_name)?;
+        let module = &modules[*module_idx];
+
+        module
+            .store
+            .exports
+            .iter()
+            .filter_map(|export| {
+                if export.name == function_name {
+                    Some(&export.desc)
+                } else {
+                    None
+                }
+            })
+            .find_map(|desc| {
+                if let ExportDesc::FuncIdx(func_idx) = desc {
+                    Some((*module_idx, *func_idx))
+                } else {
+                    None
+                }
+            })
+    }
+}

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,20 +1,22 @@
-use alloc::string::ToString;
+use alloc::collections::btree_map::BTreeMap;
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
 use const_interpreter_loop::{run_const, run_const_span};
+use execution_info::ExecutionInfo;
 use function_ref::FunctionRef;
 use interpreter_loop::run;
 use locals::Locals;
+use lut::Lut;
 use store::{DataInst, ElemInst, ImportedFuncInst, LocalFuncInst, TableInst};
 use value::{ExternAddr, FuncAddr, Ref};
 use value_stack::Stack;
 
 use crate::core::error::StoreInstantiationError;
 use crate::core::reader::types::element::{ElemItems, ElemMode};
-use crate::core::reader::types::export::{Export, ExportDesc};
+use crate::core::reader::types::export::ExportDesc;
 use crate::core::reader::types::import::ImportDesc;
-use crate::core::reader::types::FuncType;
 use crate::core::reader::WasmReader;
 use crate::execution::assert_validated::UnwrapValidatedExt;
 use crate::execution::hooks::{EmptyHookSet, HookSet};
@@ -27,6 +29,7 @@ use crate::{RefType, Result as CustomResult, RuntimeError, ValType, ValidationIn
 // TODO
 pub(crate) mod assert_validated;
 pub mod const_interpreter_loop;
+pub(crate) mod execution_info;
 pub mod function_ref;
 pub mod hooks;
 mod interpreter_loop;
@@ -43,10 +46,9 @@ pub struct RuntimeInstance<'b, H = EmptyHookSet>
 where
     H: HookSet,
 {
-    pub wasm_bytecode: &'b [u8],
-    types: Vec<FuncType>,
-    exports: Vec<Export>,
-    pub store: Store,
+    pub modules: Vec<ExecutionInfo<'b>>,
+    module_map: BTreeMap<String, usize>,
+    lut: Option<Lut>,
     pub hook_set: H,
 }
 
@@ -74,16 +76,15 @@ where
     ) -> CustomResult<Self> {
         trace!("Starting instantiation of bytecode");
 
-        let store = Self::init_store(validation_info)?;
-
         let mut instance = RuntimeInstance {
-            wasm_bytecode: validation_info.wasm,
-            types: validation_info.types.clone(),
-            exports: validation_info.exports.clone(),
-            store,
+            modules: Vec::new(),
+            module_map: BTreeMap::new(),
+            lut: None,
             hook_set,
         };
+        instance.add_module(module_name, validation_info)?;
 
+        // TODO: how do we handle the start function, if we don't have a LUT yet?
         if let Some(start) = validation_info.start {
             // "start" is not always exported, so we need create a non-API exposed function reference.
             // Note: function name is not important here, as it is not used in the verification process.
@@ -121,8 +122,13 @@ where
         module_idx: usize,
         function_idx: usize,
     ) -> Result<FunctionRef, RuntimeError> {
-        // TODO: Module resolution
-        let function_name = self
+        let module = self
+            .modules
+            .get(module_idx)
+            .ok_or(RuntimeError::ModuleNotFound)?;
+
+        let function_name = module
+            .store
             .exports
             .iter()
             .find(|export| match &export.desc {
@@ -133,8 +139,7 @@ where
             .ok_or(RuntimeError::FunctionNotFound)?;
 
         Ok(FunctionRef {
-            // TODO: get the module name from the module index
-            module_name: DEFAULT_MODULE.to_string(),
+            module_name: module.name.clone(),
             function_name,
             module_index: module_idx,
             function_index: function_idx,
@@ -142,14 +147,26 @@ where
         })
     }
 
-    // TODO: remove this annotation when implementing the function
-    #[allow(clippy::result_unit_err)]
     pub fn add_module(
         &mut self,
-        _module_name: &str,
-        _validation_info: &'_ ValidationInfo<'b>,
-    ) -> Result<(), ()> {
-        todo!("Implement module linking");
+        module_name: &str,
+        validation_info: &'_ ValidationInfo<'b>,
+    ) -> CustomResult<()> {
+        let store = Self::init_store(validation_info)?;
+        let exec_info = ExecutionInfo::new(
+            module_name,
+            validation_info.wasm,
+            validation_info.types.clone(),
+            store,
+        );
+
+        self.module_map
+            .insert(module_name.to_string(), self.modules.len());
+        self.modules.push(exec_info);
+
+        self.lut = Lut::new(&self.modules, &self.module_map);
+
+        Ok(())
     }
 
     pub fn invoke<Param: InteropValueList, Returns: InteropValueList>(
@@ -158,17 +175,22 @@ where
         params: Param,
     ) -> Result<Returns, RuntimeError> {
         // First, verify that the function reference is valid
-        let (_module_idx, func_idx) = self.verify_function_ref(function_ref)?;
+        let (module_idx, func_idx) = self.verify_function_ref(function_ref)?;
 
         // -=-= Verification =-=-
-        let func_inst = self
+        trace!("{:?}", self.modules[module_idx].store.funcs);
+
+        let func_inst = self.modules[module_idx]
             .store
             .funcs
             .get(func_idx)
-            .expect("valid FuncIdx")
+            .ok_or(RuntimeError::FunctionNotFound)?
             .try_into_local()
-            .expect("to invoke local function");
-        let func_ty = self.types.get(func_inst.ty).unwrap_validated();
+            .ok_or(RuntimeError::FunctionNotFound)?;
+        let func_ty = self.modules[module_idx]
+            .fn_types
+            .get(func_inst.ty)
+            .unwrap_validated();
 
         // Check correct function parameters and return types
         if func_ty.params.valtypes != Param::TYS {
@@ -187,13 +209,21 @@ where
 
         // setting `usize::MAX` as return address for the outermost function ensures that we
         // observably fail upon errornoeusly continuing execution after that function returns.
-        stack.push_stackframe(func_idx, func_ty, locals, usize::MAX, usize::MAX);
+        stack.push_stackframe(
+            module_idx,
+            func_idx,
+            func_ty,
+            locals,
+            usize::MAX,
+            usize::MAX,
+        );
 
+        let mut current_module_idx = module_idx;
         // Run the interpreter
         run(
-            self.wasm_bytecode,
-            &self.types,
-            &mut self.store,
+            &mut self.modules,
+            &mut current_module_idx,
+            self.lut.as_ref().ok_or(RuntimeError::UnmetImport)?,
             &mut stack,
             EmptyHookSet,
         )?;
@@ -219,17 +249,20 @@ where
         ret_types: &[ValType],
     ) -> Result<Vec<Value>, RuntimeError> {
         // First, verify that the function reference is valid
-        let (_module_idx, func_idx) = self.verify_function_ref(function_ref)?;
+        let (module_idx, func_idx) = self.verify_function_ref(function_ref)?;
 
         // -=-= Verification =-=-
-        let func_inst = self
+        let func_inst = self.modules[module_idx]
             .store
             .funcs
             .get(func_idx)
-            .expect("valid FuncIdx")
+            .ok_or(RuntimeError::FunctionNotFound)?
             .try_into_local()
-            .expect("to invoke local function");
-        let func_ty = self.types.get(func_inst.ty).unwrap_validated();
+            .ok_or(RuntimeError::FunctionNotFound)?;
+        let func_ty = self.modules[module_idx]
+            .fn_types
+            .get(func_inst.ty)
+            .unwrap_validated();
 
         // Verify that the given parameters match the function parameters
         let param_types = params.iter().map(|v| v.to_ty()).collect::<Vec<_>>();
@@ -246,25 +279,29 @@ where
         // Prepare a new stack with the locals for the entry function
         let mut stack = Stack::new();
         let locals = Locals::new(params.into_iter(), func_inst.locals.iter().cloned());
-        stack.push_stackframe(func_idx, func_ty, locals, 0, 0);
+        stack.push_stackframe(module_idx, func_idx, func_ty, locals, 0, 0);
 
+        let mut currrent_module_idx = module_idx;
         // Run the interpreter
         run(
-            self.wasm_bytecode,
-            &self.types,
-            &mut self.store,
+            &mut self.modules,
+            &mut currrent_module_idx,
+            self.lut.as_ref().ok_or(RuntimeError::UnmetImport)?,
             &mut stack,
             EmptyHookSet,
         )?;
 
-        let func_inst = self
+        let func_inst = self.modules[module_idx]
             .store
             .funcs
             .get(func_idx)
-            .expect("valid FuncIdx")
+            .ok_or(RuntimeError::FunctionNotFound)?
             .try_into_local()
-            .expect("to invoke local function");
-        let func_ty = self.types.get(func_inst.ty).unwrap_validated();
+            .ok_or(RuntimeError::FunctionNotFound)?;
+        let func_ty = self.modules[module_idx]
+            .fn_types
+            .get(func_inst.ty)
+            .unwrap_validated();
 
         // Pop return values from stack
         let return_values = func_ty
@@ -281,13 +318,30 @@ where
         Ok(ret)
     }
 
-    // TODO: replace this with the lookup table when implmenting the linker
+    /// Get the indicies of a module and function by their names.
+    ///
+    /// # Arguments
+    /// - `module_name`: The module in which to find the function.
+    /// - `function_name`: The name of the function to find inside the module. The function must be a local function and
+    ///   not an import.
+    ///
+    /// # Returns
+    /// - `Ok((module_idx, func_idx))`, where `module_idx` is the internal index of the module inside the
+    ///   [RuntimeInstance], and `func_idx` is the internal index of the function inside the module.
+    /// - `Err(RuntimeError::ModuleNotFound)`, if the module is not found.
+    /// - `Err(RuntimeError::FunctionNotFound`, if the function is not found within the module.
     fn get_indicies(
         &self,
-        _module_name: &str,
+        module_name: &str,
         function_name: &str,
     ) -> Result<(usize, usize), RuntimeError> {
-        let func_idx = self
+        let module_idx = *self
+            .module_map
+            .get(module_name)
+            .ok_or(RuntimeError::ModuleNotFound)?;
+
+        let func_idx = self.modules[module_idx]
+            .store
             .exports
             .iter()
             .find_map(|export| {
@@ -302,9 +356,25 @@ where
             })
             .ok_or(RuntimeError::FunctionNotFound)?;
 
-        Ok((0, func_idx))
+        Ok((module_idx, func_idx))
     }
 
+    /// Verify that the function reference is still valid. A function reference may be invalid if it created from
+    /// another [RuntimeInstance] or the modules inside the instance have been changed in a way that the indicies inside
+    /// the [FunctionRef] would be invalid.
+    ///
+    /// Note: this function ensures that making an unchecked indexation will not cause a panic.
+    ///
+    /// # Returns
+    /// - `Ok((function_ref.module_idx, function_ref.func_idx))`
+    /// - `Err(RuntimeError::FunctionNotFound)`, or `Err(RuntimeError::ModuleNotFound)` if the function is not valid.
+    ///
+    /// # Implementation details
+    /// For an exported function (i.e. created by the same [RuntimeInstance]), the names are re-resolved using
+    /// [RuntimeInstance::get_indicies], and the indicies are compared with the indicies in the [FunctionRef].
+    ///
+    /// For a [FunctionRef] with the [export](FunctionRef::exported) flag set to `false`, the indicies are checked to be
+    /// in-bounds, and that the module name matches the module name in the [FunctionRef]. The function name is ignored.
     fn verify_function_ref(
         &self,
         function_ref: &FunctionRef,
@@ -313,8 +383,10 @@ where
             let (module_idx, func_idx) =
                 self.get_indicies(&function_ref.module_name, &function_ref.function_name)?;
 
-            if module_idx != function_ref.module_index || func_idx != function_ref.function_index {
-                // TODO: should we return a different error here?
+            if module_idx != function_ref.module_index {
+                return Err(RuntimeError::FunctionNotFound);
+            }
+            if func_idx != function_ref.function_index {
                 return Err(RuntimeError::FunctionNotFound);
             }
 
@@ -322,11 +394,19 @@ where
         } else {
             let (module_idx, func_idx) = (function_ref.module_index, function_ref.function_index);
 
-            // TODO: verify module named - index mapping.
+            let module = self
+                .modules
+                .get(module_idx)
+                .ok_or(RuntimeError::ModuleNotFound)?;
+
+            if module.name != function_ref.module_name {
+                return Err(RuntimeError::ModuleNotFound);
+            }
 
             // Sanity check that the function index is at least in the bounds of the store, though this doesn't mean
             // that it's a valid function.
-            self.store
+            module
+                .store
                 .funcs
                 .get(func_idx)
                 .ok_or(RuntimeError::FunctionNotFound)?;
@@ -552,6 +632,7 @@ where
             })
             .collect();
 
+        let exports = validation_info.exports.clone();
         Ok(Store {
             funcs: function_instances,
             mems: memory_instances,
@@ -560,6 +641,7 @@ where
             tables,
             elements,
             passive_elem_indexes,
+            exports,
         })
     }
 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -383,8 +383,9 @@ where
             let (module_idx, func_idx) =
                 self.get_indicies(&function_ref.module_name, &function_ref.function_name)?;
 
+            // TODO: figure out errors :)
             if module_idx != function_ref.module_index {
-                return Err(RuntimeError::FunctionNotFound);
+                return Err(RuntimeError::ModuleNotFound);
             }
             if func_idx != function_ref.function_index {
                 return Err(RuntimeError::FunctionNotFound);

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -5,6 +5,7 @@ use core::iter;
 
 use crate::core::indices::TypeIdx;
 use crate::core::reader::span::Span;
+use crate::core::reader::types::export::Export;
 use crate::core::reader::types::global::Global;
 use crate::core::reader::types::{MemType, TableType, ValType};
 use crate::core::sidetable::Sidetable;
@@ -24,6 +25,7 @@ pub struct Store {
     pub tables: Vec<TableInst>,
     pub elements: Vec<ElemInst>,
     pub passive_elem_indexes: Vec<usize>,
+    pub exports: Vec<Export>,
 }
 
 #[derive(Debug)]

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::iter;
@@ -25,6 +26,50 @@ pub struct Store {
     pub passive_elem_indexes: Vec<usize>,
 }
 
+#[derive(Debug)]
+pub enum FuncInst {
+    Local(LocalFuncInst),
+    Imported(ImportedFuncInst),
+}
+
+#[derive(Debug)]
+pub struct LocalFuncInst {
+    pub ty: TypeIdx,
+    pub locals: Vec<ValType>,
+    pub code_expr: Span,
+    pub sidetable: Sidetable,
+}
+
+#[derive(Debug)]
+pub struct ImportedFuncInst {
+    pub ty: TypeIdx,
+    pub module_name: String,
+    pub function_name: String,
+}
+
+impl FuncInst {
+    pub fn ty(&self) -> TypeIdx {
+        match self {
+            FuncInst::Local(f) => f.ty,
+            FuncInst::Imported(f) => f.ty,
+        }
+    }
+
+    pub fn try_into_local(&self) -> Option<&LocalFuncInst> {
+        match self {
+            FuncInst::Local(f) => Some(f),
+            FuncInst::Imported(_) => None,
+        }
+    }
+
+    pub fn try_into_imported(&self) -> Option<&ImportedFuncInst> {
+        match self {
+            FuncInst::Local(_) => None,
+            FuncInst::Imported(f) => Some(f),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 /// <https://webassembly.github.io/spec/core/exec/runtime.html#element-instances>
 pub struct ElemInst {
@@ -39,13 +84,6 @@ impl ElemInst {
     pub fn is_empty(&self) -> bool {
         self.references.is_empty()
     }
-}
-
-pub struct FuncInst {
-    pub ty: TypeIdx,
-    pub locals: Vec<ValType>,
-    pub code_expr: Span,
-    pub sidetable: Sidetable,
 }
 
 #[derive(Debug)]

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -154,9 +154,10 @@ impl Stack {
         self.frames.last_mut().unwrap_validated()
     }
 
-    /// Pop a [`CallFrame`] from the call stack, returning the return address and the return stp
-    pub fn pop_stackframe(&mut self) -> (usize, usize) {
+    /// Pop a [`CallFrame`] from the call stack, returning the module id, return address, and the return stp
+    pub fn pop_stackframe(&mut self) -> (usize, usize, usize) {
         let CallFrame {
+            module_idx,
             return_addr,
             value_stack_base_idx,
             return_value_count,
@@ -173,7 +174,7 @@ impl Stack {
             "after a function call finished, the stack must have exactly as many values as it had before calling the function plus the number of function return values"
         );
 
-        (return_addr, return_stp)
+        (module_idx, return_addr, return_stp)
     }
 
     /// Push a stackframe to the call stack
@@ -181,6 +182,7 @@ impl Stack {
     /// Takes the current [`Self::values`]'s length as [`CallFrame::value_stack_base_idx`].
     pub fn push_stackframe(
         &mut self,
+        module_idx: usize,
         func_idx: FuncIdx,
         func_ty: &FuncType,
         locals: Locals,
@@ -188,6 +190,7 @@ impl Stack {
         return_stp: usize,
     ) {
         self.frames.push(CallFrame {
+            module_idx,
             func_idx,
             locals,
             return_addr,
@@ -220,6 +223,9 @@ impl Stack {
 
 /// The [WASM spec](https://webassembly.github.io/spec/core/exec/runtime.html#stack) calls this `Activations`, however it refers to the call frames of functions.
 pub(crate) struct CallFrame {
+    /// Index to the module idx the function originates in.
+    pub module_idx: usize,
+
     /// Index to the function of this [`CallFrame`]
     pub func_idx: FuncIdx,
 

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -23,6 +23,7 @@ pub fn validate_code_section(
     section_header: SectionHeader,
     fn_types: &[FuncType],
     type_idx_of_fn: &[usize],
+    num_imported_funcs: usize,
     globals: &[Global],
     memories: &[MemType],
     data_count: &Option<u32>,
@@ -34,7 +35,10 @@ pub fn validate_code_section(
 
     // TODO replace with single sidetable per module
     let code_block_spans_sidetables = wasm.read_vec_enumerated(|wasm, idx| {
-        let ty_idx = type_idx_of_fn[idx];
+        // We need to offset the index by the number of functions that were
+        // imported. Imported functions always live at the start of the index
+        // space.
+        let ty_idx = type_idx_of_fn[idx + num_imported_funcs];
         let func_ty = fn_types[ty_idx].clone();
 
         let func_size = wasm.read_var_u32()?;
@@ -335,7 +339,7 @@ fn read_instructions(
                         // the last end instruction will handle the return to callee during execution
                         stps_to_backpatch.iter().for_each(|i| {
                             sidetable[*i].delta_pc =
-                                (wasm.pc as isize) - sidetable[*i].delta_pc - 1; // minus 1 is important!
+                                (wasm.pc as isize) - sidetable[*i].delta_pc - 1; // minus 1 is important! TODO: Why?
                             sidetable[*i].delta_stp = (stp_here as isize) - sidetable[*i].delta_stp;
                         });
                     }

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -8,7 +8,7 @@ use crate::core::reader::types::data::DataSegment;
 use crate::core::reader::types::element::ElemType;
 use crate::core::reader::types::export::Export;
 use crate::core::reader::types::global::Global;
-use crate::core::reader::types::import::Import;
+use crate::core::reader::types::import::{Import, ImportDesc};
 use crate::core::reader::types::{FuncType, MemType, TableType};
 use crate::core::reader::{WasmReadable, WasmReader};
 use crate::core::sidetable::Sidetable;
@@ -80,10 +80,31 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
-    let functions = handle_section(&mut wasm, &mut header, SectionTy::Function, |wasm, _| {
-        wasm.read_vec(|wasm| wasm.read_var_u32().map(|u| u as usize))
-    })?
-    .unwrap_or_default();
+    // The `Function` section only covers module-level (or "local") functions.
+    // Imported functions have their types known in the `import` section. Both
+    // local and imported functions share the same index space.
+    //
+    // Imported functions are given priority and have the first indicies, and
+    // only after that do the local functions get assigned their indices.
+    let local_functions =
+        handle_section(&mut wasm, &mut header, SectionTy::Function, |wasm, _| {
+            wasm.read_vec(|wasm| wasm.read_var_u32().map(|u| u as usize))
+        })?
+        .unwrap_or_default();
+
+    let imported_functions = imports
+        .iter()
+        .filter_map(|import| match &import.desc {
+            ImportDesc::Func(type_idx) => Some(*type_idx),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let all_functions = imported_functions
+        .iter()
+        .chain(local_functions.iter())
+        .cloned()
+        .collect::<Vec<TypeIdx>>();
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
@@ -127,7 +148,12 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
     let mut referenced_functions = btree_set::BTreeSet::new();
     let elements: Vec<ElemType> =
         handle_section(&mut wasm, &mut header, SectionTy::Element, |wasm, _| {
-            ElemType::read_from_wasm(wasm, &functions, &mut referenced_functions, tables.len())
+            ElemType::read_from_wasm(
+                wasm,
+                &all_functions,
+                &mut referenced_functions,
+                tables.len(),
+            )
         })?
         .unwrap_or_default();
 
@@ -153,7 +179,8 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
                 wasm,
                 h,
                 &types,
-                &functions,
+                &all_functions,
+                imported_functions.len(),
                 &globals,
                 &memories,
                 &data_count,
@@ -166,7 +193,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
 
     assert_eq!(
         func_blocks_sidetables.len(),
-        functions.len(),
+        local_functions.len(),
         "these should be equal"
     ); // TODO check if this is in the spec
 
@@ -194,7 +221,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
         wasm: wasm.into_inner(),
         types,
         imports,
-        functions,
+        functions: local_functions,
         tables,
         memories,
         globals,

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -92,18 +92,14 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
         })?
         .unwrap_or_default();
 
-    let imported_functions = imports
-        .iter()
-        .filter_map(|import| match &import.desc {
-            ImportDesc::Func(type_idx) => Some(*type_idx),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
+    let imported_functions = imports.iter().filter_map(|import| match &import.desc {
+        ImportDesc::Func(type_idx) => Some(*type_idx),
+        _ => None,
+    });
 
     let all_functions = imported_functions
-        .iter()
-        .chain(local_functions.iter())
-        .cloned()
+        .clone()
+        .chain(local_functions.iter().cloned())
         .collect::<Vec<TypeIdx>>();
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
@@ -180,7 +176,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
                 h,
                 &types,
                 &all_functions,
-                imported_functions.len(),
+                imported_functions.count(),
                 &globals,
                 &memories,
                 &data_count,

--- a/src/validation/validation_stack.rs
+++ b/src/validation/validation_stack.rs
@@ -281,6 +281,8 @@ impl ValidationStack {
         Ok(())
     }
 
+    // TODO: rename/refactor this function to make it more clear that it ALSO
+    // checks the stack for valid return types.
     pub fn assert_pop_ctrl(&mut self) -> Result<(LabelInfo, FuncType)> {
         let return_types = &self
             .ctrl_stack

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -1,0 +1,86 @@
+use wasm::{validate, RuntimeError, RuntimeInstance, DEFAULT_MODULE};
+
+const UNMET_IMPORTS: &str = r#"
+(module
+    (import "env" "dummy1" (func (param i32)))
+    (import "env" "dummy2" (func (param i32)))
+    (func (export "get_three") (param) (result i32)
+        i32.const 1
+        i32.const 2
+        i32.add
+    )
+)"#;
+
+const SIMPLE_IMPORT_BASE: &str = r#"
+(module
+    (import "env" "get_one" (func $get_one (param) (result i32)))
+    (func (export "get_three") (param) (result i32)
+        call $get_one
+        i32.const 2
+        i32.add
+    )
+)"#;
+
+const SIMPLE_IMPORT_ADDON: &str = r#"
+(module
+    (func (export "get_one") (param) (result i32)
+        i32.const 1
+    )
+)"#;
+
+#[test_log::test]
+pub fn unmet_imports() {
+    let wasm_bytes = wat::parse_str(UNMET_IMPORTS).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+
+    let get_three = instance
+        .get_function_by_name(DEFAULT_MODULE, "get_three")
+        .unwrap();
+
+    assert_eq!(
+        RuntimeError::UnmetImport,
+        instance
+            .invoke::<(), i32>(&get_three, ())
+            .expect_err("Expected invoke to fail due to unmet imports")
+    );
+}
+
+#[test_log::test]
+pub fn compile_simple_import() {
+    let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance =
+        RuntimeInstance::new_named("base", &validation_info).expect("instantiation failed");
+
+    let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    instance
+        .add_module("addon", &validation_info)
+        .expect("Successful instantiation");
+
+    // assert_eq!((), instance.invoke_named("print_three", ()).unwrap());
+    // Function 0 should be the imported function
+    // assert_eq!((), instance.invoke_func(1, ()).unwrap());
+}
+
+#[test_log::test]
+pub fn run_simple_import() {
+    let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance =
+        RuntimeInstance::new_named("base", &validation_info).expect("instantiation failed");
+
+    let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    instance
+        .add_module("env", &validation_info)
+        .expect("Successful instantiation");
+
+    let get_three = instance.get_function_by_name("base", "get_three").unwrap();
+    assert_eq!(3, instance.invoke(&get_three, ()).unwrap());
+
+    // Function 0 should be the imported function
+    let get_three = instance.get_function_by_index(0, 1).unwrap();
+    assert_eq!(3, instance.invoke(&get_three, ()).unwrap());
+}

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -28,6 +28,12 @@ const SIMPLE_IMPORT_ADDON: &str = r#"
     )
 )"#;
 
+const CYCLICAL_IMPORT: &str = r#"
+(module
+    (import "base" "get_three" (func $get_three (param) (result i32)))
+    (export "get_three" (func $get_three))
+)"#;
+
 const CALL_INDIRECT_BASE: &str = r#"
 (module
     (import "env" "get_one" (func $get_one (param) (result i32)))
@@ -114,7 +120,7 @@ pub fn run_call_indirect() {
     let mut instance =
         RuntimeInstance::new_named("base", &validation_info).expect("instantiation failed");
 
-    let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
+    let wasm_bytes = wat::parse_str(CYCLICAL_IMPORT).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     instance
         .add_module("env", &validation_info)
@@ -122,4 +128,23 @@ pub fn run_call_indirect() {
 
     let run = instance.get_function_by_name("base", "run").unwrap();
     assert_eq!((1, 3), instance.invoke(&run, ()).unwrap());
+}
+
+#[test_log::test]
+pub fn run_cyclical() {
+    let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance =
+        RuntimeInstance::new_named("base", &validation_info).expect("instantiation failed");
+
+    let wasm_bytes = wat::parse_str(CYCLICAL_IMPORT).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    instance
+        .add_module("env", &validation_info)
+        .expect("Successful instantiation");
+
+    let run = instance.get_function_by_name("base", "get_three").unwrap();
+    // Unmet import since we can't have cyclical imports
+    // Currently, this passes since we don't allow chained imports.
+    assert!(instance.invoke::<(), i32>(&run, ()).unwrap_err() == wasm::RuntimeError::UnmetImport);
 }

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -28,6 +28,28 @@ const SIMPLE_IMPORT_ADDON: &str = r#"
     )
 )"#;
 
+const CALL_INDIRECT_BASE: &str = r#"
+(module
+    (import "env" "get_one" (func $get_one (param) (result i32)))
+    (func $get_three (param) (result i32)
+        call $get_one
+        i32.const 2
+        i32.add
+    )
+
+    (table 2 funcref)
+    (elem (i32.const 0) $get_one $get_three)
+    (type $void_to_i32 (func (param) (result i32)))
+
+    (func (export "run") (result i32 i32)
+        i32.const 0
+        call_indirect (type $void_to_i32)
+        
+        i32.const 1
+        call_indirect (type $void_to_i32)
+    )
+)"#;
+
 #[test_log::test]
 pub fn unmet_imports() {
     let wasm_bytes = wat::parse_str(UNMET_IMPORTS).unwrap();
@@ -83,4 +105,21 @@ pub fn run_simple_import() {
     // Function 0 should be the imported function
     let get_three = instance.get_function_by_index(0, 1).unwrap();
     assert_eq!(3, instance.invoke(&get_three, ()).unwrap());
+}
+
+#[test_log::test]
+pub fn run_call_indirect() {
+    let wasm_bytes = wat::parse_str(CALL_INDIRECT_BASE).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    let mut instance =
+        RuntimeInstance::new_named("base", &validation_info).expect("instantiation failed");
+
+    let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
+    let validation_info = validate(&wasm_bytes).expect("validation failed");
+    instance
+        .add_module("env", &validation_info)
+        .expect("Successful instantiation");
+
+    let run = instance.get_function_by_name("base", "run").unwrap();
+    assert_eq!((1, 3), instance.invoke(&run, ()).unwrap());
 }

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */
-use wasm::{validate, Error, RuntimeInstance};
+use wasm::{validate, Error, RuntimeInstance, DEFAULT_MODULE};
 
 #[test_log::test]
 fn memory_basic() {
@@ -79,7 +79,9 @@ fn memory_size_must_be_at_most_4gib() {
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/memory_copy.rs
+++ b/tests/memory_copy.rs
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */
-use wasm::{validate, RuntimeError, RuntimeInstance};
+use wasm::{validate, RuntimeError, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/memory_fill.rs
+++ b/tests/memory_fill.rs
@@ -17,11 +17,13 @@
 
 // use core::slice::SlicePattern;
 
-use wasm::{validate, RuntimeInstance};
+use wasm::{validate, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 
@@ -41,7 +43,7 @@ fn memory_fill() {
 
     let fill = get_func!(i, "fill");
     i.invoke::<(), ()>(fill, ()).unwrap();
-    let mem = &i.store.mems[0];
+    let mem = &i.modules[0].store.mems[0];
     assert!(mem.data.as_slice()[0..105]
         .eq_ignore_ascii_case(&vec![vec![217u8; 100], vec![0u8; 5]].concat()))
 }

--- a/tests/memory_grow.rs
+++ b/tests/memory_grow.rs
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */
-use wasm::{validate, RuntimeError, RuntimeInstance};
+use wasm::{validate, RuntimeError, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/memory_init.rs
+++ b/tests/memory_init.rs
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */
-use wasm::Error as GeneralError;
 use wasm::{validate, RuntimeError, RuntimeInstance};
+use wasm::{Error as GeneralError, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/memory_redundancy.rs
+++ b/tests/memory_redundancy.rs
@@ -15,11 +15,13 @@
 # limitations under the License.
 */
 use hexf::hexf32;
-use wasm::{validate, RuntimeInstance};
+use wasm::{validate, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/memory_size.rs
+++ b/tests/memory_size.rs
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */
-use wasm::{validate, RuntimeInstance};
+use wasm::{validate, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/memory_trap.rs
+++ b/tests/memory_trap.rs
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */
-use wasm::{validate, RuntimeError, RuntimeInstance};
+use wasm::{validate, RuntimeError, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -16,11 +16,13 @@
 */
 use wasm::value::{FuncRefForInteropValue, Ref};
 use wasm::Error as GeneralError;
-use wasm::{validate, RuntimeInstance};
+use wasm::{validate, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 
@@ -119,7 +121,7 @@ fn table_elem_test() {
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
     let instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
-    let table = &instance.store.tables[0];
+    let table = &instance.modules[0].store.tables[0];
     assert!(table.len() == 2);
     let wanted: [usize; 2] = [0, 2];
     table

--- a/tests/table_fill.rs
+++ b/tests/table_fill.rs
@@ -15,11 +15,13 @@
 # limitations under the License.
 */
 use wasm::value::{FuncAddr, FuncRefForInteropValue, Ref};
-use wasm::{validate, RuntimeError, RuntimeInstance};
+use wasm::{validate, RuntimeError, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/table_get.rs
+++ b/tests/table_get.rs
@@ -18,12 +18,14 @@
 use wasm::{
     validate,
     value::{FuncAddr, FuncRefForInteropValue, Ref},
-    RuntimeError, RuntimeInstance,
+    RuntimeError, RuntimeInstance, DEFAULT_MODULE,
 };
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/table_grow.rs
+++ b/tests/table_grow.rs
@@ -15,11 +15,13 @@
 # limitations under the License.
 */
 use wasm::value::{FuncAddr, FuncRefForInteropValue, Ref};
-use wasm::{validate, RuntimeError, RuntimeInstance};
+use wasm::{validate, RuntimeError, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 

--- a/tests/table_init.rs
+++ b/tests/table_init.rs
@@ -15,11 +15,13 @@
 # limitations under the License.
 */
 
-use wasm::{validate, Error, RuntimeError, RuntimeInstance};
+use wasm::{validate, Error, RuntimeError, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 
@@ -287,7 +289,7 @@ fn table_init_4_test() {
 
     i.invoke::<(), ()>(test, ()).unwrap();
 
-    println!("{:#?}", i.store.tables[1]);
+    println!("{:#?}", i.modules[0].store.tables[1]);
 
     assert!(i.invoke::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement);
     assert!(i.invoke::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement);

--- a/tests/table_size.rs
+++ b/tests/table_size.rs
@@ -15,11 +15,13 @@
 # limitations under the License.
 */
 
-use wasm::{validate, RuntimeInstance};
+use wasm::{validate, RuntimeInstance, DEFAULT_MODULE};
 
 macro_rules! get_func {
     ($instance:ident, $func_name:expr) => {
-        &$instance.get_function_by_name("", $func_name).unwrap()
+        &$instance
+            .get_function_by_name(DEFAULT_MODULE, $func_name)
+            .unwrap()
     };
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a "Lookup table" linker. See #83 first.

Basically, after each time a new module is added we attempt to create a "lookup table". This lookup table translate the imported functions from each module to the exported local function in the already-existing modules.

Resumability is kept by passing all module-specific details (like the wasm binary, the readers, function types, store, etc.) to the interpreter_loop::run function. These details have been compiled into a structure called `ExecutionInfo`.

Also of note, I split the "FunctionInstance" structure into two variants - local and imported, for clarity sake. This comes with the needed modification to the validation process and store-creation process.

### Testing Strategy

This pull request was tested by writing a new test, and tested against the existing tests.

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [ ] Ran `cargo doc`
- [ ] Ran `nix fmt`

### Github Issue

This pull request closes #83 
