### PR TITLE
fix: failure in global.wast spec test

### DIFF
--- a/tests/specification/run.rs
+++ b/tests/specification/run.rs
@@ -718,6 +718,12 @@ fn result_to_value(result: wast::WastRet) -> Result<Value, Box<dyn Error>> {
                     return Err(GenericError::new_boxed("RefFuncs not yet implemented"));
                 }
             },
+            WastRetCore::RefExtern(None) => unreachable!("Expected a non-null extern reference"),
+            WastRetCore::RefExtern(Some(index)) => {
+                Value::Ref(wasm::value::Ref::Extern(wasm::value::ExternAddr {
+                    addr: Some(index as usize),
+                }))
+            }
             other => {
                 return Err(Box::new(GenericError::new(&format!(
                     "handling of wast ret type {other:?} not yet implemented"


### PR DESCRIPTION
### Pull Request Overview

Make `global.wast` spec test pass.

### TODO or Help Wanted

I'm not so sure about what I'm doing there in the test runner, keen look would be welcome.

### Checks

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
