### PR TITLE
fix: custom section names always have to be parsed

### DIFF
--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -141,10 +141,6 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo> {
             // custom ::= name byte*
             // name ::= b*:vec(byte) => name (if utf8(name) = b*)
             // vec(B) ::= n:u32 (x:B)^n => x^n
-
-            if h.contents.len() == 0 {
-                return Ok(());
-            }
             let _name = wasm.read_name()?;
 
             let remaining_bytes = match h


### PR DESCRIPTION
### Pull Request Overview

names in the custom sections always have to be parsed, and they should throw an error if that is not possible.
see https://github.com/WebAssembly/spec/issues/1122

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
