### PR TITLE
Registry as a primitive linker

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -19,6 +19,7 @@ pub mod hooks;
 mod interpreter_loop;
 pub(crate) mod linear_memory;
 pub(crate) mod locals;
+pub mod registry;
 pub mod store;
 pub mod value;
 pub mod value_stack;

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -91,9 +91,6 @@ where
     ) -> Result<FunctionRef, RuntimeError> {
         // TODO fix error
         let store = self.store.as_ref().ok_or(RuntimeError::ModuleNotFound)?;
-        if !store.module_names.contains_key(module_name) {
-            return Err(RuntimeError::ModuleNotFound);
-        };
         FunctionRef::new_from_name(module_name, function_name, store)
             .map_err(|_| RuntimeError::FunctionNotFound)
     }

--- a/src/execution/registry.rs
+++ b/src/execution/registry.rs
@@ -1,0 +1,62 @@
+use crate::{Error, ModuleInst};
+
+use alloc::borrow::Cow;
+use alloc::collections::BTreeMap;
+
+use crate::ExternVal;
+
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
+struct ImportKey {
+    module_name: Cow<'static, str>,
+    name: Cow<'static, str>,
+}
+#[derive(Default, Debug)]
+pub struct Registry(BTreeMap<ImportKey, ExternVal>);
+
+impl Registry {
+    pub fn register(
+        &mut self,
+        module_name: Cow<'static, str>,
+        name: Cow<'static, str>,
+        extern_val: ExternVal,
+    ) -> Result<(), Error> {
+        if self
+            .0
+            .insert(ImportKey { module_name, name }, extern_val)
+            .is_some()
+        {
+            return Err(Error::InvalidImportType);
+        }
+
+        Ok(())
+    }
+
+    pub fn lookup(
+        &self,
+        module_name: Cow<'static, str>,
+        name: Cow<'static, str>,
+    ) -> Result<&ExternVal, Error> {
+        // Note: We cannot do a `&str` lookup on a [`String`] map key.
+        // Thus we have to use `Cow<'static, str>` as a key
+        // (at least this prevents allocations with static names).
+        self.0
+            .get(&ImportKey { module_name, name })
+            .ok_or(Error::UnknownImport)
+    }
+
+    pub fn register_module(
+        &mut self,
+        module_name: Cow<'static, str>,
+        module_inst: &ModuleInst,
+    ) -> Result<(), Error> {
+        for (entity_name, extern_val) in &module_inst.exports {
+            // FIXME this clones module_name. Maybe prevent by using `Cow<'static, Arc<str>>`.
+            self.register(
+                module_name.clone(),
+                Cow::Owned(entity_name.clone()),
+                *extern_val,
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -14,9 +14,10 @@ use crate::core::sidetable::Sidetable;
 use crate::execution::interpreter_loop::{memory_init, table_init};
 use crate::execution::value::{Ref, Value};
 use crate::execution::{run_const_span, Stack};
+use crate::registry::Registry;
 use crate::value::FuncAddr;
 use crate::{Error, Limits, RefType, RuntimeError, ValidationInfo};
-use alloc::borrow::{Cow, ToOwned};
+use alloc::borrow::ToOwned;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 use alloc::vec;
@@ -1026,58 +1027,4 @@ pub struct ModuleInst<'b> {
 
     // sidetable is not in the spec, but required for control flow
     pub sidetable: Sidetable,
-}
-
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
-struct ImportKey {
-    module_name: Cow<'static, str>,
-    name: Cow<'static, str>,
-}
-#[derive(Default, Debug)]
-pub struct Registry(BTreeMap<ImportKey, ExternVal>);
-
-impl Registry {
-    pub fn register(
-        &mut self,
-        module_name: Cow<'static, str>,
-        name: Cow<'static, str>,
-        extern_val: ExternVal,
-    ) -> Result<(), Error> {
-        if self
-            .0
-            .insert(ImportKey { module_name, name }, extern_val)
-            .is_some()
-        {
-            return Err(Error::InvalidImportType);
-        }
-
-        Ok(())
-    }
-
-    pub fn lookup(
-        &self,
-        module_name: Cow<'static, str>,
-        name: Cow<'static, str>,
-    ) -> Result<&ExternVal, Error> {
-        // Note: We cannot do a &str lookup on a [`String`] map key. Thus we have to use `Cow<'static, str> as a key (at least this prevents allocations with static names).
-        self.0
-            .get(&ImportKey { module_name, name })
-            .ok_or(Error::UnknownImport)
-    }
-
-    pub fn register_module(
-        &mut self,
-        module_name: Cow<'static, str>,
-        module_inst: &ModuleInst,
-    ) -> Result<(), Error> {
-        for (entity_name, extern_val) in &module_inst.exports {
-            // FIXME this clones module_name. Maybe prevent by using `Cow<'static, Arc<str>>`.
-            self.register(
-                module_name.clone(),
-                Cow::Owned(entity_name.clone()),
-                *extern_val,
-            )?;
-        }
-        Ok(())
-    }
 }

--- a/tests/linker.rs
+++ b/tests/linker.rs
@@ -1,4 +1,4 @@
-use wasm::{validate, Store};
+use wasm::{validate, ExternVal, Store};
 
 const SIMPLE_IMPORT_BASE: &str = r#"
 (module
@@ -41,12 +41,15 @@ pub fn compile_simple_import() {
     // let mut instance =
     //     RuntimeInstance::new_named("base", &validation_info_base).expect("instantiation failed");
 
-    let func_addr = match store.registry.lookup("base".into(), "get_three".into()).unwrap() {
-        ExternVal::Func(func_addr) => *func_addr,
-        _ => panic!("this entity is not a function"),
+    let &ExternVal::Func(func_addr) = store
+        .registry
+        .lookup("base".into(), "get_three".into())
+        .unwrap()
+    else {
+        panic!("this entity is not a function")
     };
 
-    println!("{:#?}", store.invoke::<(), i32>(func_idx, ()).unwrap());
+    println!("{:#?}", store.invoke::<(), i32>(func_addr, ()).unwrap());
 
     // let mut instance_addon = linker
     //     .instantiate(&mut store, &validation_info_addon)

--- a/tests/linker.rs
+++ b/tests/linker.rs
@@ -41,7 +41,10 @@ pub fn compile_simple_import() {
     // let mut instance =
     //     RuntimeInstance::new_named("base", &validation_info_base).expect("instantiation failed");
 
-    let func_idx = store.lookup_function("base", "get_three").unwrap();
+    let func_addr = match store.registry.lookup("base".into(), "get_three".into()).unwrap() {
+        ExternVal::Func(func_addr) => *func_addr,
+        _ => panic!("this entity is not a function"),
+    };
 
     println!("{:#?}", store.invoke::<(), i32>(func_idx, ()).unwrap());
 


### PR DESCRIPTION
### Pull Request Overview

wasm module import statements specify which module to import from, but in reality that module might not exist at all, its just a name for a namespace. This refactor handles that problem. It is inspired from spec interpreter: https://github.com/WebAssembly/spec/blob/main/interpreter/script/import.ml

### TODO or Help Wanted

- methods for runtime_instance / store to add wasm entitites externally.
~- registry's implementation is a shabby 2-level kv map, which could be just Map<(module_name: String, , entity_name: String), ExternVal>, but i didn't want to deal with implementing a Borrow trait for (str,str) tuple for now to use it as a key.~

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
