### PR TITLE
Add `RwLock` and concurrency enabled `LinearMemory`

### DIFF
--- a/src/core/little_endian.rs
+++ b/src/core/little_endian.rs
@@ -1,0 +1,37 @@
+//! This module contains the definition and implementation of [`LittleEndianBytes`], a trait to
+//! convert values (such as integers or floats) to bytes in little endian byter order
+
+/// This macro implements the [`LittleEndianBytes`] trait for a provided list of types.
+///
+/// # Assumptions
+///
+/// Each type for which this macro is executed must provide a `from_le_bytes` and `to_le_bytes`
+/// function.
+macro_rules! impl_LittleEndianBytes{
+        [$($type:ty),+] => {
+
+            $(impl LittleEndianBytes<{ ::core::mem::size_of::<$type>() }> for $type {
+                fn from_le_bytes(bytes: [u8; ::core::mem::size_of::<$type>()]) -> Self {
+                    Self::from_le_bytes(bytes)
+                }
+
+                fn to_le_bytes(self) -> [u8; ::core::mem::size_of::<$type>()] {
+                    self.to_le_bytes()
+                }
+            })+
+        }
+    }
+
+/// Convert from and to the little endian byte representation of a value
+///
+/// `N` denotes the number of bytes required for the little endian representation
+pub trait LittleEndianBytes<const N: usize> {
+    /// Convert from a byte array to Self
+    fn from_le_bytes(bytes: [u8; N]) -> Self;
+
+    /// Convert from self to a byte array
+    fn to_le_bytes(self) -> [u8; N];
+}
+
+// implements the [`LittleEndianBytes`]
+impl_LittleEndianBytes![i8, i16, i32, i64, i128, u8, u16, u32, u64, u128, f32, f64];

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 
 pub mod indices;
+pub mod little_endian;
 pub mod reader;
 pub mod rw_spinlock;
 pub mod sidetable;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,5 +2,6 @@ pub mod error;
 
 pub mod indices;
 pub mod reader;
+pub mod rw_spinlock;
 pub mod sidetable;
 pub mod utils;

--- a/src/core/rw_spinlock.rs
+++ b/src/core/rw_spinlock.rs
@@ -1,0 +1,162 @@
+//! Naive implementation of spin based locking mechanisms
+//!
+//! This module provides implementations for locking mechanisms required.
+//!
+//! # Acknowledgement
+//!
+//! This implementation is largely inspired by the book
+//! ["Rust Atomics and Locks" by Mara Bos](https://marabos.nl/atomics/).
+
+use core::cell::UnsafeCell;
+use core::hint::{self};
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::{AtomicU32, Ordering};
+
+/// A spinlock based, read-write lock which favours writers over readers
+///
+/// # Properties
+///
+/// - Read-write semantics allow for multiple readers at the same time, but require exclusive access
+///   for a writer
+/// - Spin based, e.g. waiting for the lock wastes CPU cycles in a busy loop
+///    - This design however enables an implementation independent of operating system features like
+///      condition variables, the only requirement are 32 bit atomics in the ISA
+/// - Biased towards writes: once a writer waits for the lock, all new reader wait until that writer
+///   got access
+pub struct RwSpinLock<T> {
+    /// The inner data protected by this lock
+    inner: UnsafeCell<T>,
+
+    /// Lock state (on ambiguity, the state closer to the top takes precedence)
+    ///
+    /// - `0` means there are no readers nor any writer
+    /// - `u32::MAX` means there is a single active writer
+    /// - `state % 2 == 0` means there are `state / 2` active readers
+    /// - `state % 2 != 0` means there are `(state - 1) / 2` active readers and at least one waiting
+    ///    writer
+    state: AtomicU32,
+}
+
+impl<T> RwSpinLock<T> {
+    /// Create a new instance of self, wrapping the `value` of type `T`
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: UnsafeCell::new(value),
+            state: AtomicU32::new(0),
+        }
+    }
+
+    // Get read access to the value wrapped in this [`RwSpinLock`]
+    pub fn read(&self) -> ReadLockGuard<T> {
+        // get the current state
+        let mut s = self.state.load(Ordering::Relaxed); // ordering by the book
+
+        loop {
+            // s is even, so there are maybe active readers but no active or waiting writer
+            // -> reader can acquire read guard (as long as an overflow is avoided)
+            if s % 2 == 0 && s < u32::MAX - 2 {
+                match self.state.compare_exchange_weak(
+                    s,
+                    s + 2,
+                    Ordering::Acquire,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => return ReadLockGuard { lock: self },
+                    Err(update_s) => s = update_s,
+                }
+            }
+
+            // there is one active (`s == u32::MAX`) or at least one waiting (otherwise) writer
+            // -> spin, re-load s and try again
+            if s % 2 == 1 {
+                hint::spin_loop();
+                s = self.state.load(Ordering::Relaxed); // ordering by the book
+            }
+        }
+    }
+
+    // Get write access to the value wrapped in this [`RwSpinLock`]
+    pub fn write(&self) -> WriteLockGuard<T> {
+        let mut s = self.state.load(Ordering::Relaxed);
+
+        loop {
+            // there is no active reader (`s >= 2 && s % 2 == 0`) or writer (`s == u32::MAX`)
+            if s <= 1 {
+                match self
+                    .state
+                    .compare_exchange(s, u32::MAX, Ordering::Acquire, Ordering::Relaxed)
+                {
+                    Ok(_) => return WriteLockGuard { lock: self },
+                    Err(updated_s) => {
+                        s = updated_s;
+                        continue;
+                    }
+                }
+            }
+
+            // announce that a writer is waiting if this is not yet announced
+            if s % 2 == 0 {
+                match self
+                    .state
+                    // ordering by the book
+                    .compare_exchange(s, s + 1, Ordering::Relaxed, Ordering::Relaxed)
+                {
+                    Ok(_) => {}
+                    Err(updated_s) => {
+                        s = updated_s;
+                        continue;
+                    }
+                }
+            }
+
+            // wait was announced, there are still active readers
+            // -> spin, re-load s, continue from the start of the lop
+            hint::spin_loop();
+            s = self.state.load(Ordering::Relaxed);
+        }
+    }
+}
+
+unsafe impl<T> Sync for RwSpinLock<T> where T: Send + Sync {}
+
+/// Read guard for the [`RwSpinLock`]
+pub struct ReadLockGuard<'a, T> {
+    lock: &'a RwSpinLock<T>,
+}
+
+impl<T> Deref for ReadLockGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.lock.inner.get() }
+    }
+}
+
+impl<T> Drop for ReadLockGuard<'_, T> {
+    fn drop(&mut self) {
+        self.lock.state.fetch_sub(2, Ordering::Release); // ordering by the book
+    }
+}
+
+/// Write guard for the [`RwSpinLock`]
+pub struct WriteLockGuard<'a, T> {
+    lock: &'a RwSpinLock<T>,
+}
+
+impl<T> Deref for WriteLockGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.lock.inner.get() }
+    }
+}
+
+impl<T> DerefMut for WriteLockGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.lock.inner.get() }
+    }
+}
+
+impl<T> Drop for WriteLockGuard<'_, T> {
+    fn drop(&mut self) {
+        self.lock.state.store(0, Ordering::Release); // ordering by the book
+    }
+}

--- a/src/execution/linear_memory.rs
+++ b/src/execution/linear_memory.rs
@@ -1,0 +1,554 @@
+use core::{cell::UnsafeCell, mem};
+
+use alloc::vec::Vec;
+
+use crate::{
+    core::{indices::MemIdx, little_endian::LittleEndianBytes},
+    rw_spinlock::RwSpinLock,
+    RuntimeError,
+};
+
+/// Implementation of the linear memory suitable for concurrent access
+///
+/// Implements the base for the instructions described in
+/// <https://webassembly.github.io/spec/core/exec/instructions.html#memory-instructions>.
+///
+/// This linear memory implementation internally relies on a `Vec<UnsafeCell<u8>>`. Thus, the atomic
+/// unit of information for it is a byte (`u8`). All access to the linear memory internally occurs
+/// through pointers, avoiding the creation of shared and mut refs to the internal data completely.
+/// This avoids undefined behavior, except for the race-condition inherent to concurrent writes.
+/// Because of this, the [`LinearMemory::store`] function does not require `&mut self` -- `&self`
+/// suffices.
+///
+/// # Notes on overflowing
+///
+/// All operations that rely on accessing `n` bytes starting at `index` in the linear memory have to
+/// perform bounds checking. Thus they always have to ensure that `n + index < linear_memory.len()`
+/// holds true (e.g. `n + index - 1` must be a valid index into `linear_memory`). However,
+/// writing that check as is bears the danger of an overflow, assuming that `n`, `index` and
+/// `linear_memory.len()` are the same given integer type, `n + index` can overflow, resulting in
+/// the check passing despite the access being out of bounds!
+///
+/// To avoid this, the bounds checks are carefully ordered to avoid any overflows:
+///
+/// - First we check, that `n <= linear_memory.len()` holds true, ensuring that the amount of bytes
+///   to be accessed is indeed smaller than or equal to the linear memory's size. If this does not
+///   hold true, continuation of the operation will yield out of bounds access in any case.
+/// - Then, as a second check, we verify that `index <= linear_memory.len() - n`. This way we
+///   avoid the overflow, as there is no addition. The subtraction in the left hand can not
+///   underflow, due to the previous check (which asserts that `n` is smaller than or equal to
+///   `linear_memory.len()`).
+///
+/// Combined in the given order, these two checks enable bounds checking without risking any
+/// overflow or underflow, provided that `n`, `index` and `linear_memory.len()` are of the same
+/// integer type.
+///
+/// # Notes on locking
+///
+/// The internal data vector of the [`LinearMemory`] is wrapped in a [`RwSpinLock`]. Despite the
+/// name, writes to the linear memory do not require an acquisition of a write lock. Writes are
+/// implemented through a shared ref to the internal vector, with an `UnsafeCell` to achieve
+/// interior mutability.
+///
+/// However, linear memory can grow. As the linear memory is implemented via a [`Vec`], a grow can
+/// result in the vector's internal data buffer to be copied over to a bigger, fresh allocation.
+/// The old buffer is then freed. Combined with concurrent mutable access, this can cause
+/// use-after-free. To avoid this, a grow operation of the linear memory acquires a write lock,
+/// blocking all read/write to the linear memory inbetween.
+///
+/// # Unsafe Note
+///
+/// Raw pointer access it required, because concurent mutation of the linear memory might happen
+/// (consider the threading proposal for WASM, where mutliple WASM threads access the same linear
+/// memory at the same time). The inherent race condition results in UB w/r/t the state of the `u8`s
+/// in the inner data. However, this is tolerable, e.g. avoiding race conditions on the state of the
+/// linear memory can not be the task of the interpreter, but has to be fulfilled by the interpreted
+/// bytecode itself.
+// TODO if a memmap like operation is available, the linear memory implementation can be optimized brutally. Out-of-bound access can be mapped to userspace handled page-faults, e.g. the MMU takes over that responsibility of catching out of bounds. Grow can happen without copying of data, by mapping new pages consecutively after the current final page of the linear memory.
+pub struct LinearMemory<const PAGE_SIZE: usize = { crate::Limits::MEM_PAGE_SIZE as usize }> {
+    inner_data: RwSpinLock<Vec<UnsafeCell<u8>>>,
+}
+
+/// Type to express the page count
+pub type PageCountTy = u16;
+
+impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
+    /// Size of a page in the linear memory, measured in bytes
+    ///
+    /// The WASM specification demands a page size of 64 KiB, that is `65536` bytes:
+    /// <https://webassembly.github.io/spec/core/exec/runtime.html?highlight=page#memory-instances>
+    const PAGE_SIZE: usize = PAGE_SIZE;
+
+    /// Create a new, empty [`LinearMemory`]
+    pub fn new() -> Self {
+        Self {
+            inner_data: RwSpinLock::new(Vec::new()),
+        }
+    }
+
+    /// Create a new, empty [`LinearMemory`]
+    pub fn new_with_initial_pages(pages: PageCountTy) -> Self {
+        let size_bytes = Self::PAGE_SIZE * pages as usize;
+        let mut data = Vec::with_capacity(size_bytes);
+        data.resize_with(size_bytes, || UnsafeCell::new(0));
+
+        Self {
+            inner_data: RwSpinLock::new(data),
+        }
+    }
+
+    /// Grow the [`LinearMemory`] by a number of pages
+    pub fn grow(&self, pages_to_add: PageCountTy) {
+        let mut lock_guard = self.inner_data.write();
+        let prior_length_bytes = lock_guard.len();
+        let new_length_bytes = prior_length_bytes + Self::PAGE_SIZE * pages_to_add as usize;
+        lock_guard.resize_with(new_length_bytes, || UnsafeCell::new(0));
+    }
+
+    /// Get the number of pages currently allocated to this [`LinearMemory`]
+    pub fn pages(&self) -> PageCountTy {
+        PageCountTy::try_from(self.inner_data.read().len() / PAGE_SIZE).unwrap()
+    }
+
+    /// Get the length in bytes currently allocated to this [`LinearMemory`]
+    // TODO remove this op
+    pub fn len(&self) -> usize {
+        self.inner_data.read().len()
+    }
+
+    /// At a given index, store a datum in the [`LinearMemory`]
+    pub fn store<const N: usize, T: LittleEndianBytes<N>>(
+        &self,
+        index: MemIdx,
+        value: T,
+    ) -> Result<(), RuntimeError> {
+        let value_size = mem::size_of::<T>();
+
+        // Unless someone implementes something wrong like `impl LittleEndianBytes<3> for f64`, this
+        // check is already guaranteed at the type level. Therefore only a debug_assert.
+        debug_assert_eq!(value_size, N, "value size must match const generic N");
+
+        let lock_guard = self.inner_data.read();
+
+        // A value must fit into the linear memory
+        if value_size > lock_guard.len() {
+            error!("value does not fit into linear memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        // The following statement must be true
+        // `index + value_size <= lock_guard.len()`
+        // This check verifies it, while avoiding the possible overflow. The subtraction can not
+        // underflow because of the previous check.
+
+        if (index) > lock_guard.len() - value_size {
+            error!("value write would extend beyond the end of the linear memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        // TODO this unwrap can not fail, maybe use unwrap_unchecked?
+        let ptr = lock_guard.get(index).unwrap().get();
+        let bytes = value.to_le_bytes(); //
+
+        // Safety argument:
+        //
+        // - nonoverlapping is guaranteed, because `src` is a pointer to a stack allocated array,
+        //   while the destination is heap allocated Vec
+        // - the first check above guarantee that `src` fits into the destination
+        // - the second check above guarantees that even with the offset in `index`, `src` does not
+        //   extend beyond the destinations last `UnsafeCell<u8>`
+        // - the use of `UnsafeCell` avoids any `&` or `&mut` to ever be created on any of the `u8`s
+        //   contained in the `UnsafeCell`s, so no UB is created through the existence of unsound
+        //   references
+        unsafe { ptr.copy_from_nonoverlapping(bytes.as_ref().as_ptr(), value_size) }
+
+        Ok(())
+    }
+
+    /// From a given index, load a datum in the [`LinearMemory`]
+    pub fn load<const N: usize, T: LittleEndianBytes<N>>(
+        &self,
+        index: MemIdx,
+    ) -> Result<T, RuntimeError> {
+        let value_size = mem::size_of::<T>();
+
+        // Unless someone implementes something wrong like `LittleEndianBytes<3> for i8`, this
+        // check is already guaranteed at the type level. Therefore only a debug_assert.
+        debug_assert_eq!(value_size, N, "value size must match const generic N");
+
+        let lock_guard = self.inner_data.read();
+
+        // A value must fit into the linear memory
+        if value_size > lock_guard.len() {
+            error!("value does not fit into linear memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        // The following statement must be true
+        // `index + value_size <= lock_guard.len()`
+        // This check verifies it, while avoiding the possible overflow. The subtraction can not
+        // underflow because of the previous assert.
+
+        if (index) > lock_guard.len() - value_size {
+            error!("value read would extend beyond the end of the linear_memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        let ptr = lock_guard.get(index).unwrap().get();
+        let mut bytes = [0; N];
+
+        // Safety argument:
+        //
+        // - nonoverlapping is guaranteed, because `dest` is a pointer to a stack allocated array,
+        //   while the source is heap allocated Vec
+        // - the first assert above guarantee that source is bigger than `dest`
+        // - the second assert above guarantees that even with the offset in `index`, `dest` does
+        //   not extend beyond the destinations last `UnsafeCell<u8>` in source
+        // - the use of `UnsafeCell` avoids any `&` or `&mut` to ever be created on any of the `u8`s
+        //   contained in the `UnsafeCell`s, so no UB is created through the existence of unsound
+        //   references
+        unsafe { ptr.copy_to_nonoverlapping(bytes.as_mut_ptr(), bytes.len()) };
+        Ok(T::from_le_bytes(bytes))
+    }
+
+    /// Implementation of the behavior described in
+    /// <https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-fill>.
+    /// Note, that the WASM spec defines the behavior by recursion, while our implementation uses
+    /// the memset like [`core::ptr::write_bytes`].
+    pub fn fill(&self, index: MemIdx, data_byte: u8, count: MemIdx) -> Result<(), RuntimeError> {
+        if count == 0 {
+            return Ok(());
+        }
+
+        let lock_guard = self.inner_data.read();
+
+        if count > lock_guard.len() {
+            error!("fill count is bigger than the linear memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        if index > lock_guard.len() - count {
+            error!("fill extends beyond the linear memory's end");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        let ptr = lock_guard[index].get();
+        unsafe {
+            ptr.write_bytes(data_byte, count);
+        }
+
+        Ok(())
+    }
+
+    /// Copy `count` bytes from one region in the linear memory to another region in the same or a
+    /// different linear memory
+    ///
+    /// - Both regions may overlap
+    /// - Copies the `count` bytes starting from `source_index`, overwriting the `count` bytes
+    ///   starting from `destination_index`
+    pub fn copy(
+        &self,
+        destination_index: MemIdx,
+        source_mem: &Self,
+        source_index: MemIdx,
+        count: MemIdx,
+    ) -> Result<(), RuntimeError> {
+        if count == 0 {
+            return Ok(());
+        }
+
+        // self is the destination
+        let lock_guard_self = self.inner_data.read();
+
+        // other is the source
+        let lock_guard_other = source_mem.inner_data.read();
+
+        // check destination for out of bounds access
+        if count > lock_guard_self.len() {
+            error!("copy count is bigger than the destination linear memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        if destination_index > lock_guard_self.len() - count {
+            error!("copy destination extends beyond the linear memory's end");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        // check source for out of bounds access
+        if count > lock_guard_other.len() {
+            error!("copy count is bigger than the source linear memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        if source_index > lock_guard_other.len() - count {
+            error!("copy source extends beyond the linear memory's end");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        // acquire pointers
+        let destination_ptr = lock_guard_self[destination_index].get();
+        let source_ptr = lock_guard_other[source_index].get();
+
+        // copy the data
+        unsafe {
+            // TODO investigate if it is worth to use a conditional `copy_from_nonoverlapping`
+            // if the non-overlapping can be confirmed (and the count is bigger than a certain
+            // threshold).
+            destination_ptr.copy_from(source_ptr, count);
+        }
+
+        Ok(())
+    }
+
+    // Rationale behind having `source_index` and `count` when the callsite could also just create a subslice for `source_data`? Have all the index error checks in one place.
+    pub fn init(
+        &self,
+        destination_index: MemIdx,
+        source_data: &[u8],
+        source_index: MemIdx,
+        count: MemIdx,
+    ) -> Result<(), RuntimeError> {
+        if count == 0 {
+            return Ok(());
+        }
+
+        let lock_guard_self = self.inner_data.read();
+        let data_len = source_data.len();
+
+        // check destination for out of bounds access
+        if count > lock_guard_self.len() {
+            error!("init count is bigger than the linear memory");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        if destination_index > lock_guard_self.len() - count {
+            error!("init extends beyond the linear memory's end");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        // check source for out of bounds access
+        if count > data_len {
+            error!("init count is bigger than the data instance");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        if source_index > data_len - count {
+            error!("init source extends beyond the data instance's end");
+            return Err(RuntimeError::MemoryAccessOutOfBounds);
+        }
+
+        // acquire pointers
+        let destination_ptr = lock_guard_self[destination_index].get();
+        let source_ptr = &source_data[source_index];
+
+        // copy the data
+        unsafe {
+            destination_ptr.copy_from_nonoverlapping(source_ptr, count);
+        }
+
+        Ok(())
+    }
+}
+
+impl<const PAGE_SIZE: usize> core::fmt::Debug for LinearMemory<PAGE_SIZE> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "LinearMemory {{ inner_data: [ ")?;
+        let lock_guard = self.inner_data.read();
+        let mut iter = lock_guard.iter();
+
+        if let Some(first_byte_uc) = iter.next() {
+            write!(f, "{}", unsafe { *first_byte_uc.get() })?;
+        }
+
+        for uc in iter {
+            // Safety argument:
+            //
+            // TODO
+            let byte = unsafe { *uc.get() };
+
+            write!(f, ", {byte}")?;
+        }
+        write!(f, " ] }}")
+    }
+}
+
+impl<const PAGE_SIZE: usize> Default for LinearMemory<PAGE_SIZE> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::format;
+
+    use super::*;
+
+    const PAGE_SIZE: usize = 1 << 8;
+    const PAGES: PageCountTy = 2;
+
+    #[test]
+    fn new_constructor() {
+        let lin_mem = LinearMemory::<PAGE_SIZE>::new();
+        assert_eq!(lin_mem.pages(), 0);
+    }
+
+    #[test]
+    fn new_grow() {
+        let lin_mem = LinearMemory::<PAGE_SIZE>::new();
+        lin_mem.grow(1);
+        assert_eq!(lin_mem.pages(), 1);
+    }
+
+    #[test]
+    fn debug_print() {
+        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(1);
+        assert_eq!(lin_mem.pages(), 1);
+
+        let expected_length = "LinearMemory { inner_data: [  ] }".len() + PAGE_SIZE * "0, ".len();
+        let tol = 2;
+
+        let debug_repr = format!("{lin_mem:?}");
+        let lower_bound = expected_length - tol;
+        let upper_bound = expected_length + tol;
+        assert!((lower_bound..upper_bound).contains(&debug_repr.len()));
+    }
+
+    #[test]
+    fn roundtrip_normal_range_i8_neg127() {
+        let x: i8 = -127;
+        let highest_legal_offset = PAGE_SIZE - mem::size_of::<i8>();
+        for offset in 0..MemIdx::try_from(highest_legal_offset).unwrap() {
+            let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+
+            lin_mem.store(offset, x).unwrap();
+
+            assert_eq!(
+                lin_mem
+                    .load::<{ core::mem::size_of::<i8>() }, i8>(offset)
+                    .unwrap(),
+                x,
+                "load store roundtrip for {x:?} failed!"
+            );
+        }
+    }
+
+    #[test]
+    fn roundtrip_normal_range_f32_13() {
+        let x: f32 = 13.0;
+        let highest_legal_offset = PAGE_SIZE - mem::size_of::<f32>();
+        for offset in 0..MemIdx::try_from(highest_legal_offset).unwrap() {
+            let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+
+            lin_mem.store(offset, x).unwrap();
+
+            assert_eq!(
+                lin_mem
+                    .load::<{ core::mem::size_of::<f32>() }, f32>(offset)
+                    .unwrap(),
+                x,
+                "load store roundtrip for {x:?} failed!"
+            );
+        }
+    }
+
+    #[test]
+    fn roundtrip_normal_range_f64_min() {
+        let x: f64 = f64::MIN;
+        let highest_legal_offset = PAGE_SIZE - mem::size_of::<f64>();
+        for offset in 0..MemIdx::try_from(highest_legal_offset).unwrap() {
+            let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+
+            lin_mem.store(offset, x).unwrap();
+
+            assert_eq!(
+                lin_mem
+                    .load::<{ core::mem::size_of::<f64>() }, f64>(offset)
+                    .unwrap(),
+                x,
+                "load store roundtrip for {x:?} failed!"
+            );
+        }
+    }
+
+    #[test]
+    fn roundtrip_normal_range_f64_nan() {
+        let x: f64 = f64::NAN;
+        let highest_legal_offset = PAGE_SIZE - mem::size_of::<f64>();
+        for offset in 0..MemIdx::try_from(highest_legal_offset).unwrap() {
+            let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+
+            lin_mem.store(offset, x).unwrap();
+
+            assert!(
+                lin_mem
+                    .load::<{ core::mem::size_of::<f64>() }, f64>(offset)
+                    .unwrap()
+                    .is_nan(),
+                "load store roundtrip for {x:?} failed!"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: MemoryAccessOutOfBounds"
+    )]
+    fn store_out_of_range_u128_max() {
+        let x: u128 = u128::MAX;
+        let pages = 1;
+        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u128>() + 1;
+        let lowest_illegal_offset = MemIdx::try_from(lowest_illegal_offset).unwrap();
+        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+
+        lin_mem.store(lowest_illegal_offset, x).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: MemoryAccessOutOfBounds"
+    )]
+    fn store_empty_lineaer_memory_u8() {
+        let x: u8 = u8::MAX;
+        let pages = 0;
+        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u8>() + 1;
+        let lowest_illegal_offset = MemIdx::try_from(lowest_illegal_offset).unwrap();
+        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+
+        lin_mem.store(lowest_illegal_offset, x).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: MemoryAccessOutOfBounds"
+    )]
+    fn load_out_of_range_u128_max() {
+        let pages = 1;
+        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u128>() + 1;
+        let lowest_illegal_offset = MemIdx::try_from(lowest_illegal_offset).unwrap();
+        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+
+        let _x: u128 = lin_mem.load(lowest_illegal_offset).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: MemoryAccessOutOfBounds"
+    )]
+    fn load_empty_lineaer_memory_u8() {
+        let pages = 0;
+        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u8>() + 1;
+        let lowest_illegal_offset = MemIdx::try_from(lowest_illegal_offset).unwrap();
+        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+
+        let _x: u8 = lin_mem.load(lowest_illegal_offset).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn copy_out_of_bounds() {
+        let lin_mem_0 = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(2);
+        let lin_mem_1 = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(1);
+        lin_mem_0.copy(0, &lin_mem_1, 0, PAGE_SIZE + 1).unwrap();
+    }
+}

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod execution_info;
 pub mod function_ref;
 pub mod hooks;
 mod interpreter_loop;
+pub(crate) mod linear_memory;
 pub(crate) mod locals;
 pub(crate) mod lut;
 pub(crate) mod store;

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -14,6 +14,7 @@ use value::{ExternAddr, FuncAddr, Ref};
 use value_stack::Stack;
 
 use crate::core::error::StoreInstantiationError;
+use crate::core::indices::MemIdx;
 use crate::core::reader::types::element::{ElemItems, ElemMode};
 use crate::core::reader::types::export::ExportDesc;
 use crate::core::reader::types::import::ImportDesc;
@@ -698,15 +699,10 @@ where
 
                     let mem_inst = memory_instances.get_mut(mem_idx).unwrap();
 
-                    let len = mem_inst.data.len();
-                    if offset as usize + d.init.len() > len {
-                        return Err(Error::StoreInstantiationError(ActiveDataWriteOutOfBounds));
-                    }
-                    let data = mem_inst
-                        .data
-                        .get_mut(offset as usize..offset as usize + d.init.len())
-                        .unwrap();
-                    data.copy_from_slice(&d.init);
+                    mem_inst
+                        .mem
+                        .init(offset as MemIdx, &d.init, 0, d.init.len())
+                        .map_err(|_| Error::StoreInstantiationError(ActiveDataWriteOutOfBounds))?;
                 }
                 Ok(DataInst {
                     data: d.init.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate log;
 
 pub use core::error::{Error, Result, RuntimeError};
 pub use core::reader::types::{Limits, NumType, RefType, ValType};
+pub use core::rw_spinlock;
 pub use execution::value::Value;
 pub use execution::*;
 pub use validation::*;

--- a/tests/memory_fill.rs
+++ b/tests/memory_fill.rs
@@ -43,9 +43,13 @@ fn memory_fill() {
 
     let fill = get_func!(i, "fill");
     i.invoke::<(), ()>(fill, ()).unwrap();
-    let mem = &i.modules[0].store.mems[0];
-    assert!(mem.data.as_slice()[0..105]
-        .eq_ignore_ascii_case(&vec![vec![217u8; 100], vec![0u8; 5]].concat()))
+    let mem_inst = &i.modules[0].store.mems[0];
+
+    let expected = [vec![217u8; 100], vec![0u8; 5]].concat();
+    for (idx, expected_byte) in expected.into_iter().enumerate() {
+        let mem_byte: u8 = mem_inst.mem.load(idx).unwrap();
+        assert!(mem_byte.eq_ignore_ascii_case(&expected_byte));
+    }
 }
 
 // we need control flow implemented for any of these tests

--- a/tests/rw_spinlock.rs
+++ b/tests/rw_spinlock.rs
@@ -1,0 +1,84 @@
+use std::{thread, time::Duration};
+
+use log::info;
+use wasm::rw_spinlock::*;
+
+#[test_log::test]
+fn rw_spin_lock_basic() {
+    let rw_lock = RwSpinLock::new(0i128);
+
+    // one reader
+    {
+        let reader = rw_lock.read();
+        assert_eq!(*reader, 0);
+    }
+
+    // one writer
+    {
+        let mut writer = rw_lock.write();
+        *writer = 13;
+    }
+
+    // one writer used for reading
+    {
+        let writer = rw_lock.write();
+        assert_eq!(*writer, 13);
+    }
+
+    // 10_000 readers
+    {
+        let mut vec = Vec::new();
+        for _ in 0..10_000 {
+            vec.push(rw_lock.read());
+        }
+    }
+
+    // a final writer
+    assert_eq!(*rw_lock.write(), 13);
+}
+
+#[test_log::test]
+fn write_dominates_read() {
+    let rw_lock = RwSpinLock::new(0u128);
+
+    thread::scope(|s| {
+        // this thread ensures that there first is a read lock
+        s.spawn(|| {
+            info!("t1: acquiring read lock");
+            let read_guard = rw_lock.read();
+
+            info!("t1: waiting");
+            thread::sleep(Duration::from_millis(500));
+
+            info!("t1: reading once");
+            assert_eq!(*read_guard, 0u128);
+            info!("t1: terminating");
+        });
+
+        for _ in 0..64 {
+            s.spawn(|| {
+                thread::sleep(Duration::from_millis(250));
+
+                loop {
+                    info!("tx: acquiring readlock");
+                    let read_guard = rw_lock.read();
+                    thread::sleep(Duration::from_millis(500));
+                    if *read_guard != 0 {
+                        return;
+                    }
+                }
+            });
+        }
+
+        s.spawn(|| {
+            thread::sleep(Duration::from_millis(750));
+
+            info!("t2: acquiring write lock");
+            let mut write_guard = rw_lock.write();
+
+            *write_guard = 1u128 << 74;
+        });
+    });
+
+    assert_eq!(*rw_lock.read(), 1u128 << 74);
+}


### PR DESCRIPTION
### Pull Request Overview

Adds:

- `RwSpinLock`, a spinning, writer preferring read-write lock implementation
-  `LinearMemory`, a linear memory implementation that enable shared concurrent access

### Testing Strategy

This pull request was tested by its including tests

### TODO or Help 

This pull request still needs a keen eye on the use of ordering for the atomic operations in the `RwSpinLock` implementation.

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `cargo doc`
- [x] Ran `nix fmt`

### Github Issue

This pull request continues the ideas laid out in https://github.com/DLR-FT/wasm-interpreter/issues/135
