### PR TITLE
wasm testsuite bug hunt

### DIFF
--- a/.github/workflows/testsuite_preview.yaml
+++ b/.github/workflows/testsuite_preview.yaml
@@ -93,7 +93,7 @@ jobs:
           name: head-report
 
       - name: Compare reports
-        run: cargo run --manifest-path ci-tools/compare-testsuite-rs/Cargo.toml -- old.json new.json > testsuite_report.md
+        run: cargo run --package=compare-testsuite-rs -- old.json new.json > testsuite_report.md
 
       - name: Sticky Pull Request Comment
         uses: marocchino/sticky-pull-request-comment@v2.9.1

--- a/src/core/reader/types/import.rs
+++ b/src/core/reader/types/import.rs
@@ -96,11 +96,10 @@ impl ImportDesc {
     ///<https://webassembly.github.io/spec/core/valid/modules.html#imports>
     pub fn extern_type(&self, validation_info: &ValidationInfo) -> Result<ExternType> {
         Ok(match self {
-            ImportDesc::Func(func_idx) => {
-                let type_idx = validation_info
-                    .functions
-                    .get(*func_idx)
-                    .ok_or(Error::InvalidFuncTypeIdx)?;
+            ImportDesc::Func(type_idx) => {
+                // unlike ExportDescs, these directly refer to the types section
+                // since a corresponding function entry in function section or body
+                // in code section does not exist for these
                 let func_type = validation_info
                     .types
                     .get(*type_idx)

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -376,7 +376,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
         wasm: wasm.into_inner(),
         types,
         imports,
-        functions: all_functions,
+        functions: local_functions,
         tables,
         memories,
         globals,


### PR DESCRIPTION
### Pull Request Overview
This PR fixes various errors with the official wasm testsuite

- ImportDesc externtype lookup for functions was done from function section of the bytecode, but it should have been the types section. This issue was erroneously treated before.
- Call instruction was fixed, it pushed incorrect local idx of the function if it was imported

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`
