### PR TITLE
feat: add testsuite runner debugging options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "envconfig"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1d02ec9fdd0a585580bdc8fb7ad01675eee5e3b7336cedbabe3aab4a026dbc"
+dependencies = [
+ "envconfig_derive",
+]
+
+[[package]]
+name = "envconfig_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4291f0c7220b67ad15e9d5300ba2f215cee504f0924d60e77c9d1c77e7a69b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,10 +968,13 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "env_logger 0.10.2",
+ "envconfig",
  "hexf",
  "itertools 0.14.0",
+ "lazy_static",
  "libm",
  "log",
+ "regex",
  "serde",
  "serde_json",
  "test-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ serde_json = { workspace = true }
 test-log = { workspace = true, features = ["log"] }
 wast = "212.0.0"
 wat = { workspace = true }
+regex = "1.11.1"
+envconfig = "0.11.0"
+lazy_static = "1.5.0"
 
 [features]
 default = ["hooks"]

--- a/tests/specification/files.rs
+++ b/tests/specification/files.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 
 pub fn find_wast_files(
     base_path: &Path,
-    mut file_name_filter: impl FnMut(&OsStr) -> bool,
+    mut file_name_filter: impl FnMut(&str) -> bool,
 ) -> std::io::Result<Vec<PathBuf>> {
     find_files_filtered(base_path, |path, meta| {
-        let Some(file_name) = path.file_name() else {
+        let Some(file_name) = path.file_name().and_then(OsStr::to_str) else {
             return false;
         };
 


### PR DESCRIPTION
During debugging this allows to configure the testsuite runner to only run a single `wast` test or re-enable the panic hook, so that panic information is printed by the interpreter

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
