### PR TITLE
Remove unneccesary unicode validation in testsuite file traversal

### DIFF
--- a/tests/specification/files.rs
+++ b/tests/specification/files.rs
@@ -23,10 +23,6 @@ fn find_files_filtered(
     base_path: &Path,
     mut filter: impl FnMut(&Path, &Metadata) -> bool,
 ) -> std::io::Result<Vec<PathBuf>> {
-    let base_path = base_path
-        .to_str()
-        .expect("path to contain valid unicode, which is required by glob");
-
     let mut paths = vec![];
 
     // The stack containing all directories we still have to traverse. At first contains only the base directory.


### PR DESCRIPTION
- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
