### PR TITLE
refactor: move duplicated stack initialization to interpreter loop

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -3,7 +3,6 @@ use alloc::vec::Vec;
 use const_interpreter_loop::run_const_span;
 use function_ref::FunctionRef;
 use interpreter_loop::run;
-use value_stack::Stack;
 
 use crate::execution::assert_validated::UnwrapValidatedExt;
 use crate::execution::hooks::{EmptyHookSet, HookSet};


### PR DESCRIPTION
### Pull Request Overview

I based this on #215 for now, when it merges, i'll make this draft ready for merge.

This refactor moves execution stack initialization/usage into interpreter loop and removes duplicated code in `store.invoke_*` methods.

A discussion point is, it also adds a validation check that panics in an `unreachable_validated!` way if there is a type mismatch into the last part of the interpreter loop. This check was in the `store.invoke_*` methods already. I'm not sure it should exist at all.

### TODO or Help Wanted
- The parts where very first stack initialization/function call/function return takes place in the interpreter loop have some duplication we can tend to. I want to tackle this next.

- should the type checking at the end of the `interpreter_loop::run` be removed?

- Now that `invoke_*` are thinner, they are easier to discuss about. I have the following suggestions:

1. Type checking of (input or output) values to an invoke should take place within `RuntimeInstance::invoke_*` and it should throw an `Err`. No type checking that would throw an `Err` should take place within the `store.invoke_*` methods, these methods should assume their inputs are validated (which implies the postcondition of these `invoke_*` methods are the validity of the values they return with output type of the function, here even `RuntimeInstance` doesn't have to check post` interpreter_loop::run()`)
2. The store should have a single invoke method that does no type checking with a signature along the lines
```
fn invoke(&mut self, func_addr: usize, params: Vec<Value>) -> Result<Vec<Value>, Trap)
```
similar to `invoke_dynamic_unchecked_return_ty` we have now. This method can even reduce to a single `interpreter_loop::run` call, but it is hard to tell yet.

3. `RuntimeInstance` should have two methods, one which the input/output types of the function are supplied by hand as generics (similar to our `invoke` -- lets call it `invoke_typed`), and one that the user doesn't supply any input/output type at all (similar to `invoke_dynamic_unchecked_return_ty`, let's call this one `invoke_untyped`). These methods both internally call `store.invoke`, but with the following pre-checks.

3a. `invoke_typed` checks whether types supplied with generics match with the function's input and output types. It is impossible to supply values with incorrect input types if this check goes through since rust type checker checks it for us already.
3b. `invoke_untyped` checks whether the input values match the input signature of the function.

None of these do any checks after `store.invoke` is called in an `Err` throwing way, since wasm type system guarantees we would get the correct output types.

Q: What if the user want to supply types in runtime because they are unsure of the wasm types of the things they deal with during runtime, similar to what our `invoke_dynamic` does?
A: The user can do this manually using `store.func_type` method here https://webassembly.github.io/spec/core/appendix/embedding.html#functions . There is no point in embedding it within another `invoke` variant. Our `invoke_dynamic` is seldomly used in our codebase, and these uses can be easily replaced, for example.
Q: Ok, but wouldn't that also make` invoke_typed` redundant?
A: No, since here the user supplies the types in generics and can enjoy the type system of rust when they write programs. The advantage is too big to accept an `invoke` variant here.

4. We should purge `RuntimeInstance/Store::invoke_dynamic`, and rename `invoke_dynamic_unchecked_return_ty` as `invoke_dynamic` or something along the lines. The store should only have this method (maybe with a shorter name like `invoke`, there is no need for the typed variant here)


### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
