### PR TITLE
fix: adjust width on report page

### DIFF
--- a/pkgs/report_index.html
+++ b/pkgs/report_index.html
@@ -24,7 +24,7 @@
       @media (orientation: landscape) {
         body {
           flex-flow: row;
-          font-size: calc(min(12.5vw / 5, 25vh));
+          font-size: calc(min(10vw / 5, 25vh));
         }
         a {
           flex-basis: 0;
@@ -35,7 +35,7 @@
         body {
           flex-flow: column;
           align-items: stretch;
-          font-size: calc(min(35vh / 5, 8vw));
+          font-size: calc(min(30vh / 5, 8vw));
         }
       }
     </style>


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a small issue with the displaying of the report landing page

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [ ] Ran `cargo doc`
- [ ] Ran `nix fmt`