### PR TITLE
fix: table import subtyping rule

### DIFF
--- a/src/core/reader/types/mod.rs
+++ b/src/core/reader/types/mod.rs
@@ -481,6 +481,7 @@ impl ImportSubTypeRelation for ExternType {
             ExternType::Table(self_table_type) => match other {
                 ExternType::Table(other_table_type) => {
                     self_table_type.lim.is_subtype_of(&other_table_type.lim)
+                        && self_table_type.et == other_table_type.et
                 }
                 _ => false,
             },


### PR DESCRIPTION
### Pull Request Overview

fixes overlooked implementation error on import subtyping for tables.

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
