### PR TITLE
Add Resumable API

### DIFF
--- a/examples/fuel/main.rs
+++ b/examples/fuel/main.rs
@@ -1,0 +1,74 @@
+use std::env;
+use std::process::ExitCode;
+use std::str::FromStr;
+
+use log::{error, LevelFilter};
+
+use wasm::{validate, RuntimeInstance};
+
+fn main() -> ExitCode {
+    let level = LevelFilter::from_str(&env::var("RUST_LOG").unwrap_or("TRACE".to_owned())).unwrap();
+    env_logger::builder().filter_level(level).init();
+
+    let wat = r#"
+        (module
+            (func $fac (export "fac") (param f64) (result f64)
+                local.get 0
+                f64.const 1
+                f64.lt
+                if (result f64)
+                    f64.const 1
+                else
+                    nop
+                    local.get 0
+                    local.get 0
+                    f64.const 1
+                    f64.sub
+                    call $fac
+                    f64.mul
+                end
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat).unwrap();
+
+    let validation_info = match validate(&wasm_bytes) {
+        Ok(table) => table,
+        Err(err) => {
+            error!("Validation failed: {err:?} [{err}]");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut instance = match RuntimeInstance::new(&validation_info) {
+        Ok(instance) => instance,
+        Err(err) => {
+            error!("Instantiation failed: {err:?} [{err}]");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut state = instance
+        .invoke_resumable(&instance.get_function_by_index(0, 0).unwrap(), 1.0f64)
+        .unwrap();
+
+    let mut res: Option<f64> = None;
+    loop {
+        match state {
+            wasm::InvocationState::Finished(ret) => {
+                res.replace(ret);
+                break;
+            }
+            wasm::InvocationState::OutOfFuel(res) => {
+                state = res.resume().unwrap();
+            }
+            wasm::InvocationState::Canceled => {
+                break;
+            }
+        };
+    }
+
+    assert_eq!(res.unwrap(), 1.0f64);
+
+    ExitCode::SUCCESS
+}

--- a/examples/fuel/main.rs
+++ b/examples/fuel/main.rs
@@ -49,7 +49,7 @@ fn main() -> ExitCode {
     };
 
     let mut state = instance
-        .invoke_resumable(&instance.get_function_by_index(0, 0).unwrap(), 1.0f64)
+        .invoke_resumable(&instance.get_function_by_index(0, 0).unwrap(), 5.0f64)
         .unwrap();
 
     let mut res: Option<f64> = None;
@@ -68,7 +68,7 @@ fn main() -> ExitCode {
         };
     }
 
-    assert_eq!(res.unwrap(), 1.0f64);
+    assert_eq!(res.unwrap(), 120.0f64);
 
     ExitCode::SUCCESS
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -31,6 +31,7 @@ pub enum RuntimeError {
     UndefinedTableIndex,
     // "undefined element" <- as-call_indirect-last
     // "unreachable"
+    OutOfFuel,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -290,6 +291,9 @@ impl Display for RuntimeError {
             }
             RuntimeError::UndefinedTableIndex => {
                 f.write_str("Indirect call: table index out of bounds")
+            }
+            RuntimeError::OutOfFuel => {
+                f.write_str("No sufficent fuel for next operation in a non-resumable invocation")
             }
         }
     }

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -35,6 +35,11 @@ use crate::execution::hooks::HookSet;
 
 use super::{execution_info::ExecutionInfo, lut::Lut};
 
+pub(super) enum RunState {
+    Finished,
+    OutOfFuel,
+}
+
 /// Interprets a functions. Parameters and return values are passed on the stack.
 pub(super) fn run<H: HookSet>(
     modules: &mut [ExecutionInfo],
@@ -42,7 +47,7 @@ pub(super) fn run<H: HookSet>(
     lut: &Lut,
     stack: &mut Stack,
     mut hooks: H,
-) -> Result<(), RuntimeError> {
+) -> Result<RunState, RuntimeError> {
     let func_inst = modules[*current_module_idx]
         .store
         .funcs
@@ -79,6 +84,7 @@ pub(super) fn run<H: HookSet>(
         match first_instr_byte {
             NOP => {
                 trace!("Instruction: NOP");
+                return Ok(RunState::OutOfFuel);
             }
             END => {
                 // if this is not the very last instruction in the function
@@ -2872,7 +2878,7 @@ pub(super) fn run<H: HookSet>(
             }
         }
     }
-    Ok(())
+    Ok(RunState::Finished)
 }
 
 //helper function for avoiding code duplication at intraprocedural jumps

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -35,12 +35,17 @@ use crate::execution::hooks::HookSet;
 
 use super::{execution_info::ExecutionInfo, lut::Lut};
 
+/// The result state from run()
 pub(super) enum RunState {
+    /// Interpretation was finished.
     Finished,
+    /// Interpretation was interrupted due to insufficent fuel.
     OutOfFuel,
 }
 
 /// Interprets a functions. Parameters and return values are passed on the stack.
+/// Completly stateless. All state is passed in via references. Theirfore this can be called repeatedly to resume an interpretation.
+/// Returns a state which determines whether the interpretation was finished or interrupted.
 pub(super) fn run<H: HookSet>(
     modules: &mut [ExecutionInfo],
     lut: &Lut,

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -84,7 +84,6 @@ pub(super) fn run<H: HookSet>(
         match first_instr_byte {
             NOP => {
                 trace!("Instruction: NOP");
-                return Ok(RunState::OutOfFuel);
             }
             END => {
                 // if this is not the very last instruction in the function

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -446,9 +446,10 @@ where
         }
 
         // Prepare a new stack with the locals for the entry function
-        let mut stack = Stack::new();
+        self.stack = Stack::new();
         let locals = Locals::new(params.into_iter(), func_inst.locals.iter().cloned());
-        stack.push_stackframe(module_idx, func_idx, func_ty, locals, 0, 0);
+        self.stack
+            .push_stackframe(module_idx, func_idx, func_ty, locals, 0, 0);
 
         // Start reading the function's instructions
         let wasm = &mut exec_info.wasm_reader;
@@ -489,7 +490,7 @@ where
             .valtypes
             .iter()
             .rev()
-            .map(|ty| stack.pop_value(*ty))
+            .map(|ty| self.stack.pop_value(*ty))
             .collect::<Vec<Value>>();
 
         // Values are reversed because they were popped from stack one-by-one. Now reverse them back
@@ -539,9 +540,10 @@ where
         }
 
         // Prepare a new stack with the locals for the entry function
-        let mut stack = Stack::new();
+        self.stack = Stack::new();
         let locals = Locals::new(params.into_iter(), func_inst.locals.iter().cloned());
-        stack.push_stackframe(module_idx, func_idx, func_ty, locals, 0, 0);
+        self.stack
+            .push_stackframe(module_idx, func_idx, func_ty, locals, 0, 0);
 
         // Start reading the function's instructions
         let wasm = &mut exec_info.wasm_reader;
@@ -554,7 +556,7 @@ where
         run(
             &mut self.modules,
             self.lut.as_ref().ok_or(RuntimeError::UnmetImport)?,
-            &mut stack,
+            &mut self.stack,
             &mut currrent_module_idx,
             &mut current_stp,
             EmptyHookSet,
@@ -578,7 +580,7 @@ where
             .valtypes
             .iter()
             .rev()
-            .map(|ty| stack.pop_value(*ty))
+            .map(|ty| self.stack.pop_value(*ty))
             .collect::<Vec<Value>>();
 
         // Values are reversed because they were popped from stack one-by-one. Now reverse them back

--- a/tests/specification/run.rs
+++ b/tests/specification/run.rs
@@ -49,6 +49,8 @@ pub fn to_wasm_testsuite_string(runtime_error: RuntimeError) -> std::string::Str
         RuntimeError::UndefinedTableIndex => "undefined element",
         RuntimeError::ModuleNotFound => "module not found",
         RuntimeError::UnmetImport => "unmet import",
+
+        RuntimeError::OutOfFuel => "out of fuel",
     }
     .to_string()
 }


### PR DESCRIPTION
### Pull Request Overview

This is a draft for a resume-able API #42  [req](https://github.com/DLR-FT/wasm-interpreter/blob/b24b042a76872379c76be463dbd4f33ce636282e/requirements/requirements.sdoc#L7) that enables the interpreter to pause and to be resumed. This is mainly required for the fuel mechanism in the interpreter [req](https://github.com/DLR-FT/wasm-interpreter/blob/b24b042a76872379c76be463dbd4f33ce636282e/requirements/requirements.sdoc#L106C1-L117C4).

### Testing Strategy

This pull request was tested by...

### TODO

* ~~Add new resume-able invocation function~~
* ~~Move the initialization out of the `run` function, so that is can be called on an already initialized interpreter~~
* Cleanup
* Add feature gates
* Add tests
* Add documentation

### Formatting

- [ ] Ran `cargo fmt`
- [ ] Ran `cargo check`
- [ ] Ran `cargo build`
- [ ] Ran `cargo doc`
- [ ] Ran `nix fmt`

### Github Issue

This pull request closes <GITHUB_ISSUE>
