### PR TITLE
feat: add opcodes to constant interpreter loop and expression reader

### DIFF
--- a/src/execution/const_interpreter_loop.rs
+++ b/src/execution/const_interpreter_loop.rs
@@ -1,7 +1,7 @@
 use crate::{
     assert_validated::UnwrapValidatedExt,
     core::reader::{span::Span, WasmReadable, WasmReader},
-    value::{FuncAddr, Ref},
+    value::{self, FuncAddr, Ref},
     value_stack::Stack,
     NumType, RefType, ValType, Value,
 };
@@ -43,6 +43,16 @@ pub(crate) fn run_const(
             I32_CONST => {
                 let constant = wasm.read_var_i32().unwrap_validated();
                 trace!("Constant instruction: i32.const [] -> [{constant}]");
+                stack.push_value(constant.into());
+            }
+            F32_CONST => {
+                let constant = value::F32::from_bits(wasm.read_var_f32().unwrap_validated());
+                trace!("Constanting instruction: f32.const [] -> [{constant}]");
+                stack.push_value(constant.into());
+            }
+            F64_CONST => {
+                let constant = value::F64::from_bits(wasm.read_var_f64().unwrap_validated());
+                trace!("Constanting instruction: f64.const [] -> [{constant}]");
                 stack.push_value(constant.into());
             }
             I32_ADD => {

--- a/src/validation/read_constant_expression.rs
+++ b/src/validation/read_constant_expression.rs
@@ -110,6 +110,14 @@ pub fn read_constant_expression(
                 let _num = wasm.read_var_i32()?;
                 stack.push_valtype(ValType::NumType(NumType::I32));
             }
+            F32_CONST => {
+                let _num = wasm.read_var_f32();
+                stack.push_valtype(ValType::NumType(NumType::F32));
+            }
+            F64_CONST => {
+                let _num = wasm.read_var_f64();
+                stack.push_valtype(ValType::NumType(NumType::F64));
+            }
             I64_CONST => {
                 let _num = wasm.read_var_i64()?;
                 stack.push_valtype(ValType::NumType(NumType::I64));


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for certain opcodes for the constant interpreter loop and the expression reader.

### Testing Strategy

This pull request was tested locally.

### TODO or Help Wanted

N/A

### Formatting

- [x] Ran `cargo fmt`
- [x] Ran `cargo check`
- [x] Ran `cargo build`
- [x] Ran `cargo doc`
- [ ] Ran `nix fmt`

### Github Issue

N/A
