### PR TITLE
quick fix: funcref validation, elem parser bounds check

### DIFF
--- a/src/core/reader/types/element.rs
+++ b/src/core/reader/types/element.rs
@@ -1,5 +1,6 @@
 use super::global::GlobalType;
 use super::RefType;
+use crate::core::indices::FuncIdx;
 use crate::core::reader::span::Span;
 use crate::core::reader::WasmReader;
 use crate::read_constant_expression::read_constant_expression;
@@ -50,7 +51,7 @@ impl ElemType {
     pub fn read_from_wasm(
         wasm: &mut WasmReader,
         functions: &[usize],
-        referenced_functions: &mut BTreeSet<u32>,
+        validation_context_refs: &mut BTreeSet<FuncIdx>,
         tables_length: usize,
         all_globals_types: &[GlobalType],
     ) -> Result<Vec<Self>> {
@@ -71,6 +72,11 @@ impl ElemType {
             // NOTE: This assert breaks my rustfmt :(
             // assert!(prop <= 0b111, "Element section is not encoded correctly. The type of this element is over 7 (0b111)");
 
+            // TODO fix error
+            if prop > 7 {
+                return Err(Error::InvalidSectionType(9));
+            };
+
             let elem_mode = if prop & 0b011 == 0b011 {
                 ElemMode::Declarative
             } else if prop & 0b001 == 0b001 {
@@ -88,11 +94,11 @@ impl ElemType {
 
                 let mut valid_stack = ValidationStack::new();
                 // let wasm_pc = wasm.pc;
-                let init_expr = read_constant_expression(
+                let (init_expr, _) = read_constant_expression(
                     wasm,
                     &mut valid_stack,
                     all_globals_types,
-                    Some(functions),
+                    functions.len(),
                 )?;
 
                 // at validation time we actually have to check for the function to be known
@@ -165,12 +171,14 @@ impl ElemType {
                     reftype_or_elemkind.unwrap_or(RefType::FuncRef),
                     wasm.read_vec(|w| {
                         let mut valid_stack = ValidationStack::new();
-                        let span = read_constant_expression(
+                        let (span, seen_func_refs) = read_constant_expression(
                             w,
                             &mut valid_stack,
                             all_globals_types,
-                            Some(functions),
-                        );
+                            functions.len(),
+                        )?;
+
+                        validation_context_refs.extend(seen_func_refs);
 
                         // if there are multiple types on the stack, it is invalid
                         if valid_stack.len() != 1 {
@@ -198,14 +206,14 @@ impl ElemType {
                             return Err(Error::InvalidValidationStackValType(None));
                         }
 
-                        span
+                        Ok(span)
                     })?,
                 )
             } else {
                 assert!(reftype_or_elemkind.is_none());
                 ElemItems::RefFuncs(wasm.read_vec(|w| {
                     let offset = w.read_var_u32()?;
-                    referenced_functions.insert(offset);
+                    validation_context_refs.insert(offset as FuncIdx);
                     Ok(offset)
                 })?)
             };

--- a/src/validation/data.rs
+++ b/src/validation/data.rs
@@ -23,6 +23,7 @@ pub(super) fn validate_data_section(
     section_header: SectionHeader,
     imported_global_types: &[GlobalType],
     no_of_total_memories: usize,
+    num_funcs: usize,
 ) -> Result<Vec<DataSegment>> {
     assert_eq!(section_header.ty, SectionTy::Data);
 
@@ -34,8 +35,13 @@ pub(super) fn validate_data_section(
                 // active { memory 0, offset e }
                 trace!("Data section: active {{ memory 0, offset e }}");
                 let mut valid_stack = ValidationStack::new();
-                let offset = {
-                    read_constant_expression(wasm, &mut valid_stack, imported_global_types, None)?
+                let (offset, _) = {
+                    read_constant_expression(
+                        wasm,
+                        &mut valid_stack,
+                        imported_global_types,
+                        num_funcs,
+                    )?
                 };
 
                 valid_stack.assert_val_types(&[ValType::NumType(NumType::I32)])?;
@@ -73,8 +79,13 @@ pub(super) fn validate_data_section(
                 );
 
                 let mut valid_stack = ValidationStack::new();
-                let offset = {
-                    read_constant_expression(wasm, &mut valid_stack, imported_global_types, None)?
+                let (offset, _) = {
+                    read_constant_expression(
+                        wasm,
+                        &mut valid_stack,
+                        imported_global_types,
+                        num_funcs,
+                    )?
                 };
 
                 valid_stack.assert_val_types(&[ValType::NumType(NumType::I32)])?;

--- a/src/validation/globals.rs
+++ b/src/validation/globals.rs
@@ -1,5 +1,7 @@
+use alloc::collections::btree_set::BTreeSet;
 use alloc::vec::Vec;
 
+use crate::core::indices::FuncIdx;
 use crate::core::reader::section_header::{SectionHeader, SectionTy};
 use crate::core::reader::types::global::{Global, GlobalType};
 use crate::core::reader::{WasmReadable, WasmReader};
@@ -17,15 +19,19 @@ pub(super) fn validate_global_section(
     wasm: &mut WasmReader,
     section_header: SectionHeader,
     imported_global_types: &[GlobalType],
+    validation_context_refs: &mut BTreeSet<FuncIdx>,
+    num_funcs: usize,
 ) -> Result<Vec<Global>> {
     assert_eq!(section_header.ty, SectionTy::Global);
 
     wasm.read_vec(|wasm| {
         let ty = GlobalType::read(wasm)?;
         let stack = &mut ValidationStack::new();
-        let init_expr = read_constant_expression(wasm, stack, imported_global_types, None)?;
+        let (init_expr, seen_func_idxs) =
+            read_constant_expression(wasm, stack, imported_global_types, num_funcs)?;
 
         stack.assert_val_types(&[ty.ty])?;
+        validation_context_refs.extend(seen_func_idxs);
 
         Ok(Global { ty, init_expr })
     })

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,4 +1,4 @@
-use alloc::collections::btree_set;
+use alloc::collections::btree_set::{self, BTreeSet};
 use alloc::vec::Vec;
 
 use crate::core::indices::{FuncIdx, TypeIdx};
@@ -12,7 +12,7 @@ use crate::core::reader::types::import::{Import, ImportDesc};
 use crate::core::reader::types::{FuncType, MemType, TableType};
 use crate::core::reader::{WasmReadable, WasmReader};
 use crate::core::sidetable::Sidetable;
-use crate::{Error, Result};
+use crate::{Error, ExportDesc, Result};
 
 pub(crate) mod code;
 pub(crate) mod data;
@@ -118,6 +118,18 @@ fn get_imports_length(imports: &Vec<Import>) -> ImportsLength {
 
 pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
     let mut wasm = WasmReader::new(wasm);
+
+    // represents C.refs in https://webassembly.github.io/spec/core/valid/conventions.html#context
+    // A func.ref instruction is onlv valid if it has an immediate that is a member of C.refs.
+    // this list holds all the func_idx's occurring in the module, except in its functions or start function.
+    // I make an exception here by not including func_idx's occuring within data segments in C.refs as well, so that single pass validation is possible.
+    // If there is a func_idx within the data segment, this would ultimately mean that data segment cannot be validated,
+    // therefore this hack is acceptable.
+    // https://webassembly.github.io/spec/core/valid/modules.html#data-segments
+    // https://webassembly.github.io/spec/core/valid/modules.html#valid-module
+
+    let mut validation_context_refs: BTreeSet<FuncIdx> = BTreeSet::new();
+
     trace!("Starting validation of bytecode");
 
     trace!("Validating magic value");
@@ -264,7 +276,13 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
         .collect::<Vec<GlobalType>>();
     let imported_global_types_len = imported_global_types.len();
     let globals = handle_section(&mut wasm, &mut header, SectionTy::Global, |wasm, h| {
-        globals::validate_global_section(wasm, h, &imported_global_types)
+        globals::validate_global_section(
+            wasm,
+            h,
+            &imported_global_types,
+            &mut validation_context_refs,
+            all_functions.len(),
+        )
     })?
     .unwrap_or_default();
     let mut all_globals = Vec::new();
@@ -288,6 +306,12 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
         wasm.read_vec(Export::read)
     })?
     .unwrap_or_default();
+    validation_context_refs.extend(exports.iter().filter_map(
+        |Export { name: _, desc }| match *desc {
+            ExportDesc::FuncIdx(func_idx) => Some(func_idx),
+            _ => None,
+        },
+    ));
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
@@ -297,13 +321,12 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
-    let mut referenced_functions = btree_set::BTreeSet::new();
     let elements: Vec<ElemType> =
         handle_section(&mut wasm, &mut header, SectionTy::Element, |wasm, _| {
             ElemType::read_from_wasm(
                 wasm,
                 &all_functions,
-                &mut referenced_functions,
+                &mut validation_context_refs,
                 all_tables.len(),
                 all_globals_types,
             )
@@ -339,7 +362,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
             &data_count,
             &all_tables,
             &elements,
-            &referenced_functions,
+            &validation_context_refs,
             &mut sidetable,
         )
     })?
@@ -355,7 +378,13 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
 
     let data_section = handle_section(&mut wasm, &mut header, SectionTy::Data, |wasm, h| {
         // wasm.read_vec(DataSegment::read)
-        data::validate_data_section(wasm, h, &imported_global_types, all_memories.len())
+        data::validate_data_section(
+            wasm,
+            h,
+            &imported_global_types,
+            all_memories.len(),
+            all_functions.len(),
+        )
     })?
     .unwrap_or_default();
 


### PR DESCRIPTION
### Pull Request Overview

Another tech debt accumulating fix. A prettier fix is refactoring the entire validation code, following a private validation context struct and steps specified here:  https://webassembly.github.io/spec/core/valid/modules.html#valid-module

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
