### PR TITLE
fix: polymorphic select validation

### DIFF
--- a/src/core/reader/types/opcode.rs
+++ b/src/core/reader/types/opcode.rs
@@ -419,6 +419,7 @@ pub fn opcode_byte_to_str(byte: u8) -> alloc::string::String {
         F32_REINTERPRET_I32 => "F32_REINTERPRET_I32",
         F64_REINTERPRET_I64 => "F64_REINTERPRET_I64",
         REF_NULL => "REF_NULL",
+        REF_IS_NULL => "REF_IS_NULL",
         REF_FUNC => "REF_FUNC",
         FC_EXTENSIONS => "FC_EXTENSIONS",
         I32_EXTEND8_S => "I32_EXTEND8_S",


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the polymorphic select instruction's validation, the previous one was too tight in unifying the type variable on top of the stack. Some names were also changed to better match with the spec.

The unreached-valid test actually validated the test containing a ref.is_null after a polymorphic select, but failed to validate a subsequent module #186 (that's why the test results seem not to have changed) The PR originally aimed to fix that issue as well but that one turned out to require some heavy changes, so I am excluding it for now.

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
