### PR TITLE
feat: integer extend op codes

### DIFF
--- a/src/core/reader/types/opcode.rs
+++ b/src/core/reader/types/opcode.rs
@@ -178,6 +178,11 @@ pub const REF_NULL: u8 = 0xD0;
 pub const REF_IS_NULL: u8 = 0xD1;
 pub const REF_FUNC: u8 = 0xD2;
 pub const FC_EXTENSIONS: u8 = 0xFC;
+pub const I32_EXTEND8_S: u8 = 0xC0;
+pub const I32_EXTEND16_S: u8 = 0xC1;
+pub const I64_EXTEND8_S: u8 = 0xC2;
+pub const I64_EXTEND16_S: u8 = 0xC3;
+pub const I64_EXTEND32_S: u8 = 0xC4;
 
 pub mod fc_extensions {
     pub const I32_TRUNC_SAT_F32_S: u8 = 0x00;
@@ -379,6 +384,11 @@ pub fn opcode_byte_to_str(byte: u8) -> alloc::string::String {
         REF_NULL => "REF_NULL",
         REF_FUNC => "REF_FUNC",
         FC_EXTENSIONS => "FC_EXTENSIONS",
+        I32_EXTEND8_S => "I32_EXTEND8_S",
+        I32_EXTEND16_S => "I32_EXTEND16_S",
+        I64_EXTEND8_S => "I64_EXTEND8_S",
+        I64_EXTEND16_S => "I64_EXTEND16_S",
+        I64_EXTEND32_S => "I64_EXTEND32_S",
         _ => "UNKNOWN",
     }
     .to_owned()

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -2867,6 +2867,94 @@ pub(super) fn run<H: HookSet>(
                     _ => unreachable!(),
                 }
             }
+
+            I32_EXTEND8_S => {
+                let mut v: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                if v | 0xFF != 0xFF {
+                    trace!("Number v ({}) not contained in 8 bits, truncating", v);
+                    v &= 0xFF;
+                }
+
+                let res = if v | 0x7F != 0x7F { v | 0xFFFFFF00 } else { v };
+
+                stack.push_value(res.into());
+
+                trace!("Instruction i32.extend8_s [{}] -> [{}]", v, res);
+            }
+            I32_EXTEND16_S => {
+                let mut v: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
+
+                if v | 0xFFFF != 0xFFFF {
+                    trace!("Number v ({}) not contained in 16 bits, truncating", v);
+                    v &= 0xFFFF;
+                }
+
+                let res = if v | 0x7FFF != 0x7FFF {
+                    v | 0xFFFF0000
+                } else {
+                    v
+                };
+
+                stack.push_value(res.into());
+
+                trace!("Instruction i32.extend16_s [{}] -> [{}]", v, res);
+            }
+            I64_EXTEND8_S => {
+                let mut v: u64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
+
+                if v | 0xFF != 0xFF {
+                    trace!("Number v ({}) not contained in 8 bits, truncating", v);
+                    v &= 0xFF;
+                }
+
+                let res = if v | 0x7F != 0x7F {
+                    v | 0xFFFFFFFF_FFFFFF00
+                } else {
+                    v
+                };
+
+                stack.push_value(res.into());
+
+                trace!("Instruction i64.extend8_s [{}] -> [{}]", v, res);
+            }
+            I64_EXTEND16_S => {
+                let mut v: u64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
+
+                if v | 0xFFFF != 0xFFFF {
+                    trace!("Number v ({}) not contained in 16 bits, truncating", v);
+                    v &= 0xFFFF;
+                }
+
+                let res = if v | 0x7FFF != 0x7FFF {
+                    v | 0xFFFFFFFF_FFFF0000
+                } else {
+                    v
+                };
+
+                stack.push_value(res.into());
+
+                trace!("Instruction i64.extend16_s [{}] -> [{}]", v, res);
+            }
+            I64_EXTEND32_S => {
+                let mut v: u64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
+
+                if v | 0xFFFF_FFFF != 0xFFFF_FFFF {
+                    trace!("Number v ({}) not contained in 32 bits, truncating", v);
+                    v &= 0xFFFF_FFFF;
+                }
+
+                let res = if v | 0x7FFF_FFFF != 0x7FFF_FFFF {
+                    v | 0xFFFFFFFF_00000000
+                } else {
+                    v
+                };
+
+                stack.push_value(res.into());
+
+                trace!("Instruction i64.extend32_s [{}] -> [{}]", v, res);
+            }
+
             other => {
                 trace!("Unknown instruction {other:#x}, skipping..");
             }

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -1227,6 +1227,33 @@ fn read_instructions(
                     }
                 }
             }
+
+            I32_EXTEND8_S => {
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+
+                stack.push_valtype(ValType::NumType(NumType::I32));
+            }
+            I32_EXTEND16_S => {
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+
+                stack.push_valtype(ValType::NumType(NumType::I32));
+            }
+            I64_EXTEND8_S => {
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
+
+                stack.push_valtype(ValType::NumType(NumType::I64));
+            }
+            I64_EXTEND16_S => {
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
+
+                stack.push_valtype(ValType::NumType(NumType::I64));
+            }
+            I64_EXTEND32_S => {
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
+
+                stack.push_valtype(ValType::NumType(NumType::I64));
+            }
+
             _ => return Err(Error::InvalidInstr(first_instr_byte)),
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for integer extend opcodes

### Testing Strategy

This pull request was tested using the testsuite i32.wast and i64.wast files

### TODO or Help Wanted

N/A

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `cargo doc`
- [ ] Ran `nix fmt`

### Github Issue

N/A
