### PR TITLE
feat(ci): No-Nix: state versions

### DIFF
--- a/.github/workflows/no-nix-ci.yaml
+++ b/.github/workflows/no-nix-ci.yaml
@@ -14,6 +14,8 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
+      # for CI we can treat warnings as errors
+      # for reference see: https://doc.rust-lang.org/clippy/usage.html
       RUSTFLAGS: "-D warnings"
       RUSTDOCFLAGS: "-D warnings"
 
@@ -21,11 +23,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Versions
+        run: cargo --version && rustc --version
       - name: Format
         run: cargo check
       - name: Run clippy
-        # for CI we can treat errors as warnings
-        # for reference see: https://doc.rust-lang.org/clippy/usage.html
         run: cargo clippy
       - name: Build docs
         run: cargo doc --document-private-items --verbose


### PR DESCRIPTION
### Pull Request Overview

State `cargo --version` and `rustc --version` in the No-Nix CI.

We expect the No-Nix CI to be ahead of the Nix-CI from time to time and thus have new errors. Knowing the affected versions helps with debugging :)

<!--
This pull request adds/changes/fixes...
-->

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
