### PR TITLE
fix: wasm official testsuite bug hunt

### DIFF
--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -291,8 +291,12 @@ pub(super) fn run<H: HookSet>(
                     .unwrap_validated();
 
                 let actual_type_idx = func_to_call_inst.ty();
+                let actual_ty = modules[*current_module_idx]
+                    .fn_types
+                    .get(actual_type_idx)
+                    .unwrap_validated();
 
-                if given_type_idx != actual_type_idx {
+                if func_ty != actual_ty {
                     return Err(RuntimeError::SignatureMismatch);
                 }
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -231,6 +231,7 @@ where
         // Pop return values from stack
         let return_values = Returns::TYS
             .iter()
+            .rev()
             .map(|ty| stack.pop_value(*ty))
             .collect::<Vec<Value>>();
 
@@ -308,6 +309,7 @@ where
             .returns
             .valtypes
             .iter()
+            .rev()
             .map(|ty| stack.pop_value(*ty))
             .collect::<Vec<Value>>();
 
@@ -390,6 +392,7 @@ where
             .returns
             .valtypes
             .iter()
+            .rev()
             .map(|ty| stack.pop_value(*ty))
             .collect::<Vec<Value>>();
 

--- a/tests/structured_control_flow/block.rs
+++ b/tests/structured_control_flow/block.rs
@@ -380,6 +380,30 @@ fn switch_case() {
     assert_eq!(9, instance.invoke(&switch_case_fn, 7).unwrap());
 }
 
+#[test_log::test]
+fn br_table_label_typecheck1() {
+    let wasm_bytes = wat::parse_str(
+        r#"
+    (module
+        (func $test (param $value i32) (result i32)
+        (block
+            (block (result i32)
+              	unreachable
+                (br_table 1 0 1 (i32.const 0))
+            )
+        )
+    )
+    (export "test" (func $test))
+    )"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        validate(&wasm_bytes).err().unwrap(),
+        wasm::Error::InvalidLabelIdx(0)
+    );
+}
+
 const POLYMORPHIC_SELECT_VALIDATION: &str = r#"
 (module
     (func $polymorphic_select_validation

--- a/tests/structured_control_flow/if.rs
+++ b/tests/structured_control_flow/if.rs
@@ -203,7 +203,10 @@ fn if_without_else_type_check2() {
 )"#,
     )
     .unwrap();
-    assert!(validate(&wasm_bytes).is_err_and(|x| x == wasm::Error::IfWithoutMatchingElse));
+    assert_eq!(
+        validate(&wasm_bytes).err().unwrap(),
+        wasm::Error::IfWithoutMatchingElse
+    );
 }
 
 #[test_log::test]


### PR DESCRIPTION
### Pull Request Overview

so far return type check was fixed.

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `cargo doc`
- [x] Ran `nix fmt`
