### PR TITLE
Stack refactor mockup

### DIFF
--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -537,36 +537,10 @@ impl<'b> Store<'b> {
         }
 
         let mut stack = Stack::new();
-        let locals = Locals::new(
-            params.into_values().into_iter(),
-            func_inst.locals.iter().cloned(),
-        );
-
-        let module_addr = func_inst.module_addr;
-
-        // TODO handle this bad linear search that is unavoidable
-        let (func_idx, _) = self.modules[module_addr]
-            .func_addrs
-            .iter()
-            .enumerate()
-            .find(|&(_idx, addr)| *addr == func_addr)
-            .ok_or(RuntimeError::FunctionNotFound)?;
-        // setting `usize::MAX` as return address for the outermost function ensures that we
-        // observably fail upon errornoeusly continuing execution after that function returns.
-        stack.push_stackframe(
-            module_addr,
-            func_idx,
-            &func_ty,
-            locals,
-            usize::MAX,
-            usize::MAX,
-        )?;
-
-        let mut current_module_idx = module_addr;
         // Run the interpreter
         run(
             // &mut self.modules,
-            &mut current_module_idx,
+            func_addr,
             // self.lut.as_ref().ok_or(RuntimeError::UnmetImport)?,
             &mut stack,
             EmptyHookSet,

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -248,25 +248,19 @@ impl Stack {
 
 /// The [WASM spec](https://webassembly.github.io/spec/core/exec/runtime.html#stack) calls this `Activations`, however it refers to the call frames of functions.
 pub(crate) struct CallFrame {
-    /// Index to the module idx the function originates in.
-    /// This seems to be used as a return module id LOL
-    pub module_idx: usize,
-
-    /// Index to the function of this [`CallFrame`]
-    pub func_idx: FuncIdx,
+    /// Store address of the function of this [`CallFrame`]
+    pub func_addr: usize,
 
     /// Local variables such as parameters for this [`CallFrame`]'s function
-    pub locals: Locals,
+    /// on the stack, in [value_stack_base_idx-locals.len()..value_stack_base_idx]?
+    //  pub locals: Locals,
 
-    /// Value that the PC has to be set to when this function returns
-    pub return_addr: usize,
+    /// Value of the current program counter
+    pub pc: usize,
 
     /// The index to the first value on [`Stack::values`] that belongs to this [`CallFrame`]
     pub value_stack_base_idx: usize,
 
-    /// Number of return values to retain on [`Stack::values`] when unwinding/popping a [`CallFrame`]
-    pub return_value_count: usize,
-
-    // Value that the stp has to be set to when this function returns
-    pub return_stp: usize,
+    // Value of the current sidetable pointer
+    pub stp: usize,
 }


### PR DESCRIPTION
This mockup proposes functional changes on the stack and important interpreter loop signatures in preparation for host function calls.

Advantages:
- The interpreter state is completely summarized by stack and store, no need to do bookkeeping with interpreter_loop local variables.
- since these summarize the interpreter state, function invocation is better encapsulated, leading to less duplicate code.
- adapting this to host function invocations is easier since all host functions also have a func_addr, and their implementation can be made without signature change.

Disadvantages:
- the current module instance is accessed through double indirection
```
store.modules[store.functions[func_addr].module_addr]
```
but I'm hoping the compiler will simply optimize towards keeping the current module instance reference and current function instance reference locally without re-access since they don't change often.
- because of the way interpreter loop is written, this change will warrant a big code diff (thus this mockup for discussion)

Unsure:
- I'm not sure whether we should supply the stack to interpreter_loop.run() as an argument or have the stack only within interpreter_loop.run()? maybe we'll need it?
- Should we also remove Locals field from the call frame and let the locals exist on stack (in a way push/pop instructions can't reach them)?
- In the future, fuel should be part of Store/RuntimeInstance?

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
