### PR TITLE
fix: validation stack should contain a single type for const exprs

### DIFF
--- a/src/core/reader/types/element.rs
+++ b/src/core/reader/types/element.rs
@@ -132,7 +132,7 @@ impl ElemType {
                 //     },
                 // };
 
-                valid_stack.assert_pop_val_type(super::ValType::NumType(super::NumType::I32))?;
+                valid_stack.assert_val_types(&[super::ValType::NumType(super::NumType::I32)])?;
 
                 ElemMode::Active(ActiveElem {
                     table_idx,
@@ -172,6 +172,11 @@ impl ElemType {
                             Some(functions),
                         );
 
+                        // if there are multiple types on the stack, it is invalid
+                        if valid_stack.len() != 1 {
+                            // TODO fix error type
+                            return Err(Error::InvalidValidationStackValType(None));
+                        }
                         use crate::validation_stack::ValidationStackEntry::*;
 
                         if let Some(val) = valid_stack.peek_const_validation_stack() {

--- a/src/validation/data.rs
+++ b/src/validation/data.rs
@@ -38,7 +38,7 @@ pub(super) fn validate_data_section(
                     read_constant_expression(wasm, &mut valid_stack, imported_global_types, None)?
                 };
 
-                valid_stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+                valid_stack.assert_val_types(&[ValType::NumType(NumType::I32)])?;
 
                 let byte_vec = wasm.read_vec(|el| el.read_u8())?;
 
@@ -77,7 +77,7 @@ pub(super) fn validate_data_section(
                     read_constant_expression(wasm, &mut valid_stack, imported_global_types, None)?
                 };
 
-                valid_stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+                valid_stack.assert_val_types(&[ValType::NumType(NumType::I32)])?;
 
                 let byte_vec = wasm.read_vec(|el| el.read_u8())?;
 

--- a/src/validation/validation_stack.rs
+++ b/src/validation/validation_stack.rs
@@ -234,7 +234,7 @@ impl ValidationStack {
     ///
     /// - `Ok(())` if all expected valtypes were found
     /// - `Err(_)` otherwise
-    pub(super) fn assert_val_types(&mut self, expected_val_types: &[ValType]) -> Result<()> {
+    pub fn assert_val_types(&mut self, expected_val_types: &[ValType]) -> Result<()> {
         ValidationStack::assert_val_types_with_custom_stacks(
             &mut self.stack,
             &self.ctrl_stack,


### PR DESCRIPTION
### Pull Request Overview

incorrect data/element segment type checks

### TODO or Help Wanted

~~write tests that are missing from official suite~~ they already exist in elem.wast

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
