### PR TITLE
fix: remove non const instrs from validation and const evaluation

### DIFF
--- a/src/execution/const_interpreter_loop.rs
+++ b/src/execution/const_interpreter_loop.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     value::{self, FuncAddr, Ref},
     value_stack::Stack,
-    ModuleInst, NumType, RefType, Store, ValType, Value,
+    ModuleInst, RefType, Store, Value,
 };
 
 // TODO update this documentation
@@ -68,122 +68,10 @@ pub(crate) fn run_const(
                 trace!("Constanting instruction: f64.const [] -> [{constant}]");
                 stack.push_value(constant.into());
             }
-            I32_ADD => {
-                let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
-                let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
-                let res = v1.wrapping_add(v2);
-
-                trace!("Constant instruction: i32.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            I32_SUB => {
-                let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
-                let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
-                let res = v1.wrapping_sub(v2);
-
-                trace!("Constant instruction: i32.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            I32_MUL => {
-                let v1: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
-                let v2: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
-                let res = v1.wrapping_mul(v2);
-
-                trace!("Constant instruction: i32.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
             I64_CONST => {
                 let constant = wasm.read_var_i64().unwrap_validated();
                 trace!("Constant instruction: i64.const [] -> [{constant}]");
                 stack.push_value(constant.into());
-            }
-            I64_ADD => {
-                let v1: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
-                let v2: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
-                let res = v1.wrapping_add(v2);
-
-                trace!("Constant instruction: i64.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            I64_SUB => {
-                let v2: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
-                let v1: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
-                let res = v1.wrapping_sub(v2);
-
-                trace!("Constant instruction: i64.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            I64_MUL => {
-                let v1: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
-                let v2: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
-                let res = v1.wrapping_mul(v2);
-
-                trace!("Constant instruction: i64.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F32_ADD => {
-                let v2: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let v1: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let res: value::F32 = v1 + v2;
-
-                trace!("Instruction: f32.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F32_SUB => {
-                let v2: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let v1: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let res: value::F32 = v1 - v2;
-
-                trace!("Instruction: f32.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F32_MUL => {
-                let v2: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let v1: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let res: value::F32 = v1 * v2;
-
-                trace!("Instruction: f32.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F32_DIV => {
-                let v2: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let v1: value::F32 = stack.pop_value(ValType::NumType(NumType::F32)).into();
-                let res: value::F32 = v1 / v2;
-
-                trace!("Instruction: f32.div [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F64_ADD => {
-                let v2: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let v1: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let res: value::F64 = v1 + v2;
-
-                trace!("Instruction: f64.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F64_SUB => {
-                let v2: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let v1: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let res: value::F64 = v1 - v2;
-
-                trace!("Instruction: f64.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F64_MUL => {
-                let v2: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let v1: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let res: value::F64 = v1 * v2;
-
-                trace!("Instruction: f64.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
-            }
-            F64_DIV => {
-                let v2: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let v1: value::F64 = stack.pop_value(ValType::NumType(NumType::F64)).into();
-                let res: value::F64 = v1 / v2;
-
-                trace!("Instruction: f64.div [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into());
             }
             REF_NULL => {
                 let reftype = RefType::read_unvalidated(wasm);

--- a/src/validation/read_constant_expression.rs
+++ b/src/validation/read_constant_expression.rs
@@ -145,18 +145,6 @@ pub fn read_constant_expression(
                 let _num = wasm.read_var_i64()?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
             }
-            I32_ADD | I32_SUB | I32_MUL => {
-                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
-                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
-
-                stack.push_valtype(ValType::NumType(NumType::I32));
-            }
-            I64_ADD | I64_SUB | I64_MUL => {
-                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
-                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
-
-                stack.push_valtype(ValType::NumType(NumType::I64));
-            }
             REF_NULL => {
                 stack.push_valtype(ValType::RefType(RefType::read(wasm)?));
             }

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -11,9 +11,7 @@ fn valid_global() {
     let wat = r#"
     (module
         (global $my_global (mut i32)
-            i32.const 2
-            i32.const 3
-            i32.add
+            i32.const 5
         )
 
         ;; Set global to a value and return the previous one
@@ -73,7 +71,6 @@ fn global_invalid_value_stack() {
             i32.const 2
             i32.const 2
             i32.const 3
-            i32.add
         )
     )
     "#;
@@ -137,7 +134,7 @@ fn imported_globals() {
 }
 
 #[test_log::test]
-fn global_f32_and_f64() {
+fn global_invalid_instr() {
     use wasm::validate;
 
     let wat = r#"
@@ -146,11 +143,12 @@ fn global_f32_and_f64() {
             i32.const 2
             i32.const 2
             i32.const 2
+            i32.add
             i32.const 2
             i32.const 2
             i32.const 2
             i32.const 3
-            i32.add
+
         )
     )
     "#;


### PR DESCRIPTION
### Pull Request Overview

this pr removes non const instrs from const validation and const evaluation which creates pain in coverage tests.

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
