### PR TITLE
Nero/dev/global store real assert unlinkable

### DIFF
--- a/src/execution/execution_info.rs
+++ b/src/execution/execution_info.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use crate::core::reader::types::export::Export;
 use crate::core::reader::types::FuncType;
+use crate::core::sidetable::Sidetable;
 // use crate::core::reader::types::FuncType;
 // use crate::execution::Store;
 
@@ -12,6 +13,8 @@ use crate::core::reader::types::FuncType;
 pub struct ExecutionInfo<'r> {
     pub name: String,
     pub wasm_bytecode: &'r [u8],
+    //TODO turn this into ref
+    pub sidetable: Sidetable,
 
     pub functions: Vec<usize>,
     pub functions_offset: usize,

--- a/src/execution/execution_info.rs
+++ b/src/execution/execution_info.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use crate::core::reader::types::export::Export;
 use crate::core::reader::types::FuncType;
 // use crate::core::reader::types::FuncType;
-use crate::core::reader::WasmReader;
 // use crate::execution::Store;
 
 /// ExecutionInfo is a compilation of relevant information needed by the [interpreter loop](
@@ -13,7 +12,6 @@ use crate::core::reader::WasmReader;
 pub struct ExecutionInfo<'r> {
     pub name: String,
     pub wasm_bytecode: &'r [u8],
-    pub wasm_reader: WasmReader<'r>,
 
     pub functions: Vec<usize>,
     pub functions_offset: usize,

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -53,7 +53,7 @@ pub(super) fn run<H: HookSet>(
         .unwrap_validated();
 
     // Start reading the function's instructions
-    let mut current_wasm_index = *current_module_idx;
+    let wasm = &mut WasmReader::new(store.modules[*current_module_idx].wasm_bytecode);
 
     // the sidetable and stp for this function, stp will reset to 0 every call
     // since function instances have their own sidetable.
@@ -61,34 +61,21 @@ pub(super) fn run<H: HookSet>(
     let mut stp = 0;
 
     // unwrap is sound, because the validation assures that the function points to valid subslice of the WASM binary
-    store.modules[current_wasm_index]
-        .wasm_reader
-        .move_start_to(func_inst.code_expr)
-        .unwrap();
+    wasm.move_start_to(func_inst.code_expr).unwrap();
 
     use crate::core::reader::types::opcode::*;
     loop {
         // call the instruction hook
         #[cfg(feature = "hooks")]
-        // hooks.instruction_hook(modules[*current_module_idx].wasm_bytecode, wasm.pc);
-        hooks.instruction_hook(
-            store.modules[*current_module_idx].wasm_bytecode,
-            store.modules[current_wasm_index].wasm_reader.pc,
-        );
+        hooks.instruction_hook(store.modules[*current_module_idx].wasm_bytecode, wasm.pc);
 
-        let first_instr_byte = store.modules[current_wasm_index]
-            .wasm_reader
-            .read_u8()
-            .unwrap_validated();
+        let first_instr_byte = wasm.read_u8().unwrap_validated();
 
         #[cfg(debug_assertions)]
-        crate::core::utils::print_beautiful_instruction_name_1_byte(
-            first_instr_byte,
-            store.modules[current_wasm_index].wasm_reader.pc,
+        trace!(
+            "Executing instruction {}",
+            opcode_byte_to_str(first_instr_byte)
         );
-
-        #[cfg(not(debug_assertions))]
-        trace!("Read instruction byte {first_instr_byte:#04X?} ({first_instr_byte}) at wasm_binary[{}]", store.modules[current_wasm_index].wasm_reader.pc);
 
         match first_instr_byte {
             NOP => {
@@ -109,13 +96,9 @@ pub(super) fn run<H: HookSet>(
                     .unwrap_validated()
                     .code_expr;
 
-                trace!("current_func_global_idx: {}", current_func_global_idx);
-
-                let function_real_end = current_func_span.from() + current_func_span.len();
-
                 // There might be multiple ENDs in a single function. We want to
                 // exit only when the outermost block (aka function block) ends.
-                if store.modules[*current_module_idx].wasm_reader.pc != function_real_end {
+                if wasm.pc != current_func_span.from() + current_func_span.len() {
                     continue;
                 }
 
@@ -130,11 +113,9 @@ pub(super) fn run<H: HookSet>(
                 }
 
                 trace!("end of function reached, returning to previous stack frame");
-                current_wasm_index = return_module;
                 *current_module_idx = return_module;
-
-                // wasm = &mut modules[return_module].wasm_reader;
-                store.modules[*current_module_idx].wasm_reader.pc = maybe_return_address;
+                wasm.full_wasm_binary = store.modules[*current_module_idx].wasm_bytecode;
+                wasm.pc = maybe_return_address;
                 stp = maybe_return_stp;
 
                 current_sidetable = &store
@@ -148,67 +129,40 @@ pub(super) fn run<H: HookSet>(
                     .unwrap_validated()
                     .sidetable;
 
-                *current_module_idx = return_module;
                 trace!("Instruction: END");
             }
             IF => {
-                store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated();
+                wasm.read_var_u32().unwrap_validated();
 
                 let test_val: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 if test_val != 0 {
                     stp += 1;
                 } else {
-                    do_sidetable_control_transfer(
-                        &mut store.modules[current_wasm_index].wasm_reader,
-                        stack,
-                        &mut stp,
-                        current_sidetable,
-                    );
+                    do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
                 }
                 trace!("Instruction: IF");
             }
             ELSE => {
-                do_sidetable_control_transfer(
-                    &mut store.modules[current_wasm_index].wasm_reader,
-                    stack,
-                    &mut stp,
-                    current_sidetable,
-                );
-                trace!("Instruction: ELSE");
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             BR_IF => {
-                store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated();
+                wasm.read_var_u32().unwrap_validated();
 
                 let test_val: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 if test_val != 0 {
-                    do_sidetable_control_transfer(
-                        &mut store.modules[current_wasm_index].wasm_reader,
-                        stack,
-                        &mut stp,
-                        current_sidetable,
-                    );
+                    do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
                 } else {
                     stp += 1;
                 }
                 trace!("Instruction: BR_IF");
             }
             BR_TABLE => {
-                let wasm_reader = &mut store.modules[current_wasm_index].wasm_reader;
-                let label_vec = wasm_reader
+                let label_vec = wasm
                     .read_vec(|wasm| wasm.read_var_u32().map(|v| v as LabelIdx))
                     .unwrap_validated();
-                store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated();
+                wasm.read_var_u32().unwrap_validated();
 
                 // TODO is this correct?
                 let case_val_i32: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -220,70 +174,31 @@ pub(super) fn run<H: HookSet>(
                     stp += case_val;
                 }
 
-                do_sidetable_control_transfer(
-                    &mut store.modules[current_wasm_index].wasm_reader,
-                    stack,
-                    &mut stp,
-                    current_sidetable,
-                );
-                trace!("Instruction: BR_TABLE");
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             BR => {
                 //skip n of BR n
-                store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated();
-                do_sidetable_control_transfer(
-                    &mut store.modules[current_wasm_index].wasm_reader,
-                    stack,
-                    &mut stp,
-                    current_sidetable,
-                );
-                trace!("Instruction: BR");
+                wasm.read_var_u32().unwrap_validated();
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             BLOCK | LOOP => {
-                BlockType::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
-                trace!("Instruction: BLOCK/LOOP");
+                BlockType::read_unvalidated(wasm);
             }
             RETURN => {
                 //same as BR, except no need to skip n of BR n
-                do_sidetable_control_transfer(
-                    &mut store.modules[current_wasm_index].wasm_reader,
-                    stack,
-                    &mut stp,
-                    current_sidetable,
-                );
-                trace!("Instruction: RETURN");
+                do_sidetable_control_transfer(wasm, stack, &mut stp, current_sidetable);
             }
             CALL => {
-                let func_to_call_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as FuncIdx;
-
-                // let current_wasm_index_copy = current_wasm_index;
-                // *current_module_idx = actual_module_idx_of_this_func;
-                // current_wasm_index = actual_module_idx_of_this_func;
+                let func_to_call_idx = wasm.read_var_u32().unwrap_validated() as FuncIdx;
 
                 let func_to_call_global_idx =
-                    store.modules[current_wasm_index].functions[func_to_call_idx];
+                    store.modules[*current_module_idx].functions[func_to_call_idx];
 
                 let func_to_call_inst = store
                     .functions
                     .get(func_to_call_global_idx)
                     .unwrap_validated();
                 let func_to_call_ty = func_to_call_inst.ty();
-
-                // let func_to_call_inst = modules[*current_module_idx]
-                //     .store
-                //     .funcs
-                //     .get(func_to_call_idx)
-                //     .unwrap_validated();
-                // let func_to_call_ty = modules[*current_module_idx]
-                //     .fn_types
-                //     .get(func_to_call_inst.ty())
-                //     .unwrap_validated();
 
                 let params = stack.pop_tail_iter(func_to_call_ty.params.valtypes.len());
 
@@ -305,13 +220,11 @@ pub(super) fn run<H: HookSet>(
                                     func_to_call_idx,
                                     &func_to_call_ty,
                                     locals,
-                                    store.modules[current_wasm_index].wasm_reader.pc,
+                                    wasm.pc,
                                     stp,
                                 );
 
-                                store.modules[current_wasm_index]
-                                    .wasm_reader
-                                    .move_start_to(local_func_inst.code_expr)
+                                wasm.move_start_to(local_func_inst.code_expr)
                                     .unwrap_validated();
 
                                 stp = 0;
@@ -339,17 +252,14 @@ pub(super) fn run<H: HookSet>(
                                     func_to_call_idx,
                                     &func_to_call_ty,
                                     locals,
-                                    store.modules[current_wasm_index].wasm_reader.pc,
+                                    wasm.pc,
                                     stp,
                                 );
 
-                                current_wasm_index = next_module;
-                                // wasm = &mut modules[next_module].wasm_reader;
                                 *current_module_idx = next_module;
-
-                                store.modules[current_wasm_index]
-                                    .wasm_reader
-                                    .move_start_to(local_func_inst.code_expr)
+                                wasm.full_wasm_binary =
+                                    store.modules[*current_module_idx].wasm_bytecode;
+                                wasm.move_start_to(local_func_inst.code_expr)
                                     .unwrap_validated();
 
                                 stp = 0;
@@ -369,17 +279,10 @@ pub(super) fn run<H: HookSet>(
 
             // TODO: fix push_stackframe, because the func idx that you get from the table is global func idx
             CALL_INDIRECT => {
-                let given_type_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as TypeIdx;
-                let table_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as TableIdx;
+                let given_type_idx = wasm.read_var_u32().unwrap_validated() as TypeIdx;
+                let table_idx = wasm.read_var_u32().unwrap_validated() as TableIdx;
 
                 let tab = &store.tables[store.modules[*current_module_idx].tables[table_idx]];
-
                 let func_ty = store.modules[*current_module_idx]
                     .function_types
                     .get(given_type_idx)
@@ -434,13 +337,11 @@ pub(super) fn run<H: HookSet>(
                                     local_func_addr,
                                     func_ty,
                                     locals,
-                                    store.modules[current_wasm_index].wasm_reader.pc,
+                                    wasm.pc,
                                     stp,
                                 );
 
-                                store.modules[current_wasm_index]
-                                    .wasm_reader
-                                    .move_start_to(local_func_inst.code_expr)
+                                wasm.move_start_to(local_func_inst.code_expr)
                                     .unwrap_validated();
 
                                 stp = 0;
@@ -464,17 +365,13 @@ pub(super) fn run<H: HookSet>(
                                     local_func_addr,
                                     func_ty,
                                     locals,
-                                    store.modules[current_wasm_index].wasm_reader.pc,
+                                    wasm.pc,
                                     stp,
                                 );
-
-                                current_wasm_index = next_module;
-                                // wasm = &mut modules[next_module].wasm_reader;
                                 *current_module_idx = next_module;
-
-                                store.modules[current_wasm_index]
-                                    .wasm_reader
-                                    .move_start_to(local_func_inst.code_expr)
+                                wasm.full_wasm_binary =
+                                    store.modules[*current_module_idx].wasm_bytecode;
+                                wasm.move_start_to(local_func_inst.code_expr)
                                     .unwrap_validated();
 
                                 stp = 0;
@@ -505,10 +402,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: SELECT");
             }
             SELECT_T => {
-                let type_vec = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_vec(ValType::read)
-                    .unwrap_validated();
+                let type_vec = wasm.read_vec(ValType::read).unwrap_validated();
                 let test_val: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let val2 = stack.pop_value(type_vec[0]);
                 let val1 = stack.pop_value(type_vec[0]);
@@ -520,37 +414,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: SELECT_T");
             }
             LOCAL_GET => {
-                let local_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as LocalIdx;
+                let local_idx = wasm.read_var_u32().unwrap_validated() as LocalIdx;
                 stack.get_local(local_idx);
                 trace!("Instruction: local.get {} [] -> [t]", local_idx);
             }
-            LOCAL_SET => {
-                stack.set_local(
-                    store.modules[current_wasm_index]
-                        .wasm_reader
-                        .read_var_u32()
-                        .unwrap_validated() as LocalIdx,
-                );
-                trace!("Instruction: LOCAL_SET");
-            }
-            LOCAL_TEE => {
-                stack.tee_local(
-                    store.modules[current_wasm_index]
-                        .wasm_reader
-                        .read_var_u32()
-                        .unwrap_validated() as LocalIdx,
-                );
-                trace!("Instruction: LOCAL_TEE");
-            }
+            LOCAL_SET => stack.set_local(wasm.read_var_u32().unwrap_validated() as LocalIdx),
+            LOCAL_TEE => stack.tee_local(wasm.read_var_u32().unwrap_validated() as LocalIdx),
             GLOBAL_GET => {
-                let global_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as GlobalIdx;
-
+                let global_idx = wasm.read_var_u32().unwrap_validated() as GlobalIdx;
                 let global = &store.globals[store.modules[*current_module_idx].globals[global_idx]];
 
                 stack.push_value(global.value);
@@ -562,21 +433,14 @@ pub(super) fn run<H: HookSet>(
                 );
             }
             GLOBAL_SET => {
-                let global_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as GlobalIdx;
+                let global_idx = wasm.read_var_u32().unwrap_validated() as GlobalIdx;
                 let global =
                     &mut store.globals[store.modules[*current_module_idx].globals[global_idx]];
                 global.value = stack.pop_value(global.global.ty.ty);
                 trace!("Instruction: GLOBAL_SET");
             }
             TABLE_GET => {
-                let table_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as TableIdx;
-
+                let table_idx = wasm.read_var_u32().unwrap_validated() as TableIdx;
                 let tab = &store.tables[store.modules[*current_module_idx].tables[table_idx]];
 
                 let i: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -595,10 +459,7 @@ pub(super) fn run<H: HookSet>(
                 );
             }
             TABLE_SET => {
-                let table_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as TableIdx;
+                let table_idx = wasm.read_var_u32().unwrap_validated() as TableIdx;
 
                 let tab = &mut store.tables[store.modules[*current_module_idx].tables[table_idx]];
 
@@ -617,8 +478,7 @@ pub(super) fn run<H: HookSet>(
                 )
             }
             I32_LOAD => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem_inst = &store.memories[store.modules[*current_module_idx].memories[0]];
@@ -630,8 +490,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load [{relative_address}] -> [{data}]");
             }
             I64_LOAD => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -643,8 +502,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load [{relative_address}] -> [{data}]");
             }
             F32_LOAD => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -656,8 +514,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f32.load [{relative_address}] -> [{data}]");
             }
             F64_LOAD => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -669,8 +526,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f64.load [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_S => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -682,8 +538,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load8_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_U => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -695,8 +550,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load8_u [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_S => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -708,8 +562,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load16_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_U => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -721,8 +574,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_S => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -734,8 +586,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load8_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_U => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -747,8 +598,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load8_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_S => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -760,8 +610,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load16_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_U => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -773,8 +622,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_S => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -786,8 +634,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load32_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_U => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                 let mem = &store.memories[store.modules[*current_module_idx].memories[0]]; // there is only one memory allowed as of now
@@ -799,8 +646,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.load32_u [{relative_address}] -> [{data}]");
             }
             I32_STORE => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -813,8 +659,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.store [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: u64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -827,8 +672,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.store [{relative_address} {data_to_store}] -> []");
             }
             F32_STORE => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: f32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -841,8 +685,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f32.store [{relative_address} {data_to_store}] -> []");
             }
             F64_STORE => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: f64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -855,8 +698,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: f64.store [{relative_address} {data_to_store}] -> []");
             }
             I32_STORE8 => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -869,8 +711,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.store8 [{relative_address} {data_to_store}] -> []");
             }
             I32_STORE16 => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -883,8 +724,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i32.store16 [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE8 => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -897,8 +737,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.store8 [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE16 => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -911,8 +750,7 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.store16 [{relative_address} {data_to_store}] -> []");
             }
             I64_STORE32 => {
-                let memarg =
-                    MemArg::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let memarg = MemArg::read_unvalidated(wasm);
 
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -925,21 +763,14 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: i64.store32 [{relative_address} {data_to_store}] -> []");
             }
             MEMORY_SIZE => {
-                let mem_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_u8()
-                    .unwrap_validated() as usize;
+                let mem_idx = wasm.read_u8().unwrap_validated() as usize;
                 let mem = &mut store.memories[store.modules[*current_module_idx].memories[mem_idx]];
                 let size = mem.size() as u32;
                 stack.push_value(Value::I32(size));
                 trace!("Instruction: memory.size [] -> [{}]", size);
             }
             MEMORY_GROW => {
-                let mem_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_u8()
-                    .unwrap_validated() as usize;
-
+                let mem_idx = wasm.read_u8().unwrap_validated() as usize;
                 let mem = &mut store.memories[store.modules[*current_module_idx].memories[mem_idx]];
                 let delta: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
@@ -956,20 +787,12 @@ pub(super) fn run<H: HookSet>(
                 trace!("Instruction: memory.grow [{}] -> [{}]", delta, pushed_value);
             }
             I32_CONST => {
-                let constant = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_i32()
-                    .unwrap_validated();
+                let constant = wasm.read_var_i32().unwrap_validated();
                 trace!("Instruction: i32.const [] -> [{constant}]");
                 stack.push_value(constant.into());
             }
             F32_CONST => {
-                let constant = f32::from_bits(
-                    store.modules[current_wasm_index]
-                        .wasm_reader
-                        .read_var_f32()
-                        .unwrap_validated(),
-                );
+                let constant = f32::from_bits(wasm.read_var_f32().unwrap_validated());
                 trace!("Instruction: f32.const [] -> [{constant:.7}]");
                 stack.push_value(constant.into());
             }
@@ -1303,20 +1126,12 @@ pub(super) fn run<H: HookSet>(
                 stack.push_value(res.into());
             }
             I64_CONST => {
-                let constant = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_i64()
-                    .unwrap_validated();
+                let constant = wasm.read_var_i64().unwrap_validated();
                 trace!("Instruction: i64.const [] -> [{constant}]");
                 stack.push_value(constant.into());
             }
             F64_CONST => {
-                let constant = f64::from_bits(
-                    store.modules[current_wasm_index]
-                        .wasm_reader
-                        .read_var_f64()
-                        .unwrap_validated(),
-                );
+                let constant = f64::from_bits(wasm.read_var_f64().unwrap_validated());
                 trace!("Instruction: f64.const [] -> [{constant}]");
                 stack.push_value(constant.into());
             }
@@ -2131,8 +1946,7 @@ pub(super) fn run<H: HookSet>(
                 stack.push_value(res.into());
             }
             REF_NULL => {
-                let reftype =
-                    RefType::read_unvalidated(&mut store.modules[current_wasm_index].wasm_reader);
+                let reftype = RefType::read_unvalidated(wasm);
 
                 stack.push_value(Value::Ref(reftype.to_null_ref()));
                 trace!("Instruction: ref.null '{:?}' -> [{:?}]", reftype, reftype);
@@ -2150,27 +1964,12 @@ pub(super) fn run<H: HookSet>(
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-ref-mathsf-ref-func-x
             REF_FUNC => {
-                let func_idx = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_var_u32()
-                    .unwrap_validated() as FuncIdx;
+                let func_idx = wasm.read_var_u32().unwrap_validated() as FuncIdx;
                 stack.push_value(Value::Ref(Ref::Func(FuncAddr::new(Some(func_idx)))));
             }
             FC_EXTENSIONS => {
                 // Should we call instruction hook here as well? Multibyte instruction
-                let second_instr_byte = store.modules[current_wasm_index]
-                    .wasm_reader
-                    .read_u8()
-                    .unwrap_validated();
-
-                #[cfg(debug_assertions)]
-                crate::core::utils::print_beautiful_fc_extension(
-                    second_instr_byte,
-                    store.modules[current_wasm_index].wasm_reader.pc,
-                );
-
-                #[cfg(not(debug_assertions))]
-                trace!("Read instruction byte {second_instr_byte:#04X?} ({second_instr_byte}) at wasm_binary[{}]", store.modules[current_wasm_index].wasm_reader.pc);
+                let second_instr_byte = wasm.read_u8().unwrap_validated();
 
                 use crate::core::reader::types::opcode::fc_extensions::*;
                 match second_instr_byte {
@@ -2309,16 +2108,8 @@ pub(super) fn run<H: HookSet>(
                         //      n => number of bytes to copy
                         //      s => starting pointer in the data segment
                         //      d => destination address to copy to
-                        let data_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as DataIdx;
-
-                        let mem_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_u8()
-                            .unwrap_validated() as usize;
-
+                        let data_idx = wasm.read_var_u32().unwrap_validated() as DataIdx;
+                        let mem_idx = wasm.read_u8().unwrap_validated() as usize;
                         let mem =
                             &store.memories[store.modules[*current_module_idx].memories[mem_idx]];
                         let n: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -2342,11 +2133,7 @@ pub(super) fn run<H: HookSet>(
                         // data segment is passive or active
 
                         // Also, we should set data to null here (empty), which we do using an empty init vec
-                        let data_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as DataIdx;
-
+                        let data_idx = wasm.read_var_u32().unwrap_validated() as DataIdx;
                         store.data[store.modules[*current_module_idx].data[data_idx]] =
                             DataInst { data: Vec::new() };
                     }
@@ -2356,24 +2143,18 @@ pub(super) fn run<H: HookSet>(
                         //      n => number of bytes to copy
                         //      s => source address to copy from
                         //      d => destination address to copy to
-                        let (dst, src) = (
-                            store.modules[current_wasm_index]
-                                .wasm_reader
-                                .read_u8()
-                                .unwrap_validated() as usize,
-                            store.modules[current_wasm_index]
-                                .wasm_reader
-                                .read_u8()
-                                .unwrap_validated() as usize,
+                        let (dst_idx, src_idx) = (
+                            wasm.read_u8().unwrap_validated() as usize,
+                            wasm.read_u8().unwrap_validated() as usize,
                         );
                         let n: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                         let s: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                         let d: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
                         let src_mem =
-                            &store.memories[store.modules[*current_module_idx].memories[src]];
+                            &store.memories[store.modules[*current_module_idx].memories[src_idx]];
                         let dest_mem =
-                            &store.memories[store.modules[*current_module_idx].memories[dst]];
+                            &store.memories[store.modules[*current_module_idx].memories[dst_idx]];
 
                         dest_mem
                             .mem
@@ -2386,11 +2167,7 @@ pub(super) fn run<H: HookSet>(
                         //      n => number of bytes to update
                         //      val => the value to set each byte to (must be < 256)
                         //      d => the pointer to the region to update
-                        let mem_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_u8()
-                            .unwrap_validated() as usize;
-
+                        let mem_idx = wasm.read_u8().unwrap_validated() as usize;
                         let mem = &mut store.memories
                             [store.modules[*current_module_idx].memories[mem_idx]];
                         let n: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
@@ -2411,14 +2188,8 @@ pub(super) fn run<H: HookSet>(
                     // in binary format it seems that elemidx is first ???????
                     // this is ONLY for passive elements
                     TABLE_INIT => {
-                        let elem_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
-                        let table_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
+                        let elem_idx = wasm.read_var_u32().unwrap_validated() as usize;
+                        let table_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
                         let n: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into(); // size
                         let s: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into(); // offset
@@ -2468,10 +2239,7 @@ pub(super) fn run<H: HookSet>(
                         dest[..src.len()].copy_from_slice(src);
                     }
                     ELEM_DROP => {
-                        let elem_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
+                        let elem_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
                         // WARN: i'm not sure if this is okay or not
                         store.elements[store.modules[*current_module_idx].elements[elem_idx]]
@@ -2479,14 +2247,8 @@ pub(super) fn run<H: HookSet>(
                     }
                     // https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-copy-x-y
                     TABLE_COPY => {
-                        let table_x_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
-                        let table_y_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
+                        let table_x_idx = wasm.read_var_u32().unwrap_validated() as usize;
+                        let table_y_idx = wasm.read_var_u32().unwrap_validated() as usize;
 
                         let tab_x_elem_len = store.tables
                             [store.modules[*current_module_idx].tables[table_x_idx]]
@@ -2561,11 +2323,7 @@ pub(super) fn run<H: HookSet>(
                         );
                     }
                     TABLE_GROW => {
-                        let table_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
-
+                        let table_idx = wasm.read_var_u32().unwrap_validated() as usize;
                         let tab =
                             &mut store.tables[store.modules[*current_module_idx].tables[table_idx]];
 
@@ -2592,11 +2350,7 @@ pub(super) fn run<H: HookSet>(
                         }
                     }
                     TABLE_SIZE => {
-                        let table_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
-
+                        let table_idx = wasm.read_var_u32().unwrap_validated() as usize;
                         let tab =
                             &mut store.tables[store.modules[*current_module_idx].tables[table_idx]];
 
@@ -2607,11 +2361,7 @@ pub(super) fn run<H: HookSet>(
                         trace!("Instruction: table.size '{}' [] -> [{}]", table_idx, sz);
                     }
                     TABLE_FILL => {
-                        let table_idx = store.modules[current_wasm_index]
-                            .wasm_reader
-                            .read_var_u32()
-                            .unwrap_validated() as usize;
-
+                        let table_idx = wasm.read_var_u32().unwrap_validated() as usize;
                         let tab =
                             &mut store.tables[store.modules[*current_module_idx].tables[table_idx]];
                         let ty = tab.ty.et;
@@ -2727,6 +2477,7 @@ pub(super) fn run<H: HookSet>(
 
                 trace!("Instruction i64.extend32_s [{}] -> [{}]", v, res);
             }
+
             other => {
                 trace!("Unknown instruction {other:#x}, skipping..");
             }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -196,7 +196,7 @@ where
         let mut stack = Stack::new();
         let locals = Locals::new(
             params.into_values().into_iter(),
-            func_inst.try_into_local().unwrap().locals.iter().cloned(),
+            func_inst.locals.iter().cloned(),
         );
 
         // setting `usize::MAX` as return address for the outermost function ensures that we
@@ -283,10 +283,7 @@ where
 
         // Prepare a new stack with the locals for the entry function
         let mut stack = Stack::new();
-        let locals = Locals::new(
-            params.into_iter(),
-            func_inst.try_into_local().unwrap().locals.iter().cloned(),
-        );
+        let locals = Locals::new(params.into_iter(), func_inst.locals.iter().cloned());
         stack.push_stackframe(module_idx, func_idx, &func_ty, locals, 0, 0);
 
         let mut currrent_module_idx = module_idx;
@@ -380,10 +377,7 @@ where
 
         // Prepare a new stack with the locals for the entry function
         let mut stack = Stack::new();
-        let locals = Locals::new(
-            params.into_iter(),
-            func_inst.try_into_local().unwrap().locals.iter().cloned(),
-        );
+        let locals = Locals::new(params.into_iter(), func_inst.locals.iter().cloned());
         stack.push_stackframe(module_idx, func_idx, &func_ty, locals, 0, 0);
 
         let mut currrent_module_idx = module_idx;

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -250,7 +250,6 @@ impl<'b> Store<'b> {
         let execution_info = ExecutionInfo {
             name: name.clone(),
             wasm_bytecode: module.wasm,
-            wasm_reader: WasmReader::new(module.wasm),
 
             functions: exec_functions,
             functions_offset,

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -12,7 +12,6 @@ use crate::core::reader::types::global::Global;
 use crate::core::reader::types::import::{Import, ImportDesc};
 use crate::core::reader::types::{check_limits, FuncType, MemType, TableType, ValType};
 use crate::core::reader::WasmReader;
-use crate::core::sidetable::Sidetable;
 use crate::execution::value::{Ref, Value};
 use crate::execution::{get_address_offset, run_const, run_const_span, Stack};
 use crate::value::{ExternAddr, FuncAddr};
@@ -249,6 +248,8 @@ impl<'b> Store<'b> {
         let execution_info = ExecutionInfo {
             name: name.clone(),
             wasm_bytecode: module.wasm,
+            //TODO make this a ref
+            sidetable: module.sidetable.clone(),
 
             functions: exec_functions,
             functions_offset,
@@ -732,11 +733,11 @@ impl ValidationInfo<'_> {
         let mut wasm_reader = WasmReader::new(self.wasm);
 
         let functions = self.functions.iter();
-        let func_blocks = self.func_blocks.iter();
+        let func_blocks_stps = self.func_blocks_stps.iter();
 
         Ok(functions
-            .zip(func_blocks)
-            .map(|(ty, (func, sidetable))| {
+            .zip(func_blocks_stps)
+            .map(|(ty, (func, stp))| {
                 wasm_reader
                     .move_start_to(*func)
                     .expect("function index to be in the bounds of the WASM binary");
@@ -753,8 +754,7 @@ impl ValidationInfo<'_> {
                     ty: *ty,
                     locals,
                     code_expr,
-                    // TODO figure out where we want our sidetables
-                    sidetable: sidetable.clone(),
+                    stp: *stp,
                     function_type: self.types[*ty].clone(),
                 }
             })
@@ -1063,7 +1063,8 @@ pub struct FuncInst {
     pub ty: TypeIdx,
     pub locals: Vec<ValType>,
     pub code_expr: Span,
-    pub sidetable: Sidetable,
+    ///index of the sidetable corresponding to the beginning of this functions code
+    pub stp: usize,
     pub function_type: FuncType,
 }
 

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -30,11 +30,10 @@ pub fn validate_code_section(
     tables: &[TableType],
     elements: &[ElemType],
     referenced_functions: &BTreeSet<u32>,
-) -> Result<Vec<(Span, Sidetable)>> {
+    sidetable: &mut Sidetable,
+) -> Result<Vec<(Span, usize)>> {
     assert_eq!(section_header.ty, SectionTy::Code);
-
-    // TODO replace with single sidetable per module
-    let code_block_spans_sidetables = wasm.read_vec_enumerated(|wasm, idx| {
+    let code_block_spans_stps = wasm.read_vec_enumerated(|wasm, idx| {
         // We need to offset the index by the number of functions that were
         // imported. Imported functions always live at the start of the index
         // space.
@@ -52,12 +51,12 @@ pub fn validate_code_section(
         };
 
         let mut stack = ValidationStack::new_for_func(func_ty);
-        let mut sidetable: Sidetable = Sidetable::default();
+        let stp = sidetable.len();
 
         read_instructions(
             wasm,
             &mut stack,
-            &mut sidetable,
+            sidetable,
             &locals,
             globals,
             fn_types,
@@ -76,15 +75,15 @@ pub fn validate_code_section(
             )
         }
 
-        Ok((func_block, sidetable))
+        Ok((func_block, stp))
     })?;
 
     trace!(
         "Read code section. Found {} code blocks",
-        code_block_spans_sidetables.len()
+        code_block_spans_stps.len()
     );
 
-    Ok(code_block_spans_sidetables)
+    Ok(code_block_spans_stps)
 }
 
 pub fn read_declared_locals(wasm: &mut WasmReader) -> Result<Vec<ValType>> {


### PR DESCRIPTION
I checked the reference interpreter and each AssertUnlinkable directive in the .wast files. It seems AssertUnlinkable only checks for two exceptions. Eval.Link and Import.Unknown:
https://github.com/WebAssembly/spec/blob/05949f507908aac3ad2a21661b5c39fa013da950/interpreter/script/run.ml#L472

which are only thrown when:
- there is no such import
- there is a type mismatch

https://github.com/WebAssembly/spec/blob/05949f507908aac3ad2a21661b5c39fa013da950/interpreter/script/import.ml#L17
https://github.com/WebAssembly/spec/blob/05949f507908aac3ad2a21661b5c39fa013da950/interpreter/exec/eval.ml#L732
https://github.com/WebAssembly/spec/blob/05949f507908aac3ad2a21661b5c39fa013da950/interpreter/exec/eval.ml#L788

These checks do not alter the store. Therefore no need for CleanupStore :)
Though I think even though it sounds prepostrous, we might need to be able to copy the entire store. For tests, at least, since if there is an erroneous test altering store state we need to revert somehow.

Finally in the future, for initialization order, we might want to refer to this:
https://webassembly.github.io/spec/core/exec/modules.html#instantiation

Item 11 seems small but it actually expands to https://webassembly.github.io/spec/core/exec/modules.html#alloc-module