### PR TITLE
fix: make pages_deploy_main.yaml to pull submodules

### DIFF
--- a/.github/workflows/pages_deploy_main.yaml
+++ b/.github/workflows/pages_deploy_main.yaml
@@ -39,8 +39,8 @@ jobs:
         with:
           name: dlr-ft
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build .#wasm-interpreter --print-build-logs
-      - run: nix build .#report --print-build-logs
+      - run: nix build .?submodules=1#wasm-interpreter --print-build-logs
+      - run: nix build .?submodules=1#report --print-build-logs
       - name: Deploy to Github Pages
         uses: peaceiris/actions-gh-pages@v4.0.0
         with:


### PR DESCRIPTION
Github pages dceployment fails now. Woops.
Bug introduced in #32 