### PR TITLE
Rename moduleinst fields

### DIFF
--- a/src/execution/const_interpreter_loop.rs
+++ b/src/execution/const_interpreter_loop.rs
@@ -45,7 +45,7 @@ pub(crate) fn run_const(
                 let global_idx = wasm.read_var_u32().unwrap_validated() as GlobalIdx;
 
                 //TODO replace double indirection
-                let global = &store.globals[module.globals[global_idx]];
+                let global = &store.globals[module.global_addrs[global_idx]];
 
                 trace!(
                     "Constant instruction: global.get [{global_idx}] -> [{:?}]",
@@ -196,7 +196,7 @@ pub(crate) fn run_const(
                 let func_idx = wasm.read_var_u32().unwrap_validated() as usize;
                 // TODO replace double indirection
                 stack.push_value(Value::Ref(Ref::Func(FuncAddr::new(Some(
-                    module.functions[func_idx],
+                    module.func_addrs[func_idx],
                 )))));
             }
             other => {

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -112,7 +112,7 @@ where
             .get(module_addr)
             .ok_or(RuntimeError::ModuleNotFound)?;
         let func_addr = *module_inst
-            .functions
+            .func_addrs
             .get(function_idx)
             .ok_or(RuntimeError::FunctionNotFound)?;
 
@@ -138,7 +138,7 @@ where
 
         // TODO handle this bad linear search that is unavoidable
         let (func_idx, _) = store.modules[module_addr]
-            .functions
+            .func_addrs
             .iter()
             .enumerate()
             .find(|&(_idx, addr)| *addr == func_addr)
@@ -220,7 +220,7 @@ where
 
         // TODO handle this bad linear search that is unavoidable
         let (func_idx, _) = store.modules[module_addr]
-            .functions
+            .func_addrs
             .iter()
             .enumerate()
             .find(|&(_idx, addr)| *addr == func_addr)
@@ -302,7 +302,7 @@ where
 
         // TODO handle this bad linear search that is unavoidable
         let (func_idx, _) = store.modules[module_addr]
-            .functions
+            .func_addrs
             .iter()
             .enumerate()
             .find(|&(_idx, addr)| *addr == func_addr)


### PR DESCRIPTION
- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
