### PR TITLE
fix: clippy lints from future

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -135,8 +135,7 @@ impl Display for Error {
                 "A value was expected in the WASM binary but the end of file was reached instead",
             ),
             Error::InvalidSection(section, reason) => f.write_fmt(format_args!(
-                "Section '{:?}' invalid! Reason: {}",
-                section, reason
+                "Section '{section:?}' invalid! Reason: {reason}"
             )),
             Error::InvalidSectionType(ty) => f.write_fmt(format_args!(
                 "An invalid section type id was found in a section header: {ty}"
@@ -203,21 +202,19 @@ impl Display for Error {
             Error::RuntimeError(err) => err.fmt(f),
             Error::ExpectedAnOperand => f.write_str("Expected a ValType"), // Error => f.write_str("Expected an operand (ValType) on the stack")
             Error::MemoryIsNotDefined(memidx) => f.write_fmt(format_args!(
-                "C.mems[{}] is NOT defined when it should be",
-                memidx
+                "C.mems[{memidx}] is NOT defined when it should be"
             )),
             Error::ErroneousAlignment(mem_align, minimum_wanted_alignment) => {
                 f.write_fmt(format_args!(
-                    "Alignment ({}) is not less or equal to {}",
-                    mem_align, minimum_wanted_alignment
+                    "Alignment ({mem_align}) is not less or equal to {minimum_wanted_alignment}"
                 ))
             }
             Error::NoDataSegments => f.write_str("Data Count is None"),
             Error::DataSegmentNotFound(data_idx) => {
-                f.write_fmt(format_args!("Data Segment {} not found", data_idx))
+                f.write_fmt(format_args!("Data Segment {data_idx} not found"))
             }
             Error::InvalidLabelIdx(label_idx) => {
-                f.write_fmt(format_args!("invalid label index {}", label_idx))
+                f.write_fmt(format_args!("invalid label index {label_idx}"))
             }
             Error::ValidationCtrlStackEmpty => {
                 f.write_str("cannot retrieve last ctrl block, validation ctrl stack is empty")
@@ -229,36 +226,28 @@ impl Display for Error {
                 f.write_str("read 'end' without matching 'else' instruction to 'if' instruction")
             }
             Error::TableIsNotDefined(table_idx) => f.write_fmt(format_args!(
-                "C.tables[{}] is NOT defined when it should be",
-                table_idx
+                "C.tables[{table_idx}] is NOT defined when it should be"
             )),
             Error::ElementIsNotDefined(elem_idx) => f.write_fmt(format_args!(
-                "C.elems[{}] is NOT defined when it should be",
-                elem_idx
+                "C.elems[{elem_idx}] is NOT defined when it should be"
             )),
             Error::DifferentRefTypes(rref1, rref2) => f.write_fmt(format_args!(
-                "RefType {:?} is NOT equal to RefType {:?}",
-                rref1, rref2
+                "RefType {rref1:?} is NOT equal to RefType {rref2:?}"
             )),
             Error::ExpectedARefType(found_valtype) => f.write_fmt(format_args!(
-                "Expected a RefType, found a {:?} instead",
-                found_valtype
+                "Expected a RefType, found a {found_valtype:?} instead"
             )),
             Error::WrongRefTypeForInteropValue(ref_given, ref_wanted) => f.write_fmt(format_args!(
-                "Wrong RefType for InteropValue: Given {:?} - Needed {:?}",
-                ref_given, ref_wanted
+                "Wrong RefType for InteropValue: Given {ref_given:?} - Needed {ref_wanted:?}"
             )),
             Error::FunctionIsNotDefined(func_idx) => f.write_fmt(format_args!(
-                "C.functions[{}] is NOT defined when it should be",
-                func_idx
+                "C.functions[{func_idx}] is NOT defined when it should be"
             )),
             Error::ReferencingAnUnreferencedFunction(func_idx) => f.write_fmt(format_args!(
-                "Referenced a function ({}) that was not referenced in validation",
-                func_idx
+                "Referenced a function ({func_idx}) that was not referenced in validation"
             )),
             Error::FunctionTypeIsNotDefined(func_ty_idx) => f.write_fmt(format_args!(
-                "C.fn_types[{}] is NOT defined when it should be",
-                func_ty_idx
+                "C.fn_types[{func_ty_idx}] is NOT defined when it should be"
             )),
             Error::StoreInstantiationError(err) => err.fmt(f),
             Error::OnlyFuncRefIsAllowed => f.write_str("Only FuncRef is allowed"),
@@ -269,10 +258,10 @@ impl Display for Error {
                 f.write_str("SELECT T* (0x1C) instruction must have exactly one type in the subsequent type vector")
             }
             Error::TooManyLocals(x) => {
-                f.write_fmt(format_args!("Too many locals (more than 2^32-1): {}", x))
+                f.write_fmt(format_args!("Too many locals (more than 2^32-1): {x}"))
             }
             Error::UnsupportedProposal(proposal) => {
-                f.write_fmt(format_args!("Unsupported proposal: {:?}", proposal))
+                f.write_fmt(format_args!("Unsupported proposal: {proposal:?}"))
             }
             Error::Overflow => f.write_str("Overflow"),
             Error::LinkerError(err) => err.fmt(f),
@@ -339,7 +328,7 @@ impl Display for StoreInstantiationError {
                 }
             )),
             MissingValueOnTheStack => f.write_str(""),
-            TooManyMemories(x) => f.write_fmt(format_args!("Too many memories (overflow): {}", x)),
+            TooManyMemories(x) => f.write_fmt(format_args!("Too many memories (overflow): {x}")),
         }
     }
 }

--- a/src/core/reader/types/data.rs
+++ b/src/core/reader/types/data.rs
@@ -32,7 +32,7 @@ impl Debug for DataSegment {
             if let Ok(valid_char) = alloc::string::String::from_utf8(Vec::from(&[byte])) {
                 init_str.push_str(valid_char.as_str());
             } else {
-                init_str.push_str(&format!("\\x{:02x}", byte));
+                init_str.push_str(&format!("\\x{byte:02x}"));
             }
         }
 
@@ -66,7 +66,7 @@ impl Debug for DataMode {
                     // .field("offset", format_args!("[{}..={}]", from, to))
                     .field(
                         "offset",
-                        &format_args!("[{}..={}] (hex = [{:X}..={:X}])", from, to, from, to),
+                        &format_args!("[{from}..={to}] (hex = [{from:X}..={to:X}])"),
                     )
                     .finish()
                 // f.
@@ -89,7 +89,7 @@ impl Debug for PassiveData {
                 init_str.push_str(valid_char.as_str());
             } else {
                 // If it's not valid UTF-8, print it as hex
-                init_str.push_str(&format!("\\x{:02x}", byte));
+                init_str.push_str(&format!("\\x{byte:02x}"));
             }
         }
         f.debug_struct("PassiveData")

--- a/src/core/reader/types/opcode.rs
+++ b/src/core/reader/types/opcode.rs
@@ -233,7 +233,7 @@ pub fn fc_extension_opcode_second_byte_to_str(instr: u32) -> alloc::string::Stri
     .to_owned();
 
     if opcode == "UNKNOWN" {
-        format!("UNKNOWN({:x})", instr)
+        format!("UNKNOWN({instr:x})")
     } else {
         opcode
     }
@@ -432,7 +432,7 @@ pub fn opcode_byte_to_str(byte: u8) -> alloc::string::String {
     .to_owned();
 
     if opcode == "UNKNOWN" {
-        format!("UNKNOWN({:x})", byte)
+        format!("UNKNOWN({byte:x})")
     } else {
         opcode
     }

--- a/src/execution/value.rs
+++ b/src/execution/value.rs
@@ -348,8 +348,8 @@ impl Ref {
 impl Display for Ref {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Ref::Func(func_addr) => write!(f, "FuncRef({:?})", func_addr),
-            Ref::Extern(extern_addr) => write!(f, "ExternRef({:?})", extern_addr),
+            Ref::Func(func_addr) => write!(f, "FuncRef({func_addr:?})"),
+            Ref::Extern(extern_addr) => write!(f, "ExternRef({extern_addr:?})"),
         }
     }
 }

--- a/src/validation/data.rs
+++ b/src/validation/data.rs
@@ -74,8 +74,7 @@ pub(super) fn validate_data_section(
                 }
                 assert!(
                     mem_idx == 0,
-                    "Memory index is not 0 - it's {}! Multiple memories are NOT supported",
-                    mem_idx
+                    "Memory index is not 0 - it's {mem_idx}! Multiple memories are NOT supported"
                 );
 
                 let mut valid_stack = ValidationStack::new();

--- a/tests/f32.rs
+++ b/tests/f32.rs
@@ -1015,8 +1015,7 @@ pub fn f32_convert_i32_u() {
         .unwrap();
     assert!(
         result > 4294967040.0 && result <= 4294967296.0,
-        "Large value conversion imprecise: got {}",
-        result
+        "Large value conversion imprecise: got {result}"
     );
 }
 
@@ -1123,9 +1122,9 @@ pub fn f32_reinterpret_i32() {
             .invoke::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), input)
             .unwrap();
         if expected.is_nan() {
-            assert!(result.is_nan(), "Failed for input: {:x}", input);
+            assert!(result.is_nan(), "Failed for input: {input:x}");
         } else {
-            assert_eq!(result, expected, "Failed for input: {:x}", input);
+            assert_eq!(result, expected, "Failed for input: {input:x}");
         }
     }
 }

--- a/tests/memory_size.rs
+++ b/tests/memory_size.rs
@@ -151,7 +151,7 @@ fn memory_size_5() {
     let wasm_bytes = wat::parse_str(w).unwrap();
     let mut i = 0;
     for byte in wasm_bytes.iter() {
-        print!("{:#04X} ", byte);
+        print!("{byte:#04X} ");
         i += 1;
         if i % 8 == 0 {
             i = 0;
@@ -177,7 +177,7 @@ fn memory_size_6() {
     let wasm_bytes = wat::parse_str(w).unwrap();
     let mut i = 0;
     for byte in wasm_bytes.iter() {
-        print!("{:#04X} ", byte);
+        print!("{byte:#04X} ");
         i += 1;
         if i % 8 == 0 {
             i = 0;

--- a/tests/specification/mod.rs
+++ b/tests/specification/mod.rs
@@ -121,11 +121,11 @@ pub fn spec_tests() {
         ).expect("writing into strings to never fail");
 
         if report.passed_asserts() < report.total_asserts() {
-            println!("{}", report);
+            println!("{report}");
         }
     }
 
-    println!("{}", final_status);
+    println!("{final_status}");
 
     println!(
         "\nReport for {:filename_width$}: Tests: {:passed_width$} Passed, {:failed_width$} Failed --- {:percentage_width$.2}%\n\n",
@@ -140,8 +140,7 @@ pub fn spec_tests() {
     );
 
     println!(
-        "Tests: {} Passed, {} Failed, {} Compilation Errors",
-        num_successes, num_failures, num_script_errors
+        "Tests: {num_successes} Passed, {num_failures} Failed, {num_script_errors} Compilation Errors"
     );
 
     // Optional: We need to save the result to a file for CI Regression Analysis

--- a/tests/specification/reports.rs
+++ b/tests/specification/reports.rs
@@ -180,7 +180,7 @@ impl std::fmt::Display for WastTestReport {
             }
             WastTestReport::Asserts(assert_report) => {
                 writeln!(f, "------ {} ------", assert_report.filename)?;
-                writeln!(f, "{}", assert_report)?;
+                writeln!(f, "{assert_report}")?;
                 let passed_asserts = assert_report.results.iter().filter(|r| r.is_ok()).count();
                 let failed_asserts = assert_report.results.iter().filter(|r| r.is_err()).count();
                 let total_asserts = assert_report.results.len();
@@ -188,8 +188,7 @@ impl std::fmt::Display for WastTestReport {
                 writeln!(f)?;
                 writeln!(
                     f,
-                    "Execution finished. Passed: {}, Failed: {}, Total: {}",
-                    passed_asserts, failed_asserts, total_asserts
+                    "Execution finished. Passed: {passed_asserts}, Failed: {failed_asserts}, Total: {total_asserts}"
                 )?;
                 writeln!(f, "~~~~~~~~~~~~~~~~")?;
                 writeln!(f)?;

--- a/tests/specification/test_errors.rs
+++ b/tests/specification/test_errors.rs
@@ -53,8 +53,8 @@ impl AssertEqError {
                 (a, b) => {
                     if a != b {
                         Err(AssertEqError {
-                            left: format!("{:?}", left),
-                            right: format!("{:?}", right),
+                            left: format!("{left:?}"),
+                            right: format!("{right:?}"),
                         })
                     } else {
                         Ok(())


### PR DESCRIPTION
### Pull Request Overview
Our CI environment picked up some clippy lints, which the clippy provided via Nix does not yet know about. This commit fixes the lints (all about the use of the `format!` macro).

### TODO or Help Wanted

This pull request still needs to verify that fixing this does not break our MSRV

### Checks

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
