### PR TITLE
refactor: replace invoke variants with invoke and invoke_typed

### DIFF
--- a/crates/benchmark/benches/general_purpose.rs
+++ b/crates/benchmark/benches/general_purpose.rs
@@ -102,7 +102,7 @@ macro_rules! bench_wasm {
                 let bid = BenchmarkId::new("our", n);
                 group.bench_with_input(bid, &n, |b, &s| {
                     b.iter(|| {
-                        our_instance.invoke::<$arg_type, $return_type>(&our_fn, s).unwrap();
+                        our_instance.invoke_typed::<$arg_type, $return_type>(&our_fn, s).unwrap();
                     })
                 });
             }

--- a/crates/benchmark/benches/hook_performance_impact.rs
+++ b/crates/benchmark/benches/hook_performance_impact.rs
@@ -56,14 +56,14 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let test_fn = instance_empty_hookset.get_function_by_index(0, 2).unwrap();
     c.bench_function("invoke_func EmptyHookSet", |b| {
-        b.iter(|| instance_empty_hookset.invoke::<_, ()>(&test_fn, black_box(42_i32)))
+        b.iter(|| instance_empty_hookset.invoke_typed::<_, ()>(&test_fn, black_box(42_i32)))
     });
 
     let test_fn = instance_non_empty_hookset
         .get_function_by_index(0, 2)
         .unwrap();
     c.bench_function("invoke_func MyCustomHookSet", |b| {
-        b.iter(|| instance_non_empty_hookset.invoke::<_, ()>(&test_fn, black_box(42_i32)))
+        b.iter(|| instance_non_empty_hookset.invoke_typed::<_, ()>(&test_fn, black_box(42_i32)))
     });
 }
 

--- a/examples/stuff/main.rs
+++ b/examples/stuff/main.rs
@@ -54,22 +54,22 @@ fn main() -> ExitCode {
     };
 
     let twelve: i32 = instance
-        .invoke(&instance.get_function_by_index(0, 1).unwrap(), (5, 7))
+        .invoke_typed(&instance.get_function_by_index(0, 1).unwrap(), (5, 7))
         .unwrap();
     assert_eq!(twelve, 12);
 
     let twelve_plus_one: i32 = instance
-        .invoke(&instance.get_function_by_index(0, 0).unwrap(), twelve)
+        .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), twelve)
         .unwrap();
     assert_eq!(twelve_plus_one, 13);
 
     instance
-        .invoke::<_, ()>(&instance.get_function_by_index(0, 2).unwrap(), 42_i32)
+        .invoke_typed::<_, ()>(&instance.get_function_by_index(0, 2).unwrap(), 42_i32)
         .unwrap();
 
     assert_eq!(
         instance
-            .invoke::<(), i32>(&instance.get_function_by_index(0, 3).unwrap(), ())
+            .invoke_typed::<(), i32>(&instance.get_function_by_index(0, 3).unwrap(), ())
             .unwrap(),
         42_i32
     );

--- a/src/execution/function_ref.rs
+++ b/src/execution/function_ref.rs
@@ -2,7 +2,7 @@ use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
 use crate::execution::{hooks::HookSet, value::InteropValueList, RuntimeInstance};
-use crate::{Error, ExternVal, Result as CustomResult, RuntimeError, Store, ValType, Value};
+use crate::{Error, ExternVal, Result as CustomResult, RuntimeError, Store, Value};
 
 pub struct FunctionRef {
     pub func_addr: usize,
@@ -31,7 +31,7 @@ impl FunctionRef {
         }
     }
 
-    pub fn invoke<
+    pub fn invoke_typed<
         H: HookSet + core::fmt::Debug,
         Param: InteropValueList,
         Returns: InteropValueList,
@@ -41,16 +41,15 @@ impl FunctionRef {
         params: Param,
         // store: &mut Store,
     ) -> Result<Returns, RuntimeError> {
-        runtime.invoke(self, params /* , store */)
+        runtime.invoke_typed(self, params /* , store */)
     }
 
-    pub fn invoke_dynamic<H: HookSet + core::fmt::Debug>(
+    pub fn invoke<H: HookSet + core::fmt::Debug>(
         &self,
         runtime: &mut RuntimeInstance<H>,
         params: Vec<Value>,
-        ret_types: &[ValType],
         // store: &mut Store,
     ) -> Result<Vec<Value>, RuntimeError> {
-        runtime.invoke_dynamic(self, params, ret_types /* , store */)
+        runtime.invoke(self, params)
     }
 }

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -542,21 +542,8 @@ impl<'b> Store<'b> {
             EmptyHookSet,
             self,
         )?;
-
-        // Pop return values from stack
-        let return_values = func_ty
-            .returns
-            .valtypes
-            .iter()
-            .rev()
-            .map(|ty| stack.pop_value(*ty))
-            .collect::<Vec<Value>>();
-
-        // Values are reversed because they were popped from stack one-by-one. Now reverse them back
-        let reversed_values = return_values.into_iter().rev();
-        let ret = reversed_values.collect();
         debug!("Successfully invoked function");
-        Ok(ret)
+        Ok(stack.into_values())
     }
 }
 

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -35,6 +35,10 @@ impl Stack {
         Self::default()
     }
 
+    pub(super) fn into_values(self) -> Vec<Value> {
+        self.values
+    }
+
     pub fn drop_value(&mut self) {
         // If there is at least one stack frame, we shall not pop values past the current
         // stackframe. However, there is one legitimate reason to pop when there is **no** current

--- a/tests/add_one.rs
+++ b/tests/add_one.rs
@@ -21,7 +21,7 @@ fn i32_add_one() {
     assert_eq!(
         12,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_one")
                     .unwrap(),
@@ -32,7 +32,7 @@ fn i32_add_one() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_one")
                     .unwrap(),
@@ -43,7 +43,7 @@ fn i32_add_one() {
     assert_eq!(
         -5,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_one")
                     .unwrap(),
@@ -65,19 +65,19 @@ fn i64_add_one() {
     assert_eq!(
         12_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 11_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 11_i64)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         -5_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -6_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -6_i64)
             .unwrap()
     );
 }

--- a/tests/arithmetic/bitwise.rs
+++ b/tests/arithmetic/bitwise.rs
@@ -30,19 +30,19 @@ pub fn i32_bitwise_and() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
             .unwrap()
     );
     assert_eq!(
         5,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
             .unwrap()
     );
     assert_eq!(
         180244,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534, 1231412)
             )
@@ -51,7 +51,7 @@ pub fn i32_bitwise_and() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -73,19 +73,19 @@ pub fn i32_bitwise_or() {
     assert_eq!(
         43,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
             .unwrap()
     );
     assert_eq!(
         95,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
             .unwrap()
     );
     assert_eq!(
         1243702,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534, 1231412)
             )
@@ -94,7 +94,7 @@ pub fn i32_bitwise_or() {
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -116,19 +116,19 @@ pub fn i32_bitwise_xor() {
     assert_eq!(
         42,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
             .unwrap()
     );
     assert_eq!(
         90,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
             .unwrap()
     );
     assert_eq!(
         1063458,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534, 1231412)
             )
@@ -137,7 +137,7 @@ pub fn i32_bitwise_xor() {
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -159,19 +159,19 @@ pub fn i32_bitwise_shl() {
     assert_eq!(
         67584,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (33, 11))
             .unwrap()
     );
     assert_eq!(
         645922816,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (77, 23))
             .unwrap()
     );
     assert_eq!(
         23068672,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534, 1231412)
             )
@@ -180,7 +180,7 @@ pub fn i32_bitwise_shl() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -202,7 +202,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         8881445,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123, 4)
             )
@@ -211,7 +211,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         23879,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921, 14)
             )
@@ -220,7 +220,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         601955006,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012, 33)
             )
@@ -229,7 +229,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         1056594615,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231, 33)
             )
@@ -238,7 +238,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -249,7 +249,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         4,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
             .unwrap()
     );
 
@@ -257,13 +257,13 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
 
@@ -271,13 +271,13 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         -4,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
 
@@ -285,13 +285,13 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 31)
             )
@@ -300,7 +300,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 31)
             )
@@ -311,19 +311,19 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
             .unwrap()
     );
 
@@ -331,7 +331,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         i32::MIN / 2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 1)
             )
@@ -340,7 +340,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         i32::MAX / 2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 1)
             )
@@ -351,7 +351,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         -2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 30)
             )
@@ -360,7 +360,7 @@ pub fn i32_bitwise_shr_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 30)
             )
@@ -382,7 +382,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         8881445,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123, 4)
             )
@@ -391,7 +391,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         23879,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921, 14)
             )
@@ -400,7 +400,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         601955006,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012, 33)
             )
@@ -409,7 +409,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         1056594615,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231, 33)
             )
@@ -418,7 +418,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -429,7 +429,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         4,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
             .unwrap()
     );
 
@@ -437,13 +437,13 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
 
@@ -451,13 +451,13 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         i32::MAX - 3,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
             .unwrap()
     );
     assert_eq!(
         i32::MAX,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
 
@@ -465,13 +465,13 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 31)
             )
@@ -480,7 +480,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 31)
             )
@@ -491,19 +491,19 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
             .unwrap()
     );
     assert_eq!(
         268435455,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
             .unwrap()
     );
 
@@ -511,7 +511,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         -(i32::MIN / 2),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 1)
             )
@@ -520,7 +520,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         i32::MAX / 2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 1)
             )
@@ -531,7 +531,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 30)
             )
@@ -540,7 +540,7 @@ pub fn i32_bitwise_shr_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 30)
             )
@@ -562,7 +562,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -2021317328,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123, 4)
             )
@@ -571,7 +571,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         2131117524,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921, 14)
             )
@@ -580,7 +580,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -1887147272,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012, 33)
             )
@@ -589,7 +589,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -68588834,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231, 33)
             )
@@ -598,7 +598,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         1073741824,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -609,7 +609,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         16,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
             .unwrap()
     );
 
@@ -617,13 +617,13 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
 
@@ -631,13 +631,13 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -15,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
 
@@ -645,13 +645,13 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
             .unwrap()
     );
     assert_eq!(
         i32::MAX / 2 + 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 31)
             )
@@ -660,7 +660,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         i32::MIN / 2 - 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 31)
             )
@@ -671,19 +671,19 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
             .unwrap()
     );
 
@@ -691,7 +691,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 1)
             )
@@ -700,7 +700,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         -2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 1)
             )
@@ -711,7 +711,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         i32::MAX / 4 + 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 30)
             )
@@ -720,7 +720,7 @@ pub fn i32_bitwise_rotl() {
     assert_eq!(
         i32::MIN / 4 - 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 30)
             )
@@ -742,7 +742,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         814187813,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123, 4)
             )
@@ -751,7 +751,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         -261857977,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921, 14)
             )
@@ -760,7 +760,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         601955006,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012, 33)
             )
@@ -769,7 +769,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         -1090889033,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231, 33)
             )
@@ -778,7 +778,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, i32::MAX)
             )
@@ -789,7 +789,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         4,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (8, 1))
             .unwrap()
     );
 
@@ -797,13 +797,13 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
 
@@ -811,13 +811,13 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         i32::MAX - 3,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-8, 1))
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
 
@@ -825,13 +825,13 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 31))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 31)
             )
@@ -840,7 +840,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         -2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 31)
             )
@@ -851,19 +851,19 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 32))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 32))
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 100))
             .unwrap()
     );
 
@@ -871,7 +871,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         i32::MAX / 2 + 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 1)
             )
@@ -880,7 +880,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         i32::MIN / 2 - 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 1)
             )
@@ -891,7 +891,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MIN, 30)
             )
@@ -900,7 +900,7 @@ pub fn i32_bitwise_rotr() {
     assert_eq!(
         -3,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32::MAX, 30)
             )
@@ -922,37 +922,37 @@ pub fn i32_bitwise_clz() {
     assert_eq!(
         26,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 33)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 33)
             .unwrap()
     );
     assert_eq!(
         25,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 77)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 77)
             .unwrap()
     );
     assert_eq!(
         14,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 192534)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 192534)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i32::MIN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i32::MIN)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i32::MAX)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i32::MAX)
             .unwrap()
     );
     assert_eq!(
         32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
 }
@@ -971,37 +971,37 @@ pub fn i32_bitwise_ctz() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 33)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 33)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 77)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 77)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 192534)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 192534)
             .unwrap()
     );
     assert_eq!(
         31,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i32::MIN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i32::MIN)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i32::MAX)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i32::MAX)
             .unwrap()
     );
     assert_eq!(
         32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
 }
@@ -1020,37 +1020,37 @@ pub fn i32_bitwise_popcnt() {
     assert_eq!(
         2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 33)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 33)
             .unwrap()
     );
     assert_eq!(
         4,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 77)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 77)
             .unwrap()
     );
     assert_eq!(
         8,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 192534)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 192534)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i32::MIN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i32::MIN)
             .unwrap()
     );
     assert_eq!(
         31,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i32::MAX)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i32::MAX)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
 }
@@ -1086,7 +1086,7 @@ pub fn i64_bitwise_and() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (33_i64, 11_i64)
             )
@@ -1095,7 +1095,7 @@ pub fn i64_bitwise_and() {
     assert_eq!(
         5_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (77_i64, 23_i64)
             )
@@ -1104,7 +1104,7 @@ pub fn i64_bitwise_and() {
     assert_eq!(
         180244_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534_i64, 1231412_i64)
             )
@@ -1113,7 +1113,7 @@ pub fn i64_bitwise_and() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1135,7 +1135,7 @@ pub fn i64_bitwise_or() {
     assert_eq!(
         43_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (33_i64, 11_i64)
             )
@@ -1144,7 +1144,7 @@ pub fn i64_bitwise_or() {
     assert_eq!(
         95_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (77_i64, 23_i64)
             )
@@ -1153,7 +1153,7 @@ pub fn i64_bitwise_or() {
     assert_eq!(
         1243702_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534_i64, 1231412_i64)
             )
@@ -1162,7 +1162,7 @@ pub fn i64_bitwise_or() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1184,7 +1184,7 @@ pub fn i64_bitwise_xor() {
     assert_eq!(
         42_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (33_i64, 11_i64)
             )
@@ -1193,7 +1193,7 @@ pub fn i64_bitwise_xor() {
     assert_eq!(
         90_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (77_i64, 23_i64)
             )
@@ -1202,7 +1202,7 @@ pub fn i64_bitwise_xor() {
     assert_eq!(
         1063458_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534_i64, 1231412_i64)
             )
@@ -1211,7 +1211,7 @@ pub fn i64_bitwise_xor() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1233,7 +1233,7 @@ pub fn i64_bitwise_shl() {
     assert_eq!(
         67584_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (33_i64, 11_i64)
             )
@@ -1242,7 +1242,7 @@ pub fn i64_bitwise_shl() {
     assert_eq!(
         645922816_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (77_i64, 23_i64)
             )
@@ -1251,7 +1251,7 @@ pub fn i64_bitwise_shl() {
     assert_eq!(
         99079191802150912_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (192534_i64, 1231412_i64)
             )
@@ -1260,7 +1260,7 @@ pub fn i64_bitwise_shl() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1282,7 +1282,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         8881445_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123_i64, 4_i64)
             )
@@ -1291,7 +1291,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         23879_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921_i64, 14_i64)
             )
@@ -1300,7 +1300,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012_i64, 33_i64)
             )
@@ -1309,7 +1309,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231_i64, 33_i64)
             )
@@ -1318,7 +1318,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1329,7 +1329,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         4_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (8_i64, 1_i64)
             )
@@ -1340,7 +1340,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0_i64)
             )
@@ -1349,7 +1349,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1360,7 +1360,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -4_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-8_i64, 1_i64)
             )
@@ -1369,7 +1369,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -1380,7 +1380,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 31_i64)
             )
@@ -1389,7 +1389,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 31_i64)
             )
@@ -1398,7 +1398,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         4294967295_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 31_i64)
             )
@@ -1409,7 +1409,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 32_i64)
             )
@@ -1418,7 +1418,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 32_i64)
             )
@@ -1427,7 +1427,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 100_i64)
             )
@@ -1438,7 +1438,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         i64::MIN / 2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 1_i64)
             )
@@ -1447,7 +1447,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         i64::MAX / 2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 1_i64)
             )
@@ -1458,7 +1458,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         -8589934592_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 30_i64)
             )
@@ -1467,7 +1467,7 @@ pub fn i64_bitwise_shr_s() {
     assert_eq!(
         8589934591_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 30_i64)
             )
@@ -1489,7 +1489,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         8881445_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123_i64, 4_i64)
             )
@@ -1498,7 +1498,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         23879_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921_i64, 14_i64)
             )
@@ -1507,7 +1507,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012_i64, 33_i64)
             )
@@ -1516,7 +1516,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231_i64, 33_i64)
             )
@@ -1525,7 +1525,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1536,7 +1536,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         4_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (8_i64, 1_i64)
             )
@@ -1547,7 +1547,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0_i64)
             )
@@ -1556,7 +1556,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1567,7 +1567,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         i64::MAX - 3,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-8_i64, 1_i64)
             )
@@ -1576,7 +1576,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         i64::MAX,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -1587,7 +1587,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         8589934591_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 31_i64)
             )
@@ -1596,7 +1596,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 31_i64)
             )
@@ -1605,7 +1605,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         4294967295_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 31_i64)
             )
@@ -1616,7 +1616,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         4294967295_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 32_i64)
             )
@@ -1625,7 +1625,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 32_i64)
             )
@@ -1634,7 +1634,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         268435455_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 100_i64)
             )
@@ -1645,7 +1645,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         -(i64::MIN / 2),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 1_i64)
             )
@@ -1654,7 +1654,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         i64::MAX / 2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 1_i64)
             )
@@ -1665,7 +1665,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         8589934592_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 30_i64)
             )
@@ -1674,7 +1674,7 @@ pub fn i64_bitwise_shr_u() {
     assert_eq!(
         8589934591_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 30_i64)
             )
@@ -1696,7 +1696,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         2273649968_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123_i64, 4_i64)
             )
@@ -1705,7 +1705,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         6410222321664_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921_i64, 14_i64)
             )
@@ -1714,7 +1714,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -8105235815975616512_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012_i64, 33_i64)
             )
@@ -1723,7 +1723,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -294586798900772864_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231_i64, 33_i64)
             )
@@ -1732,7 +1732,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         4611686018427387904_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1743,7 +1743,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         16_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (8_i64, 1_i64)
             )
@@ -1754,7 +1754,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0_i64)
             )
@@ -1763,7 +1763,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1774,7 +1774,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -15_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-8_i64, 1_i64)
             )
@@ -1783,7 +1783,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -1794,7 +1794,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 31_i64)
             )
@@ -1803,7 +1803,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         1073741824_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 31_i64)
             )
@@ -1812,7 +1812,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -1073741825_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 31_i64)
             )
@@ -1823,7 +1823,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 32_i64)
             )
@@ -1832,7 +1832,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 32_i64)
             )
@@ -1841,7 +1841,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 100_i64)
             )
@@ -1852,7 +1852,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 1_i64)
             )
@@ -1861,7 +1861,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 1_i64)
             )
@@ -1872,7 +1872,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         536870912_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 30_i64)
             )
@@ -1881,7 +1881,7 @@ pub fn i64_bitwise_rotl() {
     assert_eq!(
         -536870913_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 30_i64)
             )
@@ -1903,7 +1903,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         3458764513829422373_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (142_103_123_i64, 4_i64)
             )
@@ -1912,7 +1912,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -1124774006935757497_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (391_248_921_i64, 14_i64)
             )
@@ -1921,7 +1921,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         2585377064433483776_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_203_910_012_i64, 33_i64)
             )
@@ -1930,7 +1930,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         4538039318702194688_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_113_189_231_i64, 33_i64)
             )
@@ -1939,7 +1939,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, i64::MAX)
             )
@@ -1950,7 +1950,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         4_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (8_i64, 1_i64)
             )
@@ -1961,7 +1961,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0_i64)
             )
@@ -1970,7 +1970,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1981,7 +1981,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         i64::MAX - 3,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-8_i64, 1_i64)
             )
@@ -1990,7 +1990,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -2001,7 +2001,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 31_i64)
             )
@@ -2010,7 +2010,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 31_i64)
             )
@@ -2019,7 +2019,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -4294967297_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 31_i64)
             )
@@ -2030,7 +2030,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 32_i64)
             )
@@ -2039,7 +2039,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 32_i64)
             )
@@ -2048,7 +2048,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 100_i64)
             )
@@ -2059,7 +2059,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         i64::MAX / 2 + 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 1_i64)
             )
@@ -2068,7 +2068,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         i64::MIN / 2 - 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 1_i64)
             )
@@ -2079,7 +2079,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         8589934592_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 30_i64)
             )
@@ -2088,7 +2088,7 @@ pub fn i64_bitwise_rotr() {
     assert_eq!(
         -8589934593_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX, 30_i64)
             )
@@ -2110,37 +2110,37 @@ pub fn i64_bitwise_clz() {
     assert_eq!(
         58_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 33_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 33_i64)
             .unwrap()
     );
     assert_eq!(
         57_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 77_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 77_i64)
             .unwrap()
     );
     assert_eq!(
         46_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 192534_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 192534_i64)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX)
             .unwrap()
     );
     assert_eq!(
         64_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
 }
@@ -2159,37 +2159,37 @@ pub fn i64_bitwise_ctz() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 33_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 33_i64)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 77_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 77_i64)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 192534_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 192534_i64)
             .unwrap()
     );
     assert_eq!(
         63_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX)
             .unwrap()
     );
     assert_eq!(
         64_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
 }
@@ -2208,37 +2208,37 @@ pub fn i64_bitwise_popcnt() {
     assert_eq!(
         2_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 33_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 33_i64)
             .unwrap()
     );
     assert_eq!(
         4_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 77_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 77_i64)
             .unwrap()
     );
     assert_eq!(
         8_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 192534_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 192534_i64)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN)
             .unwrap()
     );
     assert_eq!(
         63_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
 }

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -33,7 +33,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -44,7 +44,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         9_001,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -55,7 +55,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         -10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -66,7 +66,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -77,7 +77,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         -10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -88,7 +88,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -99,7 +99,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         9_001,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -110,7 +110,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         -10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -121,7 +121,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -132,7 +132,7 @@ pub fn i32_division_signed_simple() {
     assert_eq!(
         -10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "signed_division")
                     .unwrap(),
@@ -153,7 +153,7 @@ pub fn i32_division_signed_panic_dividend_0() {
 
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let result = instance.invoke::<(i32, i32), i32>(
+    let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
             .get_function_by_name(DEFAULT_MODULE, "signed_division")
             .unwrap(),
@@ -174,7 +174,7 @@ pub fn i32_division_signed_panic_result_unrepresentable() {
 
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let result = instance.invoke::<(i32, i32), i32>(
+    let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
             .get_function_by_name(DEFAULT_MODULE, "signed_division")
             .unwrap(),
@@ -198,7 +198,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         10,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -209,7 +209,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         9_001,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -220,7 +220,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -232,7 +232,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -243,7 +243,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         -20,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -254,7 +254,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         2147483638,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -265,7 +265,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         1431655758,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -276,7 +276,7 @@ pub fn i32_division_unsigned_simple() {
     assert_eq!(
         1073741819,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
                     .unwrap(),
@@ -297,7 +297,7 @@ pub fn i32_division_unsigned_panic_dividend_0() {
 
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let result = instance.invoke::<(i32, i32), i32>(
+    let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
             .get_function_by_name(DEFAULT_MODULE, "unsigned_division")
             .unwrap(),
@@ -321,7 +321,7 @@ pub fn i64_division_signed_simple() {
     assert_eq!(
         10_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, 2_i64)
             )
@@ -330,7 +330,7 @@ pub fn i64_division_signed_simple() {
     assert_eq!(
         9_001_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (81_018_001_i64, 9_001_i64)
             )
@@ -339,7 +339,7 @@ pub fn i64_division_signed_simple() {
     assert_eq!(
         -10_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, -2_i64)
             )
@@ -348,7 +348,7 @@ pub fn i64_division_signed_simple() {
     assert_eq!(
         10_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-20_i64, -2_i64)
             )
@@ -357,7 +357,7 @@ pub fn i64_division_signed_simple() {
     assert_eq!(
         -10_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-20_i64, 2_i64)
             )

--- a/tests/arithmetic/multiply.rs
+++ b/tests/arithmetic/multiply.rs
@@ -23,7 +23,7 @@ pub fn i32_multiply() {
     assert_eq!(
         33,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "multiply")
                     .unwrap(),
@@ -34,7 +34,7 @@ pub fn i32_multiply() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "multiply")
                     .unwrap(),
@@ -45,7 +45,7 @@ pub fn i32_multiply() {
     assert_eq!(
         -30,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "multiply")
                     .unwrap(),
@@ -57,7 +57,7 @@ pub fn i32_multiply() {
     assert_eq!(
         i32::MAX - 5,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "multiply")
                     .unwrap(),
@@ -68,7 +68,7 @@ pub fn i32_multiply() {
     assert_eq!(
         i32::MIN + 3,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "multiply")
                     .unwrap(),
@@ -92,32 +92,32 @@ pub fn i64_multiply() {
     assert_eq!(
         33_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 11_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 11_i64)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         -30_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -10_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -10_i64)
             .unwrap()
     );
 
     assert_eq!(
         i64::MAX - 5,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX - 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MAX - 1)
             .unwrap()
     );
     assert_eq!(
         i64::MIN + 3,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN + 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), i64::MIN + 1)
             .unwrap()
     );
 }

--- a/tests/arithmetic/remainder.rs
+++ b/tests/arithmetic/remainder.rs
@@ -29,7 +29,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, 2_i64)
             )
@@ -38,7 +38,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         999_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (10_000_i64, 9_001_i64)
             )
@@ -47,7 +47,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         -2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-20_i64, 3_i64)
             )
@@ -56,7 +56,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         -2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-20_i64, -3_i64)
             )
@@ -65,7 +65,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, -3_i64)
             )
@@ -74,7 +74,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, 3_i64)
             )
@@ -83,7 +83,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, -1_i64)
             )
@@ -92,7 +92,7 @@ pub fn i64_remainder_signed_simple() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 2_i64)
             )
@@ -108,7 +108,7 @@ pub fn i64_remainder_signed_panic_dividend_0() {
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let result = instance.invoke::<(i64, i64), i64>(
+    let result = instance.invoke_typed::<(i64, i64), i64>(
         &instance.get_function_by_index(0, 0).unwrap(),
         (222_i64, 0_i64),
     );
@@ -127,7 +127,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 2_i64)
             )
@@ -136,7 +136,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         i64::MIN,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, -2_i64)
             )
@@ -145,7 +145,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         (i64::MAX - 1),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-2_i64, i64::MIN)
             )
@@ -154,7 +154,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2_i64, i64::MIN)
             )
@@ -164,7 +164,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, 2_i64)
             )
@@ -173,7 +173,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         999_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (10_000_i64, 9_001_i64)
             )
@@ -182,7 +182,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-20_i64, 3_i64)
             )
@@ -191,7 +191,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         -20_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-20_i64, -3_i64)
             )
@@ -200,7 +200,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         20_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, -3_i64)
             )
@@ -209,7 +209,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         2_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (20_i64, 3_i64)
             )
@@ -218,7 +218,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         i64::MIN,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, -1_i64)
             )
@@ -227,7 +227,7 @@ pub fn i64_remainder_unsigned_simple() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN, 2_i64)
             )
@@ -244,7 +244,7 @@ pub fn i64_remainder_unsigned_panic_dividend_0() {
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let result = instance
-        .invoke::<(i64, i64), i64>(&instance.get_function_by_index(0, 0).unwrap(), (222, 0));
+        .invoke_typed::<(i64, i64), i64>(&instance.get_function_by_index(0, 0).unwrap(), (222, 0));
 
     assert_eq!(result.unwrap_err(), RuntimeError::DivideBy0);
 }
@@ -260,7 +260,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -271,7 +271,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         999,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -282,7 +282,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         -2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -293,7 +293,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         -2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -304,7 +304,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -315,7 +315,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -326,7 +326,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -337,7 +337,7 @@ pub fn i32_remainder_signed_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_s")
                     .unwrap(),
@@ -355,7 +355,7 @@ pub fn remainder_signed_panic_dividend_0() {
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let result = instance.invoke::<(i32, i32), i32>(
+    let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
             .get_function_by_name(DEFAULT_MODULE, "rem_s")
             .unwrap(),
@@ -377,7 +377,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -388,7 +388,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         i32::MIN,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -399,7 +399,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         -(i32::MIN + 2),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -410,7 +410,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -421,7 +421,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         i32::MAX,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -433,7 +433,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -444,7 +444,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         999,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -455,7 +455,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -466,7 +466,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         -20,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -477,7 +477,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         20,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -488,7 +488,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -499,7 +499,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         i32::MIN,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -510,7 +510,7 @@ pub fn i32_remainder_unsigned_simple() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "rem_u")
                     .unwrap(),
@@ -529,7 +529,7 @@ pub fn i32_remainder_unsigned_panic_dividend_0() {
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let result = instance.invoke::<(i32, i32), i32>(
+    let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
             .get_function_by_name(DEFAULT_MODULE, "rem_u")
             .unwrap(),

--- a/tests/arithmetic/subtraction.rs
+++ b/tests/arithmetic/subtraction.rs
@@ -24,7 +24,7 @@ pub fn i64_subtract() {
     assert_eq!(
         -10_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 11_i64)
             )
@@ -33,7 +33,7 @@ pub fn i64_subtract() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -42,7 +42,7 @@ pub fn i64_subtract() {
     assert_eq!(
         10_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-10_i64, -20_i64)
             )
@@ -52,7 +52,7 @@ pub fn i64_subtract() {
     assert_eq!(
         i64::MAX - 1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MAX - 1, 0_i64)
             )
@@ -61,7 +61,7 @@ pub fn i64_subtract() {
     assert_eq!(
         i64::MIN + 3,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i64::MIN + 3, 0_i64)
             )

--- a/tests/basic_memory.rs
+++ b/tests/basic_memory.rs
@@ -19,7 +19,7 @@ fn basic_memory() {
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    let _ = instance.invoke::<i32, ()>(
+    let _ = instance.invoke_typed::<i32, ()>(
         &instance
             .get_function_by_name(DEFAULT_MODULE, "store_num")
             .unwrap(),
@@ -28,7 +28,7 @@ fn basic_memory() {
     assert_eq!(
         42,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "load_num")
                     .unwrap(),
@@ -48,12 +48,12 @@ fn f32_basic_memory() {
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     instance
-        .invoke::<f32, ()>(&instance.get_function_by_index(0, 0).unwrap(), 133.7_f32)
+        .invoke_typed::<f32, ()>(&instance.get_function_by_index(0, 0).unwrap(), 133.7_f32)
         .unwrap();
     assert_eq!(
         133.7_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 1).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 1).unwrap(), ())
             .unwrap()
     );
 }

--- a/tests/conversions.rs
+++ b/tests/conversions.rs
@@ -42,7 +42,7 @@ pub fn i32_wrap_i64_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -61,19 +61,19 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1_i64)
             .unwrap()
     );
     assert_eq!(
         -100000,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -100000_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -100000_i64)
             .unwrap()
     );
     assert_eq!(
         0x80000000_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000000_i64
             )
@@ -82,7 +82,7 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0x7fffffff,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffff7fffffff_u64 as i64
             )
@@ -91,7 +91,7 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0x00000000,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffff00000000_u64 as i64
             )
@@ -100,7 +100,7 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffffeffffffff_u64 as i64
             )
@@ -109,7 +109,7 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0x00000001,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffff00000001_u64 as i64
             )
@@ -118,13 +118,13 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         0x9abcdef0_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 1311768467463790320_i64
             )
@@ -133,7 +133,7 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x00000000ffffffff_i64
             )
@@ -142,7 +142,7 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0x00000000,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x0000000100000000_i64
             )
@@ -151,7 +151,7 @@ pub fn i32_wrap_i64() {
     assert_eq!(
         0x00000001,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x0000000100000001_i64
             )
@@ -173,7 +173,7 @@ pub fn i32_trunc_f32_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -192,19 +192,19 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -213,7 +213,7 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -222,13 +222,13 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -237,19 +237,19 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.19999ap+0")
             )
@@ -258,25 +258,25 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
             .unwrap()
     );
     assert_eq!(
         -2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
             .unwrap()
     );
     assert_eq!(
         2147483520,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483520.0_f32
             )
@@ -285,7 +285,7 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         2147483648_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483648.0_f32
             )
@@ -294,7 +294,7 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(
+            .invoke_typed::<f32, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483648.0_f32
             )
@@ -304,7 +304,7 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(
+            .invoke_typed::<f32, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483904.0_f32
             )
@@ -314,7 +314,7 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(
+            .invoke_typed::<f32, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -324,7 +324,7 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(
+            .invoke_typed::<f32, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -334,14 +334,14 @@ pub fn i32_trunc_f32_s() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .err()
             .unwrap()
     );
@@ -361,19 +361,19 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -382,7 +382,7 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -391,13 +391,13 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -406,25 +406,25 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.9_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.9_f32)
             .unwrap()
     );
     assert_eq!(
         2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f32)
             .unwrap()
     );
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483648_f32
             )
@@ -433,7 +433,7 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         -256,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967040.0_f32
             )
@@ -442,7 +442,7 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.ccccccp-1")
             )
@@ -451,7 +451,7 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.fffffep-1")
             )
@@ -460,7 +460,7 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(
+            .invoke_typed::<f32, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296.0_f32
             )
@@ -470,14 +470,14 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
+            .invoke_typed::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(
+            .invoke_typed::<f32, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -487,7 +487,7 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i32>(
+            .invoke_typed::<f32, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -497,14 +497,14 @@ pub fn i32_trunc_f32_u() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed::<f32, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .err()
             .unwrap()
     );
@@ -524,7 +524,7 @@ pub fn i32_trunc_f64_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -543,19 +543,19 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -564,7 +564,7 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -573,13 +573,13 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -588,19 +588,19 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f64)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.199999999999ap+0")
             )
@@ -609,25 +609,25 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f64)
             .unwrap()
     );
     assert_eq!(
         -2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f64)
             .unwrap()
     );
     assert_eq!(
         2147483647,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483647.0_f64
             )
@@ -636,7 +636,7 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483648.0_f64
             )
@@ -645,7 +645,7 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483648.9_f64
             )
@@ -654,7 +654,7 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483648.9_f64
             )
@@ -663,14 +663,14 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 2147483648.0)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 2147483648.0)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(
+            .invoke_typed::<f64, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483649.0
             )
@@ -680,7 +680,7 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(
+            .invoke_typed::<f64, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -690,7 +690,7 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(
+            .invoke_typed::<f64, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -700,14 +700,14 @@ pub fn i32_trunc_f64_s() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .err()
             .unwrap()
     );
@@ -727,19 +727,19 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -748,7 +748,7 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -757,13 +757,13 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -772,25 +772,25 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.9_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.9_f64)
             .unwrap()
     );
     assert_eq!(
         2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f64)
             .unwrap()
     );
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483648_f64
             )
@@ -799,7 +799,7 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967295.0_f64
             )
@@ -808,7 +808,7 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.ccccccccccccdp-1")
             )
@@ -817,7 +817,7 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffffffffffp-1")
             )
@@ -826,19 +826,19 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         100000000,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.9)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.9)
             .unwrap()
     );
     assert_eq!(
         4294967295_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967295.9_f64
             )
@@ -847,35 +847,35 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 4294967296.0)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 4294967296.0)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 1e16)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 1e16)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 1e30)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), 1e30)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(
+            .invoke_typed::<f64, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808_f64
             )
@@ -885,7 +885,7 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(
+            .invoke_typed::<f64, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -895,7 +895,7 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i32>(
+            .invoke_typed::<f64, i32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -905,14 +905,14 @@ pub fn i32_trunc_f64_u() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed::<f64, i32>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .err()
             .unwrap()
     );
@@ -932,7 +932,7 @@ pub fn i64_extend_i32_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -951,37 +951,37 @@ pub fn i64_extend_i32_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         10000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 10000)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 10000)
             .unwrap()
     );
     assert_eq!(
         -10000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -10000)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -10000)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
     assert_eq!(
         0x000000007fffffff_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0x7fffffff)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0x7fffffff)
             .unwrap()
     );
     assert_eq!(
         0xffffffff80000000_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000000_u32 as i32
             )
@@ -1003,37 +1003,37 @@ pub fn i64_extend_i32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         10000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 10000)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 10000)
             .unwrap()
     );
     assert_eq!(
         0x00000000ffffd8f0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -10000)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -10000)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
     assert_eq!(
         0x000000007fffffff_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0x7fffffff)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0x7fffffff)
             .unwrap()
     );
     assert_eq!(
         0x0000000080000000_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000000_u32 as i32
             )
@@ -1055,7 +1055,7 @@ pub fn i64_trunc_f32_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -1074,19 +1074,19 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -1095,7 +1095,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -1104,13 +1104,13 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -1119,19 +1119,19 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.19999ap+0")
             )
@@ -1140,25 +1140,25 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
             .unwrap()
     );
     assert_eq!(
         -2_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
             .unwrap()
     );
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f32
             )
@@ -1167,7 +1167,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         -4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -4294967296_f32
             )
@@ -1176,7 +1176,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         9223371487098961920_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223371487098961920.0_f32
             )
@@ -1185,7 +1185,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         -9223372036854775808_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808.0_f32
             )
@@ -1194,7 +1194,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(
+            .invoke_typed::<f32, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808.0_f32
             )
@@ -1204,7 +1204,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(
+            .invoke_typed::<f32, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223373136366403584.0_f32
             )
@@ -1214,7 +1214,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(
+            .invoke_typed::<f32, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -1224,7 +1224,7 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(
+            .invoke_typed::<f32, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -1234,14 +1234,14 @@ pub fn i64_trunc_f32_s() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .err()
             .unwrap()
     );
@@ -1261,19 +1261,19 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -1282,7 +1282,7 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -1291,13 +1291,13 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -1306,13 +1306,13 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f32
             )
@@ -1321,7 +1321,7 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         -1099511627776_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446742974197923840.0_f32
             )
@@ -1330,7 +1330,7 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -1339,7 +1339,7 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.fffffep-1")
             )
@@ -1348,7 +1348,7 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(
+            .invoke_typed::<f32, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446744073709551616.0_f32
             )
@@ -1358,14 +1358,14 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
+            .invoke_typed::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(
+            .invoke_typed::<f32, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -1375,7 +1375,7 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f32, i64>(
+            .invoke_typed::<f32, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -1385,14 +1385,14 @@ pub fn i64_trunc_f32_u() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed::<f32, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .err()
             .unwrap()
     );
@@ -1412,7 +1412,7 @@ pub fn i64_trunc_f64_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -1431,19 +1431,19 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -1452,7 +1452,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -1461,13 +1461,13 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -1476,19 +1476,19 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f64)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.199999999999ap+0")
             )
@@ -1497,25 +1497,25 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f64)
             .unwrap()
     );
     assert_eq!(
         -2_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f64)
             .unwrap()
     );
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f64
             )
@@ -1524,7 +1524,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         -4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -4294967296_f64
             )
@@ -1533,7 +1533,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         9223372036854774784_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854774784.0_f64
             )
@@ -1542,7 +1542,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         -9223372036854775808_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808.0_f64
             )
@@ -1551,7 +1551,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(
+            .invoke_typed::<f64, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808.0_f64
             )
@@ -1561,7 +1561,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(
+            .invoke_typed::<f64, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854777856.0_f64
             )
@@ -1571,7 +1571,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(
+            .invoke_typed::<f64, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -1581,7 +1581,7 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(
+            .invoke_typed::<f64, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -1591,14 +1591,14 @@ pub fn i64_trunc_f64_s() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .err()
             .unwrap()
     );
@@ -1618,19 +1618,19 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -1639,7 +1639,7 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -1648,13 +1648,13 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -1663,13 +1663,13 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967295_f64
             )
@@ -1678,7 +1678,7 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         0x100000000_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f64
             )
@@ -1687,7 +1687,7 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         -2048_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446744073709549568.0_f64
             )
@@ -1696,7 +1696,7 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.ccccccccccccdp-1")
             )
@@ -1705,7 +1705,7 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffffffffffp-1")
             )
@@ -1714,19 +1714,19 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         100000000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
             .unwrap()
     );
     assert_eq!(
         10000000000000000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e16_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e16_f64)
             .unwrap()
     );
     assert_eq!(
         -9223372036854775808_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808_f64
             )
@@ -1735,7 +1735,7 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(
+            .invoke_typed::<f64, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446744073709551616.0_f64
             )
@@ -1745,14 +1745,14 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), -1_f64)
+            .invoke_typed::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), -1_f64)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(
+            .invoke_typed::<f64, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -1762,7 +1762,7 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         RuntimeError::UnrepresentableResult,
         instance
-            .invoke::<f64, i64>(
+            .invoke_typed::<f64, i64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -1772,14 +1772,14 @@ pub fn i64_trunc_f64_u() {
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .err()
             .unwrap()
     );
     assert_eq!(
         RuntimeError::BadConversionToInteger,
         instance
-            .invoke::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed::<f64, i64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .err()
             .unwrap()
     );
@@ -1799,7 +1799,7 @@ pub fn f32_convert_i32_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -1818,37 +1818,37 @@ pub fn f32_convert_i32_s() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1)
             .unwrap()
     );
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         2147483648_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
             .unwrap()
     );
     assert_eq!(
         -2147483648_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
             .unwrap()
     );
     assert_eq!(
         hexf32!("0x1.26580cp+30"),
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1234567890)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1234567890)
             .unwrap()
     );
 }
@@ -1867,37 +1867,37 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         2147483648_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
             .unwrap()
     );
     assert_eq!(
         2147483648_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
             .unwrap()
     );
     assert_eq!(
         hexf32!("0x1.234568p+28"),
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0x12345678)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0x12345678)
             .unwrap()
     );
     assert_eq!(
         4294967296.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffff_u32 as i32
             )
@@ -1906,7 +1906,7 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         hexf32!("0x1.000000p+31"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000080_u32 as i32
             )
@@ -1915,7 +1915,7 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         hexf32!("0x1.000002p+31"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000081_u32 as i32
             )
@@ -1924,7 +1924,7 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         hexf32!("0x1.000002p+31"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000082_u32 as i32
             )
@@ -1933,7 +1933,7 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         hexf32!("0x1.fffffcp+31"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffe80_u32 as i32
             )
@@ -1942,7 +1942,7 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         hexf32!("0x1.fffffep+31"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffe81_u32 as i32
             )
@@ -1951,7 +1951,7 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         hexf32!("0x1.fffffep+31"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffe82_u32 as i32
             )
@@ -1960,13 +1960,13 @@ pub fn f32_convert_i32_u() {
     assert_eq!(
         16777216.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 16777217)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 16777217)
             .unwrap()
     );
     assert_eq!(
         16777220.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 16777219)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 16777219)
             .unwrap()
     );
 }
@@ -1985,7 +1985,7 @@ pub fn f32_convert_i64_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -2003,25 +2003,25 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
             .unwrap()
     );
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1_i64)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         9223372036854775807_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775807_i64
             )
@@ -2030,7 +2030,7 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         -9223372036854775808_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808_i64
             )
@@ -2039,7 +2039,7 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         hexf32!("0x1.1db9e8p+48"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 314159265358979_i64
             )
@@ -2048,13 +2048,13 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         16777216.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 16777217_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 16777217_i64)
             .unwrap()
     );
     assert_eq!(
         -16777216.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -16777217_i64
             )
@@ -2063,13 +2063,13 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         16777220.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 16777219_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 16777219_i64)
             .unwrap()
     );
     assert_eq!(
         -16777220.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -16777219_i64
             )
@@ -2079,7 +2079,7 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         hexf32!("0x1.fffffep+62"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x7fffff4000000001_i64
             )
@@ -2088,7 +2088,7 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         hexf32!("-0x1.fffffep+62"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000004000000001_u64 as i64
             )
@@ -2097,7 +2097,7 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         hexf32!("0x1.000002p+53"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x0020000020000001_i64
             )
@@ -2106,7 +2106,7 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         hexf32!("-0x1.000002p+53"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffdfffffdfffffff_u64 as i64
             )
@@ -2128,19 +2128,19 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         9223372036854775807_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775807_i64
             )
@@ -2149,7 +2149,7 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         9223372036854775808_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808_i64
             )
@@ -2158,7 +2158,7 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         18446744073709551616.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffffffffffff_u64 as i64
             )
@@ -2168,20 +2168,20 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         16777216.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 16777217_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 16777217_i64)
             .unwrap()
     );
     assert_eq!(
         16777220.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 16777219_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 16777219_i64)
             .unwrap()
     );
 
     assert_eq!(
         hexf32!("0x1.000002p+53"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x0020000020000001_i64
             )
@@ -2190,7 +2190,7 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         hexf32!("0x1.fffffep+62"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x7fffffbfffffffff_i64
             )
@@ -2199,7 +2199,7 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         hexf32!("0x1.000002p+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000008000000001_u64 as i64
             )
@@ -2208,7 +2208,7 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         hexf32!("0x1.fffffep+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffe8000000001_u64 as i64
             )
@@ -2230,7 +2230,7 @@ pub fn f32_demote_f64_let_it_die() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
 }
@@ -2249,19 +2249,19 @@ pub fn f32_demote_f64() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         -0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -2270,7 +2270,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         -0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -2279,19 +2279,19 @@ pub fn f32_demote_f64() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
             .unwrap()
     );
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f64)
             .unwrap()
     );
     assert_eq!(
         hexf32!("0x1p-126"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffe0000000p-127")
             )
@@ -2300,7 +2300,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1p-126"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffe0000000p-127")
             )
@@ -2309,7 +2309,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.fffffcp-127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffdfffffffp-127")
             )
@@ -2318,7 +2318,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1.fffffcp-127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffdfffffffp-127")
             )
@@ -2327,7 +2327,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1p-149"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1p-149")
             )
@@ -2336,7 +2336,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1p-149"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1p-149")
             )
@@ -2345,7 +2345,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.fffffcp+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffd0000000p+127")
             )
@@ -2354,7 +2354,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1.fffffcp+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffd0000000p+127")
             )
@@ -2363,7 +2363,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffd0000001p+127")
             )
@@ -2372,7 +2372,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffd0000001p+127")
             )
@@ -2381,7 +2381,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffep+127")
             )
@@ -2390,7 +2390,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffep+127")
             )
@@ -2399,7 +2399,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffefffffffp+127")
             )
@@ -2408,7 +2408,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffefffffffp+127")
             )
@@ -2417,7 +2417,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         f32::INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.ffffffp+127")
             )
@@ -2426,7 +2426,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         f32::NEG_INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.ffffffp+127")
             )
@@ -2435,7 +2435,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1p-119"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1p-119")
             )
@@ -2444,7 +2444,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.8f867ep+125"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.8f867ep+125")
             )
@@ -2453,7 +2453,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         f32::INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -2462,7 +2462,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         f32::NEG_INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -2471,7 +2471,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000000000001p+0")
             )
@@ -2480,7 +2480,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffffffffffp-1")
             )
@@ -2489,7 +2489,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000000p+0"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000010000000p+0")
             )
@@ -2498,7 +2498,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000002p+0"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000010000001p+0")
             )
@@ -2507,7 +2507,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000002p+0"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.000002fffffffp+0")
             )
@@ -2516,7 +2516,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000004p+0"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000030000000p+0")
             )
@@ -2525,7 +2525,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000004p+0"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000050000000p+0")
             )
@@ -2534,7 +2534,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.0p+24"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000010000000p+24")
             )
@@ -2543,7 +2543,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000002p+24"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000010000001p+24")
             )
@@ -2552,7 +2552,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000002p+24"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.000002fffffffp+24")
             )
@@ -2561,7 +2561,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.000004p+24"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000030000000p+24")
             )
@@ -2570,7 +2570,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.4eae5p+108"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.4eae4f7024c7p+108")
             )
@@ -2579,7 +2579,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.a12e72p-113"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.a12e71e358685p-113")
             )
@@ -2588,7 +2588,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1.cb9834p-127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.cb98354d521ffp-127")
             )
@@ -2597,7 +2597,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1.6972b4p+1"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.6972b30cfb562p+1")
             )
@@ -2606,22 +2606,22 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1.bedbe4p+112"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.bedbe4819d4c4p+112")
             )
             .unwrap()
     );
-    // assert_eq!(f32::NAN, instance.invoke(&instance.get_fn_idx(0, 0).unwrap(), f64::NAN).unwrap());
+    // assert_eq!(f32::NAN, instance.invoke_typed(&instance.get_fn_idx(0, 0).unwrap(), f64::NAN).unwrap());
     // (assert_return (invoke "f32.demote_f64" (f64.const nan)) (f32.const nan:canonical))
     // (assert_return (invoke "f32.demote_f64" (f64.const nan:0x4000000000000)) (f32.const nan:arithmetic))
-    // assert_eq!(f32::NAN, instance.invoke(&instance.get_fn_idx(0, 0).unwrap(), -f64::NAN).unwrap());
+    // assert_eq!(f32::NAN, instance.invoke_typed(&instance.get_fn_idx(0, 0).unwrap(), -f64::NAN).unwrap());
     // (assert_return (invoke "f32.demote_f64" (f64.const -nan)) (f32.const nan:canonical))
     // (assert_return (invoke "f32.demote_f64" (f64.const -nan:0x4000000000000)) (f32.const nan:arithmetic))
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1p-1022")
             )
@@ -2630,7 +2630,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         -0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1p-1022")
             )
@@ -2639,7 +2639,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0p-150")
             )
@@ -2648,7 +2648,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         -0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.0p-150")
             )
@@ -2657,7 +2657,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("0x1p-149"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.0000000000001p-150")
             )
@@ -2666,7 +2666,7 @@ pub fn f32_demote_f64() {
     assert_eq!(
         hexf32!("-0x1p-149"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.0000000000001p-150")
             )
@@ -2688,7 +2688,7 @@ pub fn f64_convert_i32_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -2707,37 +2707,37 @@ pub fn f64_convert_i32_s() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1)
             .unwrap()
     );
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         2147483647_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
             .unwrap()
     );
     assert_eq!(
         -2147483648_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
             .unwrap()
     );
     assert_eq!(
         987654321_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 987654321)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 987654321)
             .unwrap()
     );
 }
@@ -2756,31 +2756,31 @@ pub fn f64_convert_i32_u() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         2147483647_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2147483647)
             .unwrap()
     );
     assert_eq!(
         2147483648_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2147483648)
             .unwrap()
     );
     assert_eq!(
         4294967295.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffff_u32 as i32
             )
@@ -2802,7 +2802,7 @@ pub fn f64_convert_i64_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -2821,25 +2821,25 @@ pub fn f64_convert_i64_s() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
             .unwrap()
     );
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1_i64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         9223372036854775807_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775807_i64
             )
@@ -2848,7 +2848,7 @@ pub fn f64_convert_i64_s() {
     assert_eq!(
         -9223372036854775808_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808_i64
             )
@@ -2857,7 +2857,7 @@ pub fn f64_convert_i64_s() {
     assert_eq!(
         4669201609102990_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4669201609102990_i64
             )
@@ -2866,7 +2866,7 @@ pub fn f64_convert_i64_s() {
     assert_eq!(
         9007199254740992_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9007199254740993_i64
             )
@@ -2875,7 +2875,7 @@ pub fn f64_convert_i64_s() {
     assert_eq!(
         -9007199254740992_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9007199254740993_i64
             )
@@ -2884,7 +2884,7 @@ pub fn f64_convert_i64_s() {
     assert_eq!(
         9007199254740996_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9007199254740995_i64
             )
@@ -2893,7 +2893,7 @@ pub fn f64_convert_i64_s() {
     assert_eq!(
         -9007199254740996_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9007199254740995_i64
             )
@@ -2915,19 +2915,19 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         9223372036854775807_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775807_i64
             )
@@ -2936,7 +2936,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         9223372036854775808_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808_i64
             )
@@ -2945,7 +2945,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         18446744073709551616.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffffffffffff_u64 as i64
             )
@@ -2954,7 +2954,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         hexf64!("0x1.0000000000000p+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000000000000400_u64 as i64
             )
@@ -2963,7 +2963,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         hexf64!("0x1.0000000000001p+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000000000000401_u64 as i64
             )
@@ -2972,7 +2972,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         hexf64!("0x1.0000000000001p+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000000000000402_u64 as i64
             )
@@ -2981,7 +2981,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         hexf64!("0x1.ffffffffffffep+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffffffffff400_u64 as i64
             )
@@ -2990,7 +2990,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         hexf64!("0x1.fffffffffffffp+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffffffffff401_u64 as i64
             )
@@ -2999,7 +2999,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         hexf64!("0x1.fffffffffffffp+63"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffffffffff402_u64 as i64
             )
@@ -3009,7 +3009,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         9007199254740992_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9007199254740993_i64
             )
@@ -3018,7 +3018,7 @@ pub fn f64_convert_i64_u() {
     assert_eq!(
         9007199254740996_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9007199254740995_i64
             )
@@ -3040,7 +3040,7 @@ pub fn f64_promote_f32_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -3059,19 +3059,19 @@ pub fn f64_promote_f32() {
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         -0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         hexf64!("0x1p-149"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -3080,7 +3080,7 @@ pub fn f64_promote_f32() {
     assert_eq!(
         hexf64!("-0x1p-149"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -3089,19 +3089,19 @@ pub fn f64_promote_f32() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
             .unwrap()
     );
     assert_eq!(
         hexf64!("-0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.fffffep+127")
             )
@@ -3110,7 +3110,7 @@ pub fn f64_promote_f32() {
     assert_eq!(
         hexf64!("0x1.fffffep+127"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.fffffep+127")
             )
@@ -3119,7 +3119,7 @@ pub fn f64_promote_f32() {
     assert_eq!(
         hexf64!("0x1p-119"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-119")
             )
@@ -3128,7 +3128,7 @@ pub fn f64_promote_f32() {
     assert_eq!(
         6.638_253_671_010_439_5e37_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.8f867ep+125")
             )
@@ -3137,7 +3137,7 @@ pub fn f64_promote_f32() {
     assert_eq!(
         f64::INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -3146,7 +3146,7 @@ pub fn f64_promote_f32() {
     assert_eq!(
         f64::NEG_INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -3172,7 +3172,7 @@ pub fn i32_reinterpret_f32_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -3191,19 +3191,19 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0x80000000_u32 as i32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -3213,7 +3213,7 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         0x80000001_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -3222,13 +3222,13 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         1065353216,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1078530010,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 3.1415926_f32
             )
@@ -3237,7 +3237,7 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         2139095039,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.fffffep+127")
             )
@@ -3246,7 +3246,7 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         -8388609,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.fffffep+127")
             )
@@ -3255,7 +3255,7 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         0x7f800000,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -3264,7 +3264,7 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         0xff800000_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -3273,13 +3273,13 @@ pub fn i32_reinterpret_f32() {
     assert_eq!(
         0x7fc00000,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .unwrap()
     );
     assert_eq!(
         0xffc00000_u32 as i32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.reinterpret_f32" (f32.const -nan)) (i32.const 0xffc00000))
@@ -3301,7 +3301,7 @@ pub fn i64_reinterpret_f64_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -3320,19 +3320,19 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0x8000000000000000_u64 as i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -3342,7 +3342,7 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         0x8000000000000001_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -3351,13 +3351,13 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         4607182418800017408_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f64)
             .unwrap()
     );
     assert_eq!(
         4614256656552045841_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 3.14159265358979_f64
             )
@@ -3366,7 +3366,7 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         9218868437227405311_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.fffffffffffffp+1023")
             )
@@ -3375,7 +3375,7 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         -4503599627370497_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffffffffffp+1023")
             )
@@ -3384,7 +3384,7 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         0x7ff0000000000000_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -3393,7 +3393,7 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         0xfff0000000000000_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -3402,13 +3402,13 @@ pub fn i64_reinterpret_f64() {
     assert_eq!(
         0x7ff8000000000000_u64 as i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .unwrap()
     );
     assert_eq!(
         0xfff8000000000000_u64 as i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.reinterpret_f64" (f64.const nan:0x4000000000000)) (i64.const 0x7ff4000000000000))
@@ -3429,7 +3429,7 @@ pub fn f32_reinterpret_i32_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -3448,13 +3448,13 @@ pub fn f32_reinterpret_i32() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         -0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000000_u32 as i32
             )
@@ -3463,32 +3463,32 @@ pub fn f32_reinterpret_i32() {
     assert_eq!(
         hexf32!("0x1p-149"),
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1)
             .unwrap()
     );
     // (assert_return (invoke "f32.reinterpret_i32" (i32.const -1)) (f32.const -nan:0x7fffff))
     assert_eq!(
         hexf32!("0x1.b79a2ap-113"),
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 123456789)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 123456789)
             .unwrap()
     );
     assert_eq!(
         hexf32!("-0x1p-149"),
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2147483647)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2147483647)
             .unwrap()
     );
     assert_eq!(
         f32::INFINITY,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0x7f800000)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0x7f800000)
             .unwrap()
     );
     assert_eq!(
         f32::NEG_INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xff800000_u32 as i32
             )
@@ -3496,14 +3496,14 @@ pub fn f32_reinterpret_i32() {
     );
     {
         let result: f32 = instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0x7fc00000)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0x7fc00000)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_positive());
     }
     {
         let result: f32 = instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffc00000_u32 as i32,
             )
@@ -3529,7 +3529,7 @@ pub fn f64_reinterpret_i64_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -3548,20 +3548,20 @@ pub fn f64_reinterpret_i64() {
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         hexf64!("0x0.0000000000001p-1022"),
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
             .unwrap()
     );
     // (assert_return (invoke "f64.reinterpret_i64" (i64.const -1)) (f64.const -nan:0xfffffffffffff))
     assert_eq!(
         -0.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000000000000000_u64 as i64
             )
@@ -3570,7 +3570,7 @@ pub fn f64_reinterpret_i64() {
     assert_eq!(
         hexf64!("0x0.00000499602d2p-1022"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 1234567890_i64
             )
@@ -3579,7 +3579,7 @@ pub fn f64_reinterpret_i64() {
     assert_eq!(
         hexf64!("-0x0.0000000000001p-1022"),
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775807_i64
             )
@@ -3588,7 +3588,7 @@ pub fn f64_reinterpret_i64() {
     assert_eq!(
         f64::INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x7ff0000000000000_u64 as i64
             )
@@ -3597,7 +3597,7 @@ pub fn f64_reinterpret_i64() {
     assert_eq!(
         f64::NEG_INFINITY,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfff0000000000000_u64 as i64
             )
@@ -3605,7 +3605,7 @@ pub fn f64_reinterpret_i64() {
     );
     {
         let result: f64 = instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x7ff8000000000000_u64 as i64,
             )
@@ -3615,7 +3615,7 @@ pub fn f64_reinterpret_i64() {
     }
     {
         let result: f64 = instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfff8000000000000_u64 as i64,
             )

--- a/tests/dynamic.rs
+++ b/tests/dynamic.rs
@@ -1,11 +1,8 @@
-use wasm::NumType;
-
 /// A simple function to add two numbers and return the result, using [invoke_dynamic](wasm::RuntimeInstance::invoke_dynamic)
 /// instead of [invoke_named](wasm::RuntimeInstance::invoke_named).
 #[test_log::test]
 fn dynamic_add() {
-    use wasm::{validate, RuntimeInstance};
-    use wasm::{ValType, Value};
+    use wasm::{validate, RuntimeInstance, Value};
 
     let wat = r#"
     (module
@@ -23,20 +20,12 @@ fn dynamic_add() {
     let func = instance.get_function_by_index(0, 0).unwrap();
 
     let res = instance
-        .invoke_dynamic(
-            &func,
-            vec![Value::I32(11), Value::I32(1)],
-            &[ValType::NumType(NumType::I32)],
-        )
+        .invoke(&func, vec![Value::I32(11), Value::I32(1)])
         .expect("invocation failed");
     assert_eq!(vec![Value::I32(12)], res);
 
     let res = func
-        .invoke_dynamic(
-            &mut instance,
-            vec![Value::I32(-6i32 as u32), Value::I32(1)],
-            &[ValType::NumType(NumType::I32)],
-        )
+        .invoke(&mut instance, vec![Value::I32(-6i32 as u32), Value::I32(1)])
         .expect("invocation failed");
     assert_eq!(vec![Value::I32(-5i32 as u32)], res);
 }

--- a/tests/f32.rs
+++ b/tests/f32.rs
@@ -23,7 +23,7 @@ pub fn f32_const() {
     assert_eq!(
         3.141_592_7_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -52,7 +52,7 @@ pub fn f32_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f32, 1.1_f32)
             )
@@ -61,7 +61,7 @@ pub fn f32_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f32, 1.2_f32)
             )
@@ -81,7 +81,7 @@ pub fn f32_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f32, 1.1_f32)
             )
@@ -90,7 +90,7 @@ pub fn f32_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f32, 1.2_f32)
             )
@@ -99,7 +99,7 @@ pub fn f32_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f32, -0.0_f32)
             )
@@ -119,7 +119,7 @@ pub fn f32_lt() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 2.0_f32)
             )
@@ -128,7 +128,7 @@ pub fn f32_lt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f32, 1.0_f32)
             )
@@ -137,7 +137,7 @@ pub fn f32_lt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 1.0_f32)
             )
@@ -157,7 +157,7 @@ pub fn f32_gt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 2.0_f32)
             )
@@ -166,7 +166,7 @@ pub fn f32_gt() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f32, 1.0_f32)
             )
@@ -175,7 +175,7 @@ pub fn f32_gt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 1.0_f32)
             )
@@ -195,7 +195,7 @@ pub fn f32_le() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 2.0_f32)
             )
@@ -204,7 +204,7 @@ pub fn f32_le() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f32, 1.0_f32)
             )
@@ -213,7 +213,7 @@ pub fn f32_le() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 1.0_f32)
             )
@@ -233,7 +233,7 @@ pub fn f32_ge() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 2.0_f32)
             )
@@ -242,7 +242,7 @@ pub fn f32_ge() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f32, 1.0_f32)
             )
@@ -251,7 +251,7 @@ pub fn f32_ge() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 1.0_f32)
             )
@@ -278,21 +278,21 @@ pub fn f32_abs() {
 
     {
         let result = instance
-            .invoke::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_positive());
     }
     {
         let result = instance
-            .invoke::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_positive());
     }
     {
         let result = instance
-            .invoke::<f32, f32>(
+            .invoke_typed::<f32, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY,
             )
@@ -302,7 +302,7 @@ pub fn f32_abs() {
     }
     {
         let result = instance
-            .invoke::<f32, f32>(
+            .invoke_typed::<f32, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY,
             )
@@ -313,25 +313,25 @@ pub fn f32_abs() {
     assert_eq!(
         1.5_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         1.5_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
 }
@@ -347,21 +347,21 @@ pub fn f32_neg() {
 
     {
         let result = instance
-            .invoke::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_positive());
     }
     {
         let result = instance
-            .invoke::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_negative());
     }
     {
         let result = instance
-            .invoke::<f32, f32>(
+            .invoke_typed::<f32, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY,
             )
@@ -371,7 +371,7 @@ pub fn f32_neg() {
     }
     {
         let result = instance
-            .invoke::<f32, f32>(
+            .invoke_typed::<f32, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY,
             )
@@ -382,25 +382,25 @@ pub fn f32_neg() {
     assert_eq!(
         -1.5_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         1.5_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
 }
@@ -417,19 +417,19 @@ pub fn f32_ceil() {
     assert_eq!(
         2.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f32)
             .unwrap()
     );
 }
@@ -446,19 +446,19 @@ pub fn f32_floor() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -2.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f32)
             .unwrap()
     );
 }
@@ -475,19 +475,19 @@ pub fn f32_trunc() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.9_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.9_f32)
             .unwrap()
     );
 }
@@ -504,25 +504,25 @@ pub fn f32_nearest() {
     assert_eq!(
         2.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -2.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.6_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.6_f32)
             .unwrap()
     );
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.4_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.4_f32)
             .unwrap()
     );
 }
@@ -539,17 +539,17 @@ pub fn f32_sqrt() {
     assert_eq!(
         2.0_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 4.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 4.0_f32)
             .unwrap()
     );
     assert_eq!(
         1.4142135_f32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f32)
             .unwrap()
     );
     assert!(instance
-        .invoke::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+        .invoke_typed::<f32, f32>(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
         .unwrap()
         .is_nan());
 }
@@ -575,7 +575,7 @@ pub fn f32_add() {
     assert_eq!(
         3.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f32, 1.5_f32)
             )
@@ -584,7 +584,7 @@ pub fn f32_add() {
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, -2.0_f32)
             )
@@ -593,7 +593,7 @@ pub fn f32_add() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.1_f32, -0.1_f32)
             )
@@ -613,7 +613,7 @@ pub fn f32_sub() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f32, 1.5_f32)
             )
@@ -622,7 +622,7 @@ pub fn f32_sub() {
     assert_eq!(
         3.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, -2.0_f32)
             )
@@ -631,7 +631,7 @@ pub fn f32_sub() {
     assert_eq!(
         0.2_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.1_f32, -0.1_f32)
             )
@@ -651,7 +651,7 @@ pub fn f32_mul() {
     assert_eq!(
         6.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f32, 3.0_f32)
             )
@@ -660,7 +660,7 @@ pub fn f32_mul() {
     assert_eq!(
         -4.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f32, -2.0_f32)
             )
@@ -669,7 +669,7 @@ pub fn f32_mul() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f32, 5.0_f32)
             )
@@ -689,7 +689,7 @@ pub fn f32_div() {
     assert_eq!(
         2.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (6.0_f32, 3.0_f32)
             )
@@ -698,21 +698,21 @@ pub fn f32_div() {
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f32, -2.0_f32)
             )
             .unwrap()
     );
     assert!(instance
-        .invoke::<(f32, f32), f32>(
+        .invoke_typed::<(f32, f32), f32>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (1.0_f32, 0.0_f32)
         )
         .unwrap()
         .is_infinite());
     assert!(instance
-        .invoke::<(f32, f32), f32>(
+        .invoke_typed::<(f32, f32), f32>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (0.0_f32, 0.0_f32)
         )
@@ -731,7 +731,7 @@ pub fn f32_min() {
 
     {
         let result = instance
-            .invoke::<(f32, f32), f32>(
+            .invoke_typed::<(f32, f32), f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::NAN, -f32::NAN),
             )
@@ -740,7 +740,7 @@ pub fn f32_min() {
     }
     {
         let result = instance
-            .invoke::<(f32, f32), f32>(
+            .invoke_typed::<(f32, f32), f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::NAN, f32::NAN),
             )
@@ -750,7 +750,7 @@ pub fn f32_min() {
     }
     {
         let result = instance
-            .invoke::<(f32, f32), f32>(
+            .invoke_typed::<(f32, f32), f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::INFINITY, f32::NEG_INFINITY),
             )
@@ -761,7 +761,7 @@ pub fn f32_min() {
     assert_eq!(
         42_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::INFINITY, 42_f32)
             )
@@ -770,7 +770,7 @@ pub fn f32_min() {
     assert_eq!(
         -0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-0_f32, 0_f32)
             )
@@ -779,7 +779,7 @@ pub fn f32_min() {
     assert_eq!(
         1.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 2.0_f32)
             )
@@ -788,7 +788,7 @@ pub fn f32_min() {
     assert_eq!(
         -2.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.0_f32, -2.0_f32)
             )
@@ -797,14 +797,14 @@ pub fn f32_min() {
     assert_eq!(
         -0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f32, -0.0_f32)
             )
             .unwrap()
     );
     assert!(instance
-        .invoke::<(f32, f32), f32>(
+        .invoke_typed::<(f32, f32), f32>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (f32::NAN, 1.0_f32)
         )
@@ -823,7 +823,7 @@ pub fn f32_max() {
 
     {
         let result = instance
-            .invoke::<(f32, f32), f32>(
+            .invoke_typed::<(f32, f32), f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::NAN, -f32::NAN),
             )
@@ -832,7 +832,7 @@ pub fn f32_max() {
     }
     {
         let result = instance
-            .invoke::<(f32, f32), f32>(
+            .invoke_typed::<(f32, f32), f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::NAN, f32::NAN),
             )
@@ -842,7 +842,7 @@ pub fn f32_max() {
     }
     {
         let result = instance
-            .invoke::<(f32, f32), f32>(
+            .invoke_typed::<(f32, f32), f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::INFINITY, f32::NEG_INFINITY),
             )
@@ -853,7 +853,7 @@ pub fn f32_max() {
     assert_eq!(
         42_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f32::NEG_INFINITY, 42_f32)
             )
@@ -862,7 +862,7 @@ pub fn f32_max() {
     assert_eq!(
         0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-0_f32, 0_f32)
             )
@@ -872,7 +872,7 @@ pub fn f32_max() {
     assert_eq!(
         2.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f32, 2.0_f32)
             )
@@ -881,7 +881,7 @@ pub fn f32_max() {
     assert_eq!(
         -1.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.0_f32, -2.0_f32)
             )
@@ -890,14 +890,14 @@ pub fn f32_max() {
     assert_eq!(
         0.0_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f32, -0.0_f32)
             )
             .unwrap()
     );
     assert!(instance
-        .invoke::<(f32, f32), f32>(
+        .invoke_typed::<(f32, f32), f32>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (f32::NAN, 1.0_f32)
         )
@@ -917,7 +917,7 @@ pub fn f32_copysign() {
     assert_eq!(
         1.5_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f32, 2.0_f32)
             )
@@ -926,7 +926,7 @@ pub fn f32_copysign() {
     assert_eq!(
         -1.5_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f32, -2.0_f32)
             )
@@ -935,7 +935,7 @@ pub fn f32_copysign() {
     assert_eq!(
         -1.5_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.5_f32, -0.0_f32)
             )
@@ -944,7 +944,7 @@ pub fn f32_copysign() {
     assert_eq!(
         1.5_f32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.5_f32, 0.0_f32)
             )
@@ -968,7 +968,7 @@ pub fn f32_convert_i32_s() {
 
     let i32_s_val = -42_i32;
     let f32_result = instance
-        .invoke::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), i32_s_val)
+        .invoke_typed::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), i32_s_val)
         .unwrap();
     assert_eq!(f32_result, -42.0_f32);
 }
@@ -999,7 +999,7 @@ pub fn f32_convert_i32_u() {
 
     for (input, expected) in test_cases {
         let result = instance
-            .invoke::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), input)
+            .invoke_typed::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), input)
             .unwrap();
         assert_eq!(
             result, expected,
@@ -1011,7 +1011,7 @@ pub fn f32_convert_i32_u() {
     // Test for precision loss
     let large_value = 0xFFFFFFFF_u32 as i32; // Maximum u32 value
     let result = instance
-        .invoke::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), large_value)
+        .invoke_typed::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), large_value)
         .unwrap();
     assert!(
         result > 4294967040.0 && result <= 4294967296.0,
@@ -1035,14 +1035,14 @@ pub fn f32_convert_i64_s() {
 
     let i64_s_val = i64::MIN; // Minimum i64 value
     let f32_result: f32 = instance
-        .invoke::<i64, f32>(&instance.get_function_by_index(0, 0).unwrap(), i64_s_val)
+        .invoke_typed::<i64, f32>(&instance.get_function_by_index(0, 0).unwrap(), i64_s_val)
         .unwrap();
     assert_eq!(f32_result, i64::MIN as f32);
 
     assert_eq!(
         9223371500000000000.0,
         instance
-            .invoke::<i64, f32>(
+            .invoke_typed::<i64, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x7fffff4000000001_i64
             )
@@ -1051,7 +1051,7 @@ pub fn f32_convert_i64_s() {
     assert_eq!(
         -9223371500000000000.0,
         instance
-            .invoke::<i64, f32>(
+            .invoke_typed::<i64, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000004000000001_u64 as i64
             )
@@ -1076,7 +1076,7 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         9223373000000000000.0,
         instance
-            .invoke::<i64, f32>(
+            .invoke_typed::<i64, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000008000000001u64 as i64
             )
@@ -1085,7 +1085,7 @@ pub fn f32_convert_i64_u() {
     assert_eq!(
         18446743000000000000.0,
         instance
-            .invoke::<i64, f32>(
+            .invoke_typed::<i64, f32>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xfffffe8000000001u64 as i64
             )
@@ -1119,7 +1119,7 @@ pub fn f32_reinterpret_i32() {
 
     for (input, expected) in test_cases {
         let result = instance
-            .invoke::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), input)
+            .invoke_typed::<i32, f32>(&instance.get_function_by_index(0, 0).unwrap(), input)
             .unwrap();
         if expected.is_nan() {
             assert!(result.is_nan(), "Failed for input: {input:x}");

--- a/tests/f64.rs
+++ b/tests/f64.rs
@@ -23,7 +23,7 @@ pub fn f64_const() {
     assert_eq!(
         3.14159265359_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -50,7 +50,7 @@ pub fn f64_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f64, 1.1_f64)
             )
@@ -59,7 +59,7 @@ pub fn f64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f64, 1.2_f64)
             )
@@ -87,7 +87,7 @@ pub fn f64_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f64, 1.1_f64)
             )
@@ -96,7 +96,7 @@ pub fn f64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.1_f64, 1.2_f64)
             )
@@ -105,7 +105,7 @@ pub fn f64_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f64, -0.0_f64)
             )
@@ -133,7 +133,7 @@ pub fn f64_lt() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 2.0_f64)
             )
@@ -142,7 +142,7 @@ pub fn f64_lt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f64, 1.0_f64)
             )
@@ -151,7 +151,7 @@ pub fn f64_lt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 1.0_f64)
             )
@@ -179,7 +179,7 @@ pub fn f64_gt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 2.0_f64)
             )
@@ -188,7 +188,7 @@ pub fn f64_gt() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f64, 1.0_f64)
             )
@@ -197,7 +197,7 @@ pub fn f64_gt() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 1.0_f64)
             )
@@ -225,7 +225,7 @@ pub fn f64_le() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 2.0_f64)
             )
@@ -234,7 +234,7 @@ pub fn f64_le() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f64, 1.0_f64)
             )
@@ -243,7 +243,7 @@ pub fn f64_le() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 1.0_f64)
             )
@@ -271,7 +271,7 @@ pub fn f64_ge() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 2.0_f64)
             )
@@ -280,7 +280,7 @@ pub fn f64_ge() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f64, 1.0_f64)
             )
@@ -289,7 +289,7 @@ pub fn f64_ge() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 1.0_f64)
             )
@@ -315,21 +315,21 @@ pub fn f64_abs() {
 
     {
         let result = instance
-            .invoke::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_positive());
     }
     {
         let result = instance
-            .invoke::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_positive());
     }
     {
         let result = instance
-            .invoke::<f64, f64>(
+            .invoke_typed::<f64, f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY,
             )
@@ -339,7 +339,7 @@ pub fn f64_abs() {
     }
     {
         let result = instance
-            .invoke::<f64, f64>(
+            .invoke_typed::<f64, f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY,
             )
@@ -350,25 +350,25 @@ pub fn f64_abs() {
     assert_eq!(
         1.5_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         1.5_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
 }
@@ -391,21 +391,21 @@ pub fn f64_neg() {
 
     {
         let result = instance
-            .invoke::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_positive());
     }
     {
         let result = instance
-            .invoke::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .unwrap();
         assert!(result.is_nan());
         assert!(result.is_sign_negative());
     }
     {
         let result = instance
-            .invoke::<f64, f64>(
+            .invoke_typed::<f64, f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY,
             )
@@ -415,7 +415,7 @@ pub fn f64_neg() {
     }
     {
         let result = instance
-            .invoke::<f64, f64>(
+            .invoke_typed::<f64, f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY,
             )
@@ -426,25 +426,25 @@ pub fn f64_neg() {
     assert_eq!(
         -1.5_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         1.5_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f64)
             .unwrap()
     );
 }
@@ -468,19 +468,19 @@ pub fn f64_ceil() {
     assert_eq!(
         2.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f64)
             .unwrap()
     );
 }
@@ -504,19 +504,19 @@ pub fn f64_floor() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -2.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.1_f64)
             .unwrap()
     );
 }
@@ -540,19 +540,19 @@ pub fn f64_trunc() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.9_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.9_f64)
             .unwrap()
     );
 }
@@ -576,25 +576,25 @@ pub fn f64_nearest() {
     assert_eq!(
         2.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f64)
             .unwrap()
     );
     assert_eq!(
         -2.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f64)
             .unwrap()
     );
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.6_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.6_f64)
             .unwrap()
     );
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.4_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.4_f64)
             .unwrap()
     );
 }
@@ -618,17 +618,17 @@ pub fn f64_sqrt() {
     assert_eq!(
         2.0_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 4.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 4.0_f64)
             .unwrap()
     );
     assert_eq!(
         1.4142135623730951_f64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f64)
             .unwrap()
     );
     assert!(instance
-        .invoke::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+        .invoke_typed::<f64, f64>(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
         .unwrap()
         .is_nan());
 }
@@ -653,7 +653,7 @@ pub fn f64_add() {
     assert_eq!(
         3.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f64, 1.5_f64)
             )
@@ -662,7 +662,7 @@ pub fn f64_add() {
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, -2.0_f64)
             )
@@ -671,7 +671,7 @@ pub fn f64_add() {
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.1_f64, -0.1_f64)
             )
@@ -699,7 +699,7 @@ pub fn f64_sub() {
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f64, 1.5_f64)
             )
@@ -708,7 +708,7 @@ pub fn f64_sub() {
     assert_eq!(
         3.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, -2.0_f64)
             )
@@ -717,7 +717,7 @@ pub fn f64_sub() {
     assert_eq!(
         0.2_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.1_f64, -0.1_f64)
             )
@@ -745,7 +745,7 @@ pub fn f64_mul() {
     assert_eq!(
         6.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f64, 3.0_f64)
             )
@@ -754,7 +754,7 @@ pub fn f64_mul() {
     assert_eq!(
         -4.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f64, -2.0_f64)
             )
@@ -763,7 +763,7 @@ pub fn f64_mul() {
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f64, 5.0_f64)
             )
@@ -791,7 +791,7 @@ pub fn f64_div() {
     assert_eq!(
         2.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (6.0_f64, 3.0_f64)
             )
@@ -800,21 +800,21 @@ pub fn f64_div() {
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (2.0_f64, -2.0_f64)
             )
             .unwrap()
     );
     assert!(instance
-        .invoke::<(f64, f64), f64>(
+        .invoke_typed::<(f64, f64), f64>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (1.0_f64, 0.0_f64)
         )
         .unwrap()
         .is_infinite());
     assert!(instance
-        .invoke::<(f64, f64), f64>(
+        .invoke_typed::<(f64, f64), f64>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (0.0_f64, 0.0_f64)
         )
@@ -841,7 +841,7 @@ pub fn f64_min() {
 
     {
         let result = instance
-            .invoke::<(f64, f64), f64>(
+            .invoke_typed::<(f64, f64), f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::NAN, -f64::NAN),
             )
@@ -850,7 +850,7 @@ pub fn f64_min() {
     }
     {
         let result = instance
-            .invoke::<(f64, f64), f64>(
+            .invoke_typed::<(f64, f64), f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::NAN, f64::NAN),
             )
@@ -860,7 +860,7 @@ pub fn f64_min() {
     }
     {
         let result = instance
-            .invoke::<(f64, f64), f64>(
+            .invoke_typed::<(f64, f64), f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::INFINITY, f64::NEG_INFINITY),
             )
@@ -871,7 +871,7 @@ pub fn f64_min() {
     assert_eq!(
         42_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::INFINITY, 42_f64)
             )
@@ -880,7 +880,7 @@ pub fn f64_min() {
     assert_eq!(
         -0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-0_f64, 0_f64)
             )
@@ -889,7 +889,7 @@ pub fn f64_min() {
     assert_eq!(
         1.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 2.0_f64)
             )
@@ -898,7 +898,7 @@ pub fn f64_min() {
     assert_eq!(
         -2.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.0_f64, -2.0_f64)
             )
@@ -907,14 +907,14 @@ pub fn f64_min() {
     assert_eq!(
         -0.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f64, -0.0_f64)
             )
             .unwrap()
     );
     assert!(instance
-        .invoke::<(f64, f64), f64>(
+        .invoke_typed::<(f64, f64), f64>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (f64::NAN, 1.0_f64)
         )
@@ -941,7 +941,7 @@ pub fn f64_max() {
 
     {
         let result = instance
-            .invoke::<(f64, f64), f64>(
+            .invoke_typed::<(f64, f64), f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::NAN, -f64::NAN),
             )
@@ -950,7 +950,7 @@ pub fn f64_max() {
     }
     {
         let result = instance
-            .invoke::<(f64, f64), f64>(
+            .invoke_typed::<(f64, f64), f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::NAN, f64::NAN),
             )
@@ -960,7 +960,7 @@ pub fn f64_max() {
     }
     {
         let result = instance
-            .invoke::<(f64, f64), f64>(
+            .invoke_typed::<(f64, f64), f64>(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::INFINITY, f64::NEG_INFINITY),
             )
@@ -971,7 +971,7 @@ pub fn f64_max() {
     assert_eq!(
         42_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (f64::NEG_INFINITY, 42_f64)
             )
@@ -980,7 +980,7 @@ pub fn f64_max() {
     assert_eq!(
         0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-0_f64, 0_f64)
             )
@@ -990,7 +990,7 @@ pub fn f64_max() {
     assert_eq!(
         2.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.0_f64, 2.0_f64)
             )
@@ -999,7 +999,7 @@ pub fn f64_max() {
     assert_eq!(
         -1.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.0_f64, -2.0_f64)
             )
@@ -1008,14 +1008,14 @@ pub fn f64_max() {
     assert_eq!(
         0.0_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0.0_f64, -0.0_f64)
             )
             .unwrap()
     );
     assert!(instance
-        .invoke::<(f64, f64), f64>(
+        .invoke_typed::<(f64, f64), f64>(
             &instance.get_function_by_index(0, 0).unwrap(),
             (f64::NAN, 1.0_f64)
         )
@@ -1043,7 +1043,7 @@ pub fn f64_copysign() {
     assert_eq!(
         1.5_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f64, 2.0_f64)
             )
@@ -1052,7 +1052,7 @@ pub fn f64_copysign() {
     assert_eq!(
         -1.5_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1.5_f64, -2.0_f64)
             )
@@ -1061,7 +1061,7 @@ pub fn f64_copysign() {
     assert_eq!(
         -1.5_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.5_f64, -0.0_f64)
             )
@@ -1070,7 +1070,7 @@ pub fn f64_copysign() {
     assert_eq!(
         1.5_f64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1.5_f64, 0.0_f64)
             )

--- a/tests/fc_extensions.rs
+++ b/tests/fc_extensions.rs
@@ -41,7 +41,7 @@ pub fn i32_trunc_sat_f32_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -59,19 +59,19 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -80,7 +80,7 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -89,13 +89,13 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -104,19 +104,19 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.19999ap+0")
             )
@@ -125,25 +125,25 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
             .unwrap()
     );
     assert_eq!(
         -2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
             .unwrap()
     );
     assert_eq!(
         2147483520,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483520.0_f32
             )
@@ -152,7 +152,7 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483648.0_f32
             )
@@ -161,7 +161,7 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         0x7fffffff,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483648.0_f32
             )
@@ -170,7 +170,7 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         0x80000000_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483904.0_f32
             )
@@ -179,7 +179,7 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         0x7fffffff,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -188,7 +188,7 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         0x80000000_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -f32::INFINITY
             )
@@ -197,14 +197,14 @@ pub fn i32_trunc_sat_f32_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_f32_s" (f32.const nan:0x200000)) (i32.const 0))
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_f32_s" (f32.const -nan:0x200000)) (i32.const 0))
@@ -224,7 +224,7 @@ pub fn i32_trunc_sat_f32_u_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -242,19 +242,19 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -263,7 +263,7 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -272,13 +272,13 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -287,25 +287,25 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.9_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.9_f32)
             .unwrap()
     );
     assert_eq!(
         2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2.0_f32)
             .unwrap()
     );
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483648_f32
             )
@@ -314,7 +314,7 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         -256,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967040.0_f32
             )
@@ -323,7 +323,7 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.ccccccp-1")
             )
@@ -332,7 +332,7 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.fffffep-1")
             )
@@ -341,7 +341,7 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296.0_f32
             )
@@ -350,13 +350,13 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0x00000000,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1_f32)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -365,7 +365,7 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0x00000000,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -374,14 +374,14 @@ pub fn i32_trunc_sat_f32_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_f32_u" (f32.const nan:0x200000)) (i32.const 0))
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_f32_u" (f32.const -nan:0x200000)) (i32.const 0))
@@ -401,7 +401,7 @@ pub fn i32_trunc_sat_f64_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -419,19 +419,19 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -440,7 +440,7 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -449,13 +449,13 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -464,19 +464,19 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.199999999999ap+0")
             )
@@ -485,31 +485,31 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5)
             .unwrap()
     );
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9)
             .unwrap()
     );
     assert_eq!(
         -2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0)
             .unwrap()
     );
     assert_eq!(
         2147483647,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2147483647.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2147483647.0)
             .unwrap()
     );
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483648.0
             )
@@ -518,13 +518,13 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         0x7fffffff,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2147483648.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2147483648.0)
             .unwrap()
     );
     assert_eq!(
         0x80000000_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -2147483649.0
             )
@@ -533,7 +533,7 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         0x7fffffff,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -542,7 +542,7 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         0x80000000_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -f64::INFINITY
             )
@@ -551,14 +551,14 @@ pub fn i32_trunc_sat_f64_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_s" (f32.const nan:0x200000)) (i32.const 0))
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_s" (f32.const -nan:0x200000)) (i32.const 0))
@@ -578,7 +578,7 @@ pub fn i32_trunc_sat_f64_u_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -596,19 +596,19 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -617,7 +617,7 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -626,13 +626,13 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -641,25 +641,25 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.9)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.9)
             .unwrap()
     );
     assert_eq!(
         2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 2.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 2.0)
             .unwrap()
     );
     assert_eq!(
         -2147483648,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 2147483648_f64
             )
@@ -668,13 +668,13 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 4294967295.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 4294967295.0)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.ccccccccccccdp-1")
             )
@@ -683,7 +683,7 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffffffffffp-1")
             )
@@ -692,37 +692,37 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         100000000,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 4294967296.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 4294967296.0)
             .unwrap()
     );
     assert_eq!(
         0x00000000,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e16_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e16_f64)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e30_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e30_f64)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808_f64
             )
@@ -731,7 +731,7 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         0xffffffff_u32 as i32,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -740,7 +740,7 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         0x00000000,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -749,14 +749,14 @@ pub fn i32_trunc_sat_f64_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_f64_u" (f64.const nan:0x4000000000000)) (i32.const 0))
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i32.trunc_sat_f64_u" (f64.const -nan:0x4000000000000)) (i32.const 0))
@@ -776,7 +776,7 @@ pub fn i64_trunc_sat_f32_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -794,19 +794,19 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -815,7 +815,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -824,13 +824,13 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -839,19 +839,19 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.19999ap+0")
             )
@@ -860,25 +860,25 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5_f32)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9_f32)
             .unwrap()
     );
     assert_eq!(
         -2_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0_f32)
             .unwrap()
     );
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f32
             )
@@ -887,7 +887,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         -4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -4294967296_f32
             )
@@ -896,7 +896,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         9223371487098961920_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223371487098961920.0_f32
             )
@@ -905,7 +905,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         -9223372036854775808_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808.0_f32
             )
@@ -914,7 +914,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         0x7fffffffffffffff_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808.0_f32
             )
@@ -923,7 +923,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         0x8000000000000000_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223373136366403584.0_f32
             )
@@ -932,7 +932,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         0x7fffffffffffffff_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -941,7 +941,7 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         0x8000000000000000_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -f32::INFINITY
             )
@@ -950,14 +950,14 @@ pub fn i64_trunc_sat_f32_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f32_s" (f32.const nan:0x200000)) (i64.const 0))
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f32_s" (f32.const -nan:0x200000)) (i64.const 0))
@@ -977,7 +977,7 @@ pub fn i64_trunc_sat_f32_u_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -995,19 +995,19 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0_f32)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1p-149")
             )
@@ -1016,7 +1016,7 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1p-149")
             )
@@ -1025,13 +1025,13 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0_f32)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("0x1.19999ap+0")
             )
@@ -1040,13 +1040,13 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5_f32)
             .unwrap()
     );
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f32
             )
@@ -1055,7 +1055,7 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         -1099511627776_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446742974197923840.0_f32
             )
@@ -1064,7 +1064,7 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.ccccccp-1")
             )
@@ -1073,7 +1073,7 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf32!("-0x1.fffffep-1")
             )
@@ -1082,7 +1082,7 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0xffffffffffffffff_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446744073709551616.0_f32
             )
@@ -1091,13 +1091,13 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0x0000000000000000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0_f32)
             .unwrap()
     );
     assert_eq!(
         0xffffffffffffffff_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::INFINITY
             )
@@ -1106,7 +1106,7 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0x0000000000000000_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f32::NEG_INFINITY
             )
@@ -1115,14 +1115,14 @@ pub fn i64_trunc_sat_f32_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f32_u" (f32.const nan:0x200000)) (i64.const 0))
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f32::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f32_u" (f32.const -nan:0x200000)) (i64.const 0))
@@ -1142,7 +1142,7 @@ pub fn i64_trunc_sat_f64_s_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -1160,19 +1160,19 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -1181,7 +1181,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -1190,13 +1190,13 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -1205,19 +1205,19 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.199999999999ap+0")
             )
@@ -1226,25 +1226,25 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.5)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.5)
             .unwrap()
     );
     assert_eq!(
         -1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.9)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.9)
             .unwrap()
     );
     assert_eq!(
         -2_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -2.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -2.0)
             .unwrap()
     );
     assert_eq!(
         4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f64
             )
@@ -1253,7 +1253,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         -4294967296_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -4294967296_f64
             )
@@ -1262,7 +1262,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         9223372036854774784_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854774784.0
             )
@@ -1271,7 +1271,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         -9223372036854775808_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854775808.0
             )
@@ -1280,7 +1280,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         0x7fffffffffffffff_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808.0
             )
@@ -1289,7 +1289,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         0x8000000000000000_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -9223372036854777856.0
             )
@@ -1298,7 +1298,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         0x7fffffffffffffff_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -1307,7 +1307,7 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         0x8000000000000000_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 -f64::INFINITY
             )
@@ -1316,14 +1316,14 @@ pub fn i64_trunc_sat_f64_s() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f64_s" (f64.const nan:0x4000000000000)) (i64.const 0))
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f64_s" (f64.const -nan:0x4000000000000)) (i64.const 0))
@@ -1343,7 +1343,7 @@ pub fn i64_trunc_sat_f64_u_let_it_die() {
     assert_eq!(
         -1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1)
             .unwrap()
     );
 }
@@ -1361,19 +1361,19 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0.0)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -0.0)
             .unwrap()
     );
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x0.0000000000001p-1022")
             )
@@ -1382,7 +1382,7 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x0.0000000000001p-1022")
             )
@@ -1391,13 +1391,13 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.0)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("0x1.199999999999ap+0")
             )
@@ -1406,19 +1406,19 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.5)
             .unwrap()
     );
     assert_eq!(
         1_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1.9)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1.9)
             .unwrap()
     );
     assert_eq!(
         0xffffffff_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967295_f64
             )
@@ -1427,7 +1427,7 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0x100000000_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 4294967296_f64
             )
@@ -1436,7 +1436,7 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         -2048_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446744073709549568.0
             )
@@ -1445,7 +1445,7 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.ccccccccccccdp-1")
             )
@@ -1454,7 +1454,7 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 hexf64!("-0x1.fffffffffffffp-1")
             )
@@ -1463,19 +1463,19 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         100000000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e8_f64)
             .unwrap()
     );
     assert_eq!(
         10000000000000000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1e16_f64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1e16_f64)
             .unwrap()
     );
     assert_eq!(
         -9223372036854775808_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 9223372036854775808_f64
             )
@@ -1484,7 +1484,7 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0xffffffffffffffff_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 18446744073709551616.0_f64
             )
@@ -1493,13 +1493,13 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0x0000000000000000_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -1.0)
             .unwrap()
     );
     assert_eq!(
         0xffffffffffffffff_u64 as i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::INFINITY
             )
@@ -1508,7 +1508,7 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0x0000000000000000_i64,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 f64::NEG_INFINITY
             )
@@ -1517,14 +1517,14 @@ pub fn i64_trunc_sat_f64_u() {
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f64_u" (f64.const nan:0x4000000000000)) (i64.const 0))
     assert_eq!(
         0_i64,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), -f64::NAN)
             .unwrap()
     );
     // (assert_return (invoke "i64.trunc_sat_f64_u" (f64.const -nan:0x4000000000000)) (i64.const 0))

--- a/tests/function_recursion.rs
+++ b/tests/function_recursion.rs
@@ -24,7 +24,7 @@ fn simple_function_call() {
     assert_eq!(
         3 * 7 + 13,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "simple_caller")
                     .unwrap(),
@@ -61,7 +61,7 @@ fn recursion_valid() {
     assert_eq!(
         12,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_two")
                     .unwrap(),
@@ -72,7 +72,7 @@ fn recursion_valid() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_two")
                     .unwrap(),
@@ -83,7 +83,7 @@ fn recursion_valid() {
     assert_eq!(
         -4,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_two")
                     .unwrap(),
@@ -149,6 +149,8 @@ fn multivalue_call() {
 
     assert_eq!(
         (10, 42.0, 5),
-        instance.invoke::<(), (i32, f32, i64)>(&foo_fn, ()).unwrap()
+        instance
+            .invoke_typed::<(), (i32, f32, i64)>(&foo_fn, ())
+            .unwrap()
     );
 }

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -34,7 +34,7 @@ fn valid_global() {
     assert_eq!(
         5,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "set")
                     .unwrap(),
@@ -47,7 +47,7 @@ fn valid_global() {
     assert_eq!(
         17,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "get")
                     .unwrap(),
@@ -110,7 +110,7 @@ fn imported_globals() {
     assert_eq!(
         3,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "set")
                     .unwrap(),
@@ -123,7 +123,7 @@ fn imported_globals() {
     assert_eq!(
         17,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "get")
                     .unwrap(),

--- a/tests/i32.rs
+++ b/tests/i32.rs
@@ -36,25 +36,25 @@ pub fn i32_add() {
     assert_eq!(
         2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         -2,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     // Chaned the following value from the spec:
@@ -64,7 +64,7 @@ pub fn i32_add() {
     assert_eq!(
         i32_min,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 1)
             )
@@ -73,7 +73,7 @@ pub fn i32_add() {
     assert_eq!(
         0x7fffffff,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32_min, -1)
             )
@@ -82,7 +82,7 @@ pub fn i32_add() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32_min, i32_min)
             )
@@ -91,7 +91,7 @@ pub fn i32_add() {
     assert_eq!(
         0x40000000,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x3fffffff, 1)
             )
@@ -110,19 +110,19 @@ pub fn i32_sub() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     // Chaned the following value from the spec:
@@ -132,7 +132,7 @@ pub fn i32_sub() {
     assert_eq!(
         i32_min,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, -1)
             )
@@ -141,13 +141,13 @@ pub fn i32_sub() {
     assert_eq!(
         0x7fffffff,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (i32_min, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (i32_min, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (i32_min, i32_min)
             )
@@ -156,7 +156,7 @@ pub fn i32_sub() {
     assert_eq!(
         0x40000000,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x3fffffff, -1)
             )
@@ -185,7 +185,7 @@ pub fn i32_eqz_panic() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -211,19 +211,19 @@ pub fn i32_eqz() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x80000000u32 as i32
             )
@@ -232,13 +232,13 @@ pub fn i32_eqz() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0x7fffffff)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0x7fffffff)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffffu32 as i32
             )
@@ -268,7 +268,7 @@ pub fn i32_eq_panic_first_arg() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -295,7 +295,7 @@ pub fn i32_eq_panic_second_arg() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -311,25 +311,25 @@ pub fn i32_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -338,7 +338,7 @@ pub fn i32_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -347,25 +347,25 @@ pub fn i32_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -374,7 +374,7 @@ pub fn i32_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -383,7 +383,7 @@ pub fn i32_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -392,7 +392,7 @@ pub fn i32_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -401,7 +401,7 @@ pub fn i32_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -410,7 +410,7 @@ pub fn i32_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -429,25 +429,25 @@ pub fn i32_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -456,7 +456,7 @@ pub fn i32_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -465,25 +465,25 @@ pub fn i32_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -492,7 +492,7 @@ pub fn i32_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -501,7 +501,7 @@ pub fn i32_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -510,7 +510,7 @@ pub fn i32_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -519,7 +519,7 @@ pub fn i32_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -528,7 +528,7 @@ pub fn i32_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -547,25 +547,25 @@ pub fn i32_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -574,7 +574,7 @@ pub fn i32_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -583,25 +583,25 @@ pub fn i32_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -610,7 +610,7 @@ pub fn i32_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -619,7 +619,7 @@ pub fn i32_lt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -628,7 +628,7 @@ pub fn i32_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -637,7 +637,7 @@ pub fn i32_lt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -646,7 +646,7 @@ pub fn i32_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -665,25 +665,25 @@ pub fn i32_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -692,7 +692,7 @@ pub fn i32_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -701,25 +701,25 @@ pub fn i32_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -728,7 +728,7 @@ pub fn i32_lt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -737,7 +737,7 @@ pub fn i32_lt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -746,7 +746,7 @@ pub fn i32_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -755,7 +755,7 @@ pub fn i32_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -764,7 +764,7 @@ pub fn i32_lt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -783,25 +783,25 @@ pub fn i32_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -810,7 +810,7 @@ pub fn i32_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -819,25 +819,25 @@ pub fn i32_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -846,7 +846,7 @@ pub fn i32_gt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -855,7 +855,7 @@ pub fn i32_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -864,7 +864,7 @@ pub fn i32_gt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -873,7 +873,7 @@ pub fn i32_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -882,7 +882,7 @@ pub fn i32_gt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -901,25 +901,25 @@ pub fn i32_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -928,7 +928,7 @@ pub fn i32_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -937,25 +937,25 @@ pub fn i32_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -964,7 +964,7 @@ pub fn i32_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -973,7 +973,7 @@ pub fn i32_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -982,7 +982,7 @@ pub fn i32_gt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -991,7 +991,7 @@ pub fn i32_gt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -1000,7 +1000,7 @@ pub fn i32_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -1019,25 +1019,25 @@ pub fn i32_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -1046,7 +1046,7 @@ pub fn i32_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -1055,25 +1055,25 @@ pub fn i32_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -1082,7 +1082,7 @@ pub fn i32_le_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -1091,7 +1091,7 @@ pub fn i32_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -1100,7 +1100,7 @@ pub fn i32_le_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -1109,7 +1109,7 @@ pub fn i32_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -1118,7 +1118,7 @@ pub fn i32_le_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -1138,25 +1138,25 @@ pub fn i32_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -1165,7 +1165,7 @@ pub fn i32_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -1174,25 +1174,25 @@ pub fn i32_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -1201,7 +1201,7 @@ pub fn i32_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -1210,7 +1210,7 @@ pub fn i32_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -1219,7 +1219,7 @@ pub fn i32_le_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -1228,7 +1228,7 @@ pub fn i32_le_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -1237,7 +1237,7 @@ pub fn i32_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -1256,25 +1256,25 @@ pub fn i32_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -1283,7 +1283,7 @@ pub fn i32_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -1292,25 +1292,25 @@ pub fn i32_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -1319,7 +1319,7 @@ pub fn i32_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -1328,7 +1328,7 @@ pub fn i32_ge_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -1337,7 +1337,7 @@ pub fn i32_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -1346,7 +1346,7 @@ pub fn i32_ge_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -1355,7 +1355,7 @@ pub fn i32_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )
@@ -1374,25 +1374,25 @@ pub fn i32_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 0))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x80000000u32 as i32)
             )
@@ -1401,7 +1401,7 @@ pub fn i32_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x7fffffff)
             )
@@ -1410,25 +1410,25 @@ pub fn i32_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (-1, -1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (1, 0))
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), (0, 1))
             .unwrap()
     );
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0)
             )
@@ -1437,7 +1437,7 @@ pub fn i32_ge_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0, 0x80000000u32 as i32)
             )
@@ -1446,7 +1446,7 @@ pub fn i32_ge_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, -1)
             )
@@ -1455,7 +1455,7 @@ pub fn i32_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1, 0x80000000u32 as i32)
             )
@@ -1464,7 +1464,7 @@ pub fn i32_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x80000000u32 as i32, 0x7fffffff)
             )
@@ -1473,7 +1473,7 @@ pub fn i32_ge_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffff, 0x80000000u32 as i32)
             )

--- a/tests/i64.rs
+++ b/tests/i64.rs
@@ -46,7 +46,7 @@ pub fn i64_eqz_panic() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -72,19 +72,19 @@ pub fn i64_eqz() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 0_i64)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 1_i64)
             .unwrap()
     );
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x8000000000000000u64 as i64
             )
@@ -93,7 +93,7 @@ pub fn i64_eqz() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0x7fffffffffffffffu64 as i64
             )
@@ -102,7 +102,7 @@ pub fn i64_eqz() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 0xffffffffffffffffu64 as i64
             )
@@ -132,7 +132,7 @@ pub fn i64_eq_panic_first_arg() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -159,7 +159,7 @@ pub fn i64_eq_panic_second_arg() {
     assert_eq!(
         1,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -175,7 +175,7 @@ pub fn i64_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -184,7 +184,7 @@ pub fn i64_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -193,7 +193,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -202,7 +202,7 @@ pub fn i64_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -211,7 +211,7 @@ pub fn i64_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -220,7 +220,7 @@ pub fn i64_eq() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -229,7 +229,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -238,7 +238,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -247,7 +247,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -256,7 +256,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -265,7 +265,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -274,7 +274,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -283,7 +283,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -292,7 +292,7 @@ pub fn i64_eq() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -311,7 +311,7 @@ pub fn i64_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -320,7 +320,7 @@ pub fn i64_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -329,7 +329,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -338,7 +338,7 @@ pub fn i64_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -347,7 +347,7 @@ pub fn i64_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -356,7 +356,7 @@ pub fn i64_ne() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -365,7 +365,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -374,7 +374,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -383,7 +383,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -392,7 +392,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -401,7 +401,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -410,7 +410,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -419,7 +419,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -428,7 +428,7 @@ pub fn i64_ne() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -447,7 +447,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -456,7 +456,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -465,7 +465,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -474,7 +474,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -483,7 +483,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -492,7 +492,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -501,7 +501,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -510,7 +510,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -519,7 +519,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -528,7 +528,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -537,7 +537,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -546,7 +546,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -555,7 +555,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -564,7 +564,7 @@ pub fn i64_lt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -583,7 +583,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -592,7 +592,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -601,7 +601,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -610,7 +610,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -619,7 +619,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -628,7 +628,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -637,7 +637,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -646,7 +646,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -655,7 +655,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -664,7 +664,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -673,7 +673,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -682,7 +682,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -691,7 +691,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -700,7 +700,7 @@ pub fn i64_lt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -719,7 +719,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -728,7 +728,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -737,7 +737,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -746,7 +746,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -755,7 +755,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -764,7 +764,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -773,7 +773,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -782,7 +782,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -791,7 +791,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -800,7 +800,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -809,7 +809,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -818,7 +818,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -827,7 +827,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -836,7 +836,7 @@ pub fn i64_gt_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -855,7 +855,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -864,7 +864,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -873,7 +873,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -882,7 +882,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -891,7 +891,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -900,7 +900,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -909,7 +909,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -918,7 +918,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -927,7 +927,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -936,7 +936,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -945,7 +945,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -954,7 +954,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -963,7 +963,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -972,7 +972,7 @@ pub fn i64_gt_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -991,7 +991,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -1000,7 +1000,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -1009,7 +1009,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -1018,7 +1018,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -1027,7 +1027,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1036,7 +1036,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -1045,7 +1045,7 @@ pub fn i64_le_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1054,7 +1054,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -1063,7 +1063,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -1072,7 +1072,7 @@ pub fn i64_le_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -1081,7 +1081,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -1090,7 +1090,7 @@ pub fn i64_le_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -1099,7 +1099,7 @@ pub fn i64_le_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1108,7 +1108,7 @@ pub fn i64_le_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -1128,7 +1128,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -1137,7 +1137,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -1146,7 +1146,7 @@ pub fn i64_le_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -1155,7 +1155,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -1164,7 +1164,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1173,7 +1173,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -1182,7 +1182,7 @@ pub fn i64_le_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1191,7 +1191,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -1200,7 +1200,7 @@ pub fn i64_le_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -1209,7 +1209,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -1218,7 +1218,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -1227,7 +1227,7 @@ pub fn i64_le_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -1236,7 +1236,7 @@ pub fn i64_le_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1245,7 +1245,7 @@ pub fn i64_le_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -1264,7 +1264,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -1273,7 +1273,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -1282,7 +1282,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -1291,7 +1291,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -1300,7 +1300,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1309,7 +1309,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -1318,7 +1318,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1327,7 +1327,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -1336,7 +1336,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -1345,7 +1345,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -1354,7 +1354,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -1363,7 +1363,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -1372,7 +1372,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1381,7 +1381,7 @@ pub fn i64_ge_s() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -1400,7 +1400,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0_i64)
             )
@@ -1409,7 +1409,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 1_i64)
             )
@@ -1418,7 +1418,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 1_i64)
             )
@@ -1427,7 +1427,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x8000000000000000u64 as i64)
             )
@@ -1436,7 +1436,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1445,7 +1445,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, -1_i64)
             )
@@ -1454,7 +1454,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (1_i64, 0_i64)
             )
@@ -1463,7 +1463,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 1_i64)
             )
@@ -1472,7 +1472,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0_i64)
             )
@@ -1481,7 +1481,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0_i64, 0x8000000000000000u64 as i64)
             )
@@ -1490,7 +1490,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, -1_i64)
             )
@@ -1499,7 +1499,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (-1_i64, 0x8000000000000000u64 as i64)
             )
@@ -1508,7 +1508,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         1,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x8000000000000000u64 as i64, 0x7fffffffffffffffu64 as i64)
             )
@@ -1517,7 +1517,7 @@ pub fn i64_ge_u() {
     assert_eq!(
         0,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance.get_function_by_index(0, 0).unwrap(),
                 (0x7fffffffffffffffu64 as i64, 0x8000000000000000u64 as i64)
             )

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -73,7 +73,7 @@ pub fn unmet_imports() {
     // assert_eq!(
     //     RuntimeError::UnmetImport,
     //     instance
-    //         .invoke::<(), i32>(&get_three, ())
+    //         .invoke_typed::<(), i32>(&get_three, ())
     //         .expect_err("Expected invoke to fail due to unmet imports")
     // );
 }
@@ -91,9 +91,9 @@ pub fn compile_simple_import() {
         .add_module("base", &validation_info)
         .expect("Successful instantiation");
 
-    // assert_eq!((), instance.invoke_named("print_three", ()).unwrap());
+    // assert_eq!((), instance.invoke_typed_named("print_three", ()).unwrap());
     // Function 0 should be the imported function
-    // assert_eq!((), instance.invoke_func(1, ()).unwrap());
+    // assert_eq!((), instance.invoke_typed_func(1, ()).unwrap());
 }
 
 #[test_log::test]
@@ -110,11 +110,11 @@ pub fn run_simple_import() {
         .expect("instantiation failed");
 
     let get_three = instance.get_function_by_name("base", "get_three").unwrap();
-    assert_eq!(3, instance.invoke(&get_three, ()).unwrap());
+    assert_eq!(3, instance.invoke_typed(&get_three, ()).unwrap());
 
     // Function 0 should be the imported function
     let get_three = instance.get_function_by_index(1, 1).unwrap();
-    assert_eq!(3, instance.invoke(&get_three, ()).unwrap());
+    assert_eq!(3, instance.invoke_typed(&get_three, ()).unwrap());
 }
 
 #[test_log::test]
@@ -131,7 +131,7 @@ pub fn run_call_indirect() {
         .expect("Successful instantiation");
 
     let run = instance.get_function_by_name("base", "run").unwrap();
-    assert_eq!((1, 3), instance.invoke(&run, ()).unwrap());
+    assert_eq!((1, 3), instance.invoke_typed(&run, ()).unwrap());
 }
 
 // #[test_log::test]
@@ -150,5 +150,5 @@ pub fn run_call_indirect() {
 //     // let run = instance.get_function_by_name("base", "get_three").unwrap();
 //     // Unmet import since we can't have cyclical imports
 //     // Currently, this passes since we don't allow chained imports.
-//     // assert!(instance.invoke::<(), i32>(&run, ()).unwrap_err() == wasm::RuntimeError::UnmetImport);
+//     // assert!(instance.invoke_typed::<(), i32>(&run, ()).unwrap_err() == wasm::RuntimeError::UnmetImport);
 // }

--- a/tests/linker.rs
+++ b/tests/linker.rs
@@ -49,7 +49,7 @@ pub fn compile_simple_import() {
         panic!("this entity is not a function")
     };
 
-    println!("{:#?}", store.invoke::<(), i32>(func_addr, ()).unwrap());
+    println!("{:#?}", store.invoke(func_addr, Vec::new()).unwrap());
 
     // let mut instance_addon = linker
     //     .instantiate(&mut store, &validation_info_addon)

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -87,7 +87,7 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func_name:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func_name, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func_name, $arg).unwrap());
     };
 }
 
@@ -202,7 +202,7 @@ fn i32_and_i64_loads() {
     // let cast = get_func!(i, "cast");
 
     // assert_result!(i, data, (), 1);
-    assert_eq!(1, i.invoke(data, ()).unwrap());
+    assert_eq!(1, i.invoke_typed(data, ()).unwrap());
     // (assert_return (invoke "cast") (f64.const 42.0))
 
     assert_result!(i, i32_load8_s, -1, -1);

--- a/tests/memory_copy.rs
+++ b/tests/memory_copy.rs
@@ -26,7 +26,7 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func_name:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func_name, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func_name, $arg).unwrap());
     };
 }
 
@@ -49,7 +49,7 @@ fn memory_copy_test_1() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
     let results = Vec::from([
@@ -80,7 +80,7 @@ fn memory_copy_test_2() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
     let results = Vec::from([
@@ -111,7 +111,7 @@ fn memory_copy_test_3() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
     let offsets = Vec::from([
@@ -146,7 +146,7 @@ fn memory_copy_test_4() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
     let offsets = Vec::from([
@@ -181,7 +181,7 @@ fn memory_copy_test_5() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
     let offsets = Vec::from([
@@ -215,7 +215,7 @@ fn memory_copy_test_6() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65516, 0, 40));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 0, 40));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -287,7 +287,7 @@ fn memory_copy_test_7() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65515, 0, 39));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65515, 0, 39));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -359,7 +359,7 @@ fn memory_copy_test_8() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65515, 0, 39));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65515, 0, 39));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -431,7 +431,7 @@ fn memory_copy_test_9() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (0, 65516, 40));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65516, 40));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -504,7 +504,7 @@ fn memory_copy_test_10() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (0, 65515, 39));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65515, 39));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -577,7 +577,7 @@ fn memory_copy_test_11() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65516, 65486, 40));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65486, 40));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -650,7 +650,7 @@ fn memory_copy_test_12() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65486, 65516, 40));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65486, 65516, 40));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -723,7 +723,7 @@ fn memory_copy_test_13() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65516, 65506, 40));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65506, 40));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -796,7 +796,7 @@ fn memory_copy_test_14() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65506, 65516, 40));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65506, 65516, 40));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -869,7 +869,7 @@ fn memory_copy_test_15() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65516, 65516, 40));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65516, 40));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -942,7 +942,7 @@ fn memory_copy_test_16() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (0, 65516, 4294963200_u32 as i32));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65516, 4294963200_u32 as i32));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }
@@ -1015,7 +1015,7 @@ fn memory_copy_test_17() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
-    let err = i.invoke::<(i32, i32, i32), ()>(run, (65516, 61440, 4294967040_u32 as i32));
+    let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 61440, 4294967040_u32 as i32));
     if err.is_err() {
         assert!(err.unwrap_err() == RuntimeError::MemoryAccessOutOfBounds);
     }

--- a/tests/memory_fill.rs
+++ b/tests/memory_fill.rs
@@ -42,7 +42,7 @@ fn memory_fill() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let fill = get_func!(i, "fill");
-    i.invoke::<(), ()>(fill, ()).unwrap();
+    i.invoke_typed::<(), ()>(fill, ()).unwrap();
     let mem_inst = &i.store.as_ref().unwrap().memories[0];
 
     let expected = [vec![217u8; 100], vec![0u8; 5]].concat();

--- a/tests/memory_grow.rs
+++ b/tests/memory_grow.rs
@@ -26,14 +26,14 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func_name:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func_name, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func_name, $arg).unwrap());
     };
 }
 
 macro_rules! assert_error {
     ($instance:expr, $func_name:expr, $arg:expr, $ret_type:ty, $invoke_param_type:ty, $invoke_return_type:ty, $err_type:expr) => {
         let val: $ret_type =
-            $instance.invoke::<$invoke_param_type, $invoke_return_type>($func_name, $arg);
+            $instance.invoke_typed::<$invoke_param_type, $invoke_return_type>($func_name, $arg);
         assert!(val.is_err());
         assert!(val.unwrap_err() == $err_type);
     };
@@ -59,7 +59,7 @@ fn memory_grow_test_1() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
-    // let x = i.invoke(function_ref, params)
+    // let x = i.invoke_typed(function_ref, params)
     assert_result!(i, get_func!(i, "size"), (), 0);
     assert_error!(i, get_func!(i, "store_at_zero"), (), Result<(), RuntimeError>, (), (), RuntimeError::MemoryAccessOutOfBounds);
     assert_error!(i, get_func!(i, "load_at_zero"), (), Result<i32, RuntimeError>, (), i32, RuntimeError::MemoryAccessOutOfBounds);

--- a/tests/memory_init.rs
+++ b/tests/memory_init.rs
@@ -27,14 +27,14 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func, $arg).unwrap());
     };
 }
 
 macro_rules! assert_error {
     ($instance:expr, $func:expr, $arg:expr, $ret_type:ty, $invoke_param_type:ty, $invoke_return_type:ty, $err_type:expr) => {
         let val: $ret_type =
-            $instance.invoke::<$invoke_param_type, $invoke_return_type>($func, $arg);
+            $instance.invoke_typed::<$invoke_param_type, $invoke_return_type>($func, $arg);
         assert!(val.is_err());
         assert!(val.unwrap_err() == $err_type);
     };
@@ -58,7 +58,7 @@ fn memory_init_test_1() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
 
@@ -92,7 +92,7 @@ fn memory_init_test_2() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
 
@@ -126,7 +126,7 @@ fn memory_init_test_3() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
 
@@ -168,7 +168,7 @@ fn memory_init_test_4() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     let load8_u = get_func!(i, "load8_u");
 
@@ -225,7 +225,7 @@ fn memory_init_test_7() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -301,7 +301,7 @@ fn memory_init_test_12() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]

--- a/tests/memory_redundancy.rs
+++ b/tests/memory_redundancy.rs
@@ -27,7 +27,7 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func, $arg).unwrap());
     };
 }
 
@@ -93,15 +93,15 @@ fn memory_redundancy() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     let zero_everything = get_func!(i, "zero_everything");
     assert_result!(i, get_func!(i, "test_store_to_load"), (), 0x00000080);
-    i.invoke::<(), ()>(zero_everything, ()).unwrap();
+    i.invoke_typed::<(), ()>(zero_everything, ()).unwrap();
     assert_result!(i, get_func!(i, "test_redundant_load"), (), 0x00000080);
-    i.invoke::<(), ()>(zero_everything, ()).unwrap();
+    i.invoke_typed::<(), ()>(zero_everything, ()).unwrap();
     assert_result!(
         i,
         get_func!(i, "test_dead_store"),
         (),
         hexf32!("0x1.18p-144")
     );
-    i.invoke::<(), ()>(zero_everything, ()).unwrap();
+    i.invoke_typed::<(), ()>(zero_everything, ()).unwrap();
     assert_result!(i, get_func!(i, "malloc_aliasing"), (), 43);
 }

--- a/tests/memory_size.rs
+++ b/tests/memory_size.rs
@@ -26,7 +26,7 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func, $arg).unwrap());
     };
 }
 

--- a/tests/memory_trap.rs
+++ b/tests/memory_trap.rs
@@ -26,14 +26,14 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func, $arg).unwrap());
     };
 }
 
 macro_rules! assert_error {
     ($instance:expr, $func:expr, $arg:expr, $ret_type:ty, $invoke_param_type:ty, $invoke_return_type:ty, $err_type:expr) => {
         let val: $ret_type =
-            $instance.invoke::<$invoke_param_type, $invoke_return_type>($func, $arg);
+            $instance.invoke_typed::<$invoke_param_type, $invoke_return_type>($func, $arg);
         assert!(val.is_err());
         assert!(val.unwrap_err() == $err_type);
     };

--- a/tests/return.rs
+++ b/tests/return.rs
@@ -29,7 +29,7 @@ fn return_valid() {
     assert_eq!(
         12,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add")
                     .unwrap(),
@@ -40,7 +40,7 @@ fn return_valid() {
     assert_eq!(
         2,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add")
                     .unwrap(),
@@ -51,7 +51,7 @@ fn return_valid() {
     assert_eq!(
         -4,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add")
                     .unwrap(),

--- a/tests/same_type_fn.rs
+++ b/tests/same_type_fn.rs
@@ -26,7 +26,7 @@ fn same_type_fn() {
     assert_eq!(
         -5,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_one")
                     .unwrap(),
@@ -37,7 +37,7 @@ fn same_type_fn() {
     assert_eq!(
         -4,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "add_two")
                     .unwrap(),

--- a/tests/select.rs
+++ b/tests/select.rs
@@ -43,10 +43,10 @@ fn polymorphic_select_test() {
 
     let select_test_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(4, instance.invoke(&select_test_fn, 0).unwrap());
-    assert_eq!(8, instance.invoke(&select_test_fn, 1).unwrap());
-    assert_eq!(15, instance.invoke(&select_test_fn, 2).unwrap());
-    assert_eq!(16, instance.invoke(&select_test_fn, 3).unwrap());
+    assert_eq!(4, instance.invoke_typed(&select_test_fn, 0).unwrap());
+    assert_eq!(8, instance.invoke_typed(&select_test_fn, 1).unwrap());
+    assert_eq!(15, instance.invoke_typed(&select_test_fn, 2).unwrap());
+    assert_eq!(16, instance.invoke_typed(&select_test_fn, 3).unwrap());
 }
 
 #[test_log::test]
@@ -62,8 +62,8 @@ fn typed_select_test() {
 
     let select_test_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(4, instance.invoke(&select_test_fn, 0).unwrap());
-    assert_eq!(8, instance.invoke(&select_test_fn, 1).unwrap());
-    assert_eq!(15, instance.invoke(&select_test_fn, 2).unwrap());
-    assert_eq!(16, instance.invoke(&select_test_fn, 3).unwrap());
+    assert_eq!(4, instance.invoke_typed(&select_test_fn, 0).unwrap());
+    assert_eq!(8, instance.invoke_typed(&select_test_fn, 1).unwrap());
+    assert_eq!(15, instance.invoke_typed(&select_test_fn, 2).unwrap());
+    assert_eq!(16, instance.invoke_typed(&select_test_fn, 3).unwrap());
 }

--- a/tests/specification/run.rs
+++ b/tests/specification/run.rs
@@ -504,7 +504,7 @@ pub fn run_spec_test(filepath: &str) -> WastTestReport {
 
                 let err_or_panic: Result<_, Box<dyn Error>> =
                     catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                        interpreter.invoke_dynamic_unchecked_return_ty(&function_ref, args)
+                        interpreter.invoke(&function_ref, args)
                     }))
                     .map_err(PanicError::from_panic_boxed)
                     .and_then(|result| {
@@ -553,10 +553,6 @@ fn execute_assert_return(
                 .into_iter()
                 .map(result_to_value)
                 .collect::<Result<Vec<_>, _>>()?;
-            let result_types = result_vals
-                .iter()
-                .map(|val| val.to_ty())
-                .collect::<Vec<_>>();
 
             // spec tests tells us to use the last defined module if module name is not specified
             // TODO this ugly chunk might need to be refactored out
@@ -590,7 +586,7 @@ fn execute_assert_return(
             .map_err(|err| WasmInterpreterError::new_boxed(wasm::Error::RuntimeError(err)))?;
 
             let actual = catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                interpreter.invoke_dynamic(&func, args, &result_types)
+                interpreter.invoke(&func, args)
             }))
             .map_err(PanicError::from_panic_boxed)?
             .map_err(|err| WasmInterpreterError::new_boxed(wasm::Error::RuntimeError(err)))?;
@@ -688,7 +684,7 @@ fn execute_assert_trap<'a>(
             .map_err(|err| WasmInterpreterError::new_boxed(wasm::Error::RuntimeError(err)))?;
 
             let actual = catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                interpreter.invoke_dynamic_unchecked_return_ty(&func, args)
+                interpreter.invoke(&func, args)
             }))
             .map_err(PanicError::from_panic_boxed)?;
 

--- a/tests/start_function.rs
+++ b/tests/start_function.rs
@@ -30,7 +30,7 @@ fn start_function() {
     assert_eq!(
         42,
         instance
-            .invoke(
+            .invoke_typed(
                 &instance
                     .get_function_by_name(DEFAULT_MODULE, "load_num")
                     .unwrap(),

--- a/tests/structured_control_flow/block.rs
+++ b/tests/structured_control_flow/block.rs
@@ -17,7 +17,7 @@ fn empty() {
     let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     instance
-        .invoke::<(), ()>(&instance.get_function_by_index(0, 0).unwrap(), ())
+        .invoke_typed::<(), ()>(&instance.get_function_by_index(0, 0).unwrap(), ())
         .unwrap();
 }
 
@@ -48,7 +48,7 @@ fn branch() {
     assert_eq!(
         8,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -90,7 +90,7 @@ fn branch2() {
     assert_eq!(
         13,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -106,7 +106,7 @@ fn branch3() {
     assert_eq!(
         5,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -135,7 +135,7 @@ fn param_and_result() {
     assert_eq!(
         7,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), 6)
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), 6)
             .unwrap()
     );
 }
@@ -179,7 +179,7 @@ fn return_out_of_block() {
     assert_eq!(
         3,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -195,7 +195,7 @@ fn br_return_out_of_block() {
     assert_eq!(
         3,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -211,7 +211,7 @@ fn return_out_of_block2() {
     assert_eq!(
         5,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -227,7 +227,7 @@ fn br_return_out_of_block2() {
     assert_eq!(
         5,
         instance
-            .invoke(&instance.get_function_by_index(0, 0).unwrap(), ())
+            .invoke_typed(&instance.get_function_by_index(0, 0).unwrap(), ())
             .unwrap()
     );
 }
@@ -260,9 +260,9 @@ fn branch_if() {
 
     let switch_case_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(6, instance.invoke(&switch_case_fn, 6).unwrap());
-    assert_eq!(123, instance.invoke(&switch_case_fn, -123).unwrap());
-    assert_eq!(0, instance.invoke(&switch_case_fn, 0).unwrap());
+    assert_eq!(6, instance.invoke_typed(&switch_case_fn, 6).unwrap());
+    assert_eq!(123, instance.invoke_typed(&switch_case_fn, -123).unwrap());
+    assert_eq!(0, instance.invoke_typed(&switch_case_fn, 0).unwrap());
 }
 
 #[test_log::test]
@@ -323,7 +323,7 @@ fn recursive_fibonacci() {
     let fib_fn = instance.get_function_by_index(0, 0).unwrap();
 
     let first_ten = (0..10)
-        .map(|n| instance.invoke(&fib_fn, n).unwrap())
+        .map(|n| instance.invoke_typed(&fib_fn, n).unwrap())
         .collect::<Vec<i32>>();
     assert_eq!(&first_ten, &[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
 }
@@ -367,14 +367,14 @@ fn switch_case() {
 
     let switch_case_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(9, instance.invoke(&switch_case_fn, -5).unwrap());
-    assert_eq!(9, instance.invoke(&switch_case_fn, -1).unwrap());
-    assert_eq!(1, instance.invoke(&switch_case_fn, 0).unwrap());
-    assert_eq!(3, instance.invoke(&switch_case_fn, 1).unwrap());
-    assert_eq!(5, instance.invoke(&switch_case_fn, 2).unwrap());
-    assert_eq!(7, instance.invoke(&switch_case_fn, 3).unwrap());
-    assert_eq!(9, instance.invoke(&switch_case_fn, 4).unwrap());
-    assert_eq!(9, instance.invoke(&switch_case_fn, 7).unwrap());
+    assert_eq!(9, instance.invoke_typed(&switch_case_fn, -5).unwrap());
+    assert_eq!(9, instance.invoke_typed(&switch_case_fn, -1).unwrap());
+    assert_eq!(1, instance.invoke_typed(&switch_case_fn, 0).unwrap());
+    assert_eq!(3, instance.invoke_typed(&switch_case_fn, 1).unwrap());
+    assert_eq!(5, instance.invoke_typed(&switch_case_fn, 2).unwrap());
+    assert_eq!(7, instance.invoke_typed(&switch_case_fn, 3).unwrap());
+    assert_eq!(9, instance.invoke_typed(&switch_case_fn, 4).unwrap());
+    assert_eq!(9, instance.invoke_typed(&switch_case_fn, 7).unwrap());
 }
 
 #[test_log::test]

--- a/tests/structured_control_flow/if.rs
+++ b/tests/structured_control_flow/if.rs
@@ -28,10 +28,10 @@ fn odd_with_if_else() {
 
     let odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(1, instance.invoke(&odd_fn, -5).unwrap());
-    assert_eq!(0, instance.invoke(&odd_fn, 0).unwrap());
-    assert_eq!(1, instance.invoke(&odd_fn, 3).unwrap());
-    assert_eq!(0, instance.invoke(&odd_fn, 4).unwrap());
+    assert_eq!(1, instance.invoke_typed(&odd_fn, -5).unwrap());
+    assert_eq!(0, instance.invoke_typed(&odd_fn, 0).unwrap());
+    assert_eq!(1, instance.invoke_typed(&odd_fn, 3).unwrap());
+    assert_eq!(0, instance.invoke_typed(&odd_fn, 4).unwrap());
 }
 
 #[test_log::test]
@@ -60,10 +60,10 @@ fn odd_with_if() {
 
     let odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(1, instance.invoke(&odd_fn, -5).unwrap());
-    assert_eq!(0, instance.invoke(&odd_fn, 0).unwrap());
-    assert_eq!(1, instance.invoke(&odd_fn, 3).unwrap());
-    assert_eq!(0, instance.invoke(&odd_fn, 4).unwrap());
+    assert_eq!(1, instance.invoke_typed(&odd_fn, -5).unwrap());
+    assert_eq!(0, instance.invoke_typed(&odd_fn, 0).unwrap());
+    assert_eq!(1, instance.invoke_typed(&odd_fn, 3).unwrap());
+    assert_eq!(0, instance.invoke_typed(&odd_fn, 4).unwrap());
 }
 
 #[test_log::test]
@@ -114,10 +114,10 @@ fn odd_with_if_else_recursive() {
 
     let even_odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(1, instance.invoke(&even_odd_fn, 1).unwrap());
-    assert_eq!(0, instance.invoke(&even_odd_fn, 0).unwrap());
-    assert_eq!(1, instance.invoke(&even_odd_fn, 3).unwrap());
-    assert_eq!(0, instance.invoke(&even_odd_fn, 4).unwrap());
+    assert_eq!(1, instance.invoke_typed(&even_odd_fn, 1).unwrap());
+    assert_eq!(0, instance.invoke_typed(&even_odd_fn, 0).unwrap());
+    assert_eq!(1, instance.invoke_typed(&even_odd_fn, 3).unwrap());
+    assert_eq!(0, instance.invoke_typed(&even_odd_fn, 4).unwrap());
 }
 
 #[test_log::test]
@@ -158,13 +158,13 @@ fn recursive_fibonacci_if_else() {
 
     let fibonacci_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(1, instance.invoke(&fibonacci_fn, -5).unwrap());
-    assert_eq!(1, instance.invoke(&fibonacci_fn, 0).unwrap());
-    assert_eq!(1, instance.invoke(&fibonacci_fn, 1).unwrap());
-    assert_eq!(2, instance.invoke(&fibonacci_fn, 2).unwrap());
-    assert_eq!(3, instance.invoke(&fibonacci_fn, 3).unwrap());
-    assert_eq!(5, instance.invoke(&fibonacci_fn, 4).unwrap());
-    assert_eq!(8, instance.invoke(&fibonacci_fn, 5).unwrap());
+    assert_eq!(1, instance.invoke_typed(&fibonacci_fn, -5).unwrap());
+    assert_eq!(1, instance.invoke_typed(&fibonacci_fn, 0).unwrap());
+    assert_eq!(1, instance.invoke_typed(&fibonacci_fn, 1).unwrap());
+    assert_eq!(2, instance.invoke_typed(&fibonacci_fn, 2).unwrap());
+    assert_eq!(3, instance.invoke_typed(&fibonacci_fn, 3).unwrap());
+    assert_eq!(5, instance.invoke_typed(&fibonacci_fn, 4).unwrap());
+    assert_eq!(8, instance.invoke_typed(&fibonacci_fn, 5).unwrap());
 }
 
 #[test_log::test]
@@ -185,8 +185,8 @@ fn if_without_else_type_check1() {
 
     let empty_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    instance.invoke::<i32, ()>(&empty_fn, 1).unwrap();
-    instance.invoke::<i32, ()>(&empty_fn, 0).unwrap();
+    instance.invoke_typed::<i32, ()>(&empty_fn, 1).unwrap();
+    instance.invoke_typed::<i32, ()>(&empty_fn, 0).unwrap();
 }
 
 #[test_log::test]
@@ -228,8 +228,8 @@ fn if_without_else_type_check3() {
 
     let add_one_if_true_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(7, instance.invoke(&add_one_if_true_fn, 1).unwrap());
-    assert_eq!(5, instance.invoke(&add_one_if_true_fn, 0).unwrap());
+    assert_eq!(7, instance.invoke_typed(&add_one_if_true_fn, 1).unwrap());
+    assert_eq!(5, instance.invoke_typed(&add_one_if_true_fn, 0).unwrap());
 }
 
 #[test_log::test]
@@ -254,13 +254,13 @@ fn if_without_else_type_check4() {
     assert_eq!(
         (7, 42),
         instance
-            .invoke::<i32, (i32, i64)>(&add_one_if_true_fn, 1)
+            .invoke_typed::<i32, (i32, i64)>(&add_one_if_true_fn, 1)
             .unwrap()
     );
     assert_eq!(
         (5, 20),
         instance
-            .invoke::<i32, (i32, i64)>(&add_one_if_true_fn, 0)
+            .invoke_typed::<i32, (i32, i64)>(&add_one_if_true_fn, 0)
             .unwrap()
     );
 }

--- a/tests/structured_control_flow/loop.rs
+++ b/tests/structured_control_flow/loop.rs
@@ -60,11 +60,11 @@ fn fibonacci_with_loop_and_br_if() {
 
     let fibonacci_fn = instance.get_function_by_index(0, 0).unwrap();
 
-    assert_eq!(1, instance.invoke(&fibonacci_fn, -5).unwrap());
-    assert_eq!(1, instance.invoke(&fibonacci_fn, 0).unwrap());
-    assert_eq!(1, instance.invoke(&fibonacci_fn, 1).unwrap());
-    assert_eq!(2, instance.invoke(&fibonacci_fn, 2).unwrap());
-    assert_eq!(3, instance.invoke(&fibonacci_fn, 3).unwrap());
-    assert_eq!(5, instance.invoke(&fibonacci_fn, 4).unwrap());
-    assert_eq!(8, instance.invoke(&fibonacci_fn, 5).unwrap());
+    assert_eq!(1, instance.invoke_typed(&fibonacci_fn, -5).unwrap());
+    assert_eq!(1, instance.invoke_typed(&fibonacci_fn, 0).unwrap());
+    assert_eq!(1, instance.invoke_typed(&fibonacci_fn, 1).unwrap());
+    assert_eq!(2, instance.invoke_typed(&fibonacci_fn, 2).unwrap());
+    assert_eq!(3, instance.invoke_typed(&fibonacci_fn, 3).unwrap());
+    assert_eq!(5, instance.invoke_typed(&fibonacci_fn, 4).unwrap());
+    assert_eq!(8, instance.invoke_typed(&fibonacci_fn, 5).unwrap());
 }

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -166,7 +166,7 @@ fn table_get_set_test() {
     // assert the function at index 1 is a FuncRef and is NOT null
     {
         let funcref = i
-            .invoke::<i32, FuncRefForInteropValue>(get_funcref, 1)
+            .invoke_typed::<i32, FuncRefForInteropValue>(get_funcref, 1)
             .unwrap();
 
         let rref = funcref.get_ref();
@@ -182,7 +182,7 @@ fn table_get_set_test() {
     // assert the function at index 2 is a FuncRef and is null
     {
         let funcref = i
-            .invoke::<i32, FuncRefForInteropValue>(get_funcref, 2)
+            .invoke_typed::<i32, FuncRefForInteropValue>(get_funcref, 2)
             .unwrap();
 
         let rref = funcref.get_ref();
@@ -196,11 +196,11 @@ fn table_get_set_test() {
     }
 
     // set the function at index 2 the same as the one at index 1
-    i.invoke::<(), ()>(init, ()).unwrap();
+    i.invoke_typed::<(), ()>(init, ()).unwrap();
     // assert the function at index 2 is a FuncRef and is NOT null
     {
         let funcref = i
-            .invoke::<i32, FuncRefForInteropValue>(get_funcref, 2)
+            .invoke_typed::<i32, FuncRefForInteropValue>(get_funcref, 2)
             .unwrap();
 
         let rref = funcref.get_ref();
@@ -258,25 +258,25 @@ fn call_indirect_type_check() {
     assert_eq!(
         4,
         instance
-            .invoke::<(i32, i32), i32>(&call_fn, (3, 0))
+            .invoke_typed::<(i32, i32), i32>(&call_fn, (3, 0))
             .unwrap()
     );
     assert_eq!(
         6,
         instance
-            .invoke::<(i32, i32), i32>(&call_fn, (5, 0))
+            .invoke_typed::<(i32, i32), i32>(&call_fn, (5, 0))
             .unwrap()
     );
     assert_eq!(
         6,
         instance
-            .invoke::<(i32, i32), i32>(&call_fn, (3, 1))
+            .invoke_typed::<(i32, i32), i32>(&call_fn, (3, 1))
             .unwrap()
     );
     assert_eq!(
         10,
         instance
-            .invoke::<(i32, i32), i32>(&call_fn, (5, 1))
+            .invoke_typed::<(i32, i32), i32>(&call_fn, (5, 1))
             .unwrap()
     );
 }

--- a/tests/table_fill.rs
+++ b/tests/table_fill.rs
@@ -63,32 +63,32 @@ fn table_fill_test() {
     let fill_abbrev = get_func!(i, "fill-abbrev");
 
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 1)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 1)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 2)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 2)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 3)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 3)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 4)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 4)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 5)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 5)
         .unwrap()
         .get_ref()
         .is_null());
 
-    i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+    i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
         fill,
         (
             2,
@@ -99,35 +99,35 @@ fn table_fill_test() {
     .unwrap();
 
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 1)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 1)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 2)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 2)
             .unwrap()
             .get_ref(),
         1
     ));
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 3)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 3)
             .unwrap()
             .get_ref(),
         1
     ));
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 4)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 4)
             .unwrap()
             .get_ref(),
         1
     ));
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 5)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 5)
         .unwrap()
         .get_ref()
         .is_null());
 
-    i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+    i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
         fill,
         (
             4,
@@ -138,30 +138,30 @@ fn table_fill_test() {
     .unwrap();
 
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 3)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 3)
             .unwrap()
             .get_ref(),
         1
     ));
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 4)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 4)
             .unwrap()
             .get_ref(),
         2
     ));
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 5)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 5)
             .unwrap()
             .get_ref(),
         2
     ));
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 6)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 6)
         .unwrap()
         .get_ref()
         .is_null());
 
-    i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+    i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
         fill,
         (
             4,
@@ -172,25 +172,25 @@ fn table_fill_test() {
     .unwrap();
 
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 3)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 3)
             .unwrap()
             .get_ref(),
         1
     ));
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 4)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 4)
             .unwrap()
             .get_ref(),
         2
     ));
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 5)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 5)
             .unwrap()
             .get_ref(),
         2
     ));
 
-    i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+    i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
         fill,
         (
             8,
@@ -201,24 +201,24 @@ fn table_fill_test() {
     .unwrap();
 
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 7)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 7)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 8)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 8)
             .unwrap()
             .get_ref(),
         4
     ));
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 9)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 9)
             .unwrap()
             .get_ref(),
         4
     ));
 
-    i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+    i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
         fill_abbrev,
         (
             9,
@@ -228,18 +228,18 @@ fn table_fill_test() {
     )
     .unwrap();
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 8)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 8)
             .unwrap()
             .get_ref(),
         4
     ));
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 9)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 9)
         .unwrap()
         .get_ref()
         .is_null());
 
-    i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+    i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
         fill,
         (
             10,
@@ -249,13 +249,13 @@ fn table_fill_test() {
     )
     .unwrap();
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 9)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 9)
         .unwrap()
         .get_ref()
         .is_null());
 
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
             fill,
             (
                 8,
@@ -269,24 +269,24 @@ fn table_fill_test() {
     );
 
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 7)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 7)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(is_specific_func!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 8)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 8)
             .unwrap()
             .get_ref(),
         4
     ));
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 9)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 9)
         .unwrap()
         .get_ref()
         .is_null());
 
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
             fill,
             (
                 11,
@@ -300,7 +300,7 @@ fn table_fill_test() {
     );
 
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue, i32), ()>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue, i32), ()>(
             fill,
             (
                 11,

--- a/tests/table_get.rs
+++ b/tests/table_get.rs
@@ -31,14 +31,14 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func, $arg).unwrap());
     };
 }
 
 macro_rules! assert_error {
     ($instance:expr, $func:expr, $arg:expr, $ret_type:ty, $invoke_param_type:ty, $invoke_return_type:ty, $err_type:expr) => {
         let val: $ret_type =
-            $instance.invoke::<$invoke_param_type, $invoke_return_type>($func, $arg);
+            $instance.invoke_typed::<$invoke_param_type, $invoke_return_type>($func, $arg);
         assert!(val.is_err());
         assert!(val.unwrap_err() == $err_type);
     };
@@ -77,8 +77,11 @@ fn table_funcref_test() {
     let is_null_funcref = get_func!(i, "is_null-funcref");
 
     let func_ref: Ref = Ref::Func(FuncAddr::new(Some(1)));
-    i.invoke::<FuncRefForInteropValue, ()>(init, FuncRefForInteropValue::new(func_ref).unwrap())
-        .unwrap();
+    i.invoke_typed::<FuncRefForInteropValue, ()>(
+        init,
+        FuncRefForInteropValue::new(func_ref).unwrap(),
+    )
+    .unwrap();
 
     assert_result!(
         i,

--- a/tests/table_grow.rs
+++ b/tests/table_grow.rs
@@ -27,7 +27,7 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func, $arg).unwrap());
     };
 }
 
@@ -58,9 +58,9 @@ fn table_grow_test() {
     let grow_abbrev = get_func!(i, "grow-abbrev");
     let size = get_func!(i, "size");
 
-    assert!(i.invoke::<(), i32>(size, ()).unwrap() == 0);
+    assert!(i.invoke_typed::<(), i32>(size, ()).unwrap() == 0);
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue), ()>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue), ()>(
             set,
             (
                 0,
@@ -72,14 +72,14 @@ fn table_grow_test() {
             == RuntimeError::TableAccessOutOfBounds
     );
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 0)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 0)
             .err()
             .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
 
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue), i32>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue), i32>(
             grow,
             (
                 1,
@@ -89,14 +89,14 @@ fn table_grow_test() {
         .unwrap()
             == 0
     );
-    assert!(i.invoke::<(), i32>(size, ()).unwrap() == 1);
+    assert!(i.invoke_typed::<(), i32>(size, ()).unwrap() == 1);
     assert!(i
-        .invoke::<i32, FuncRefForInteropValue>(get, 0)
+        .invoke_typed::<i32, FuncRefForInteropValue>(get, 0)
         .unwrap()
         .get_ref()
         .is_null());
     assert!(i
-        .invoke::<(i32, FuncRefForInteropValue), ()>(
+        .invoke_typed::<(i32, FuncRefForInteropValue), ()>(
             set,
             (
                 0,
@@ -105,11 +105,12 @@ fn table_grow_test() {
         )
         .is_ok());
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 0).unwrap()
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 0)
+            .unwrap()
             == FuncRefForInteropValue::new(Ref::Func(FuncAddr::new(Some(2)))).unwrap()
     );
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue), ()>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue), ()>(
             set,
             (
                 1,
@@ -121,14 +122,14 @@ fn table_grow_test() {
             == RuntimeError::TableAccessOutOfBounds
     );
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 1)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 1)
             .err()
             .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
 
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue), i32>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue), i32>(
             grow_abbrev,
             (
                 4,
@@ -138,13 +139,14 @@ fn table_grow_test() {
         .unwrap()
             == 1
     );
-    assert!(i.invoke::<(), i32>(size, ()).unwrap() == 5);
+    assert!(i.invoke_typed::<(), i32>(size, ()).unwrap() == 5);
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 0).unwrap()
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 0)
+            .unwrap()
             == FuncRefForInteropValue::new(Ref::Func(FuncAddr::new(Some(2)))).unwrap()
     );
     assert!(i
-        .invoke::<(i32, FuncRefForInteropValue), ()>(
+        .invoke_typed::<(i32, FuncRefForInteropValue), ()>(
             set,
             (
                 0,
@@ -153,19 +155,22 @@ fn table_grow_test() {
         )
         .is_ok());
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 0).unwrap()
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 0)
+            .unwrap()
             == FuncRefForInteropValue::new(Ref::Func(FuncAddr::new(Some(2)))).unwrap()
     );
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 1).unwrap()
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 1)
+            .unwrap()
             == FuncRefForInteropValue::new(Ref::Func(FuncAddr::new(Some(3)))).unwrap()
     );
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 4).unwrap()
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 4)
+            .unwrap()
             == FuncRefForInteropValue::new(Ref::Func(FuncAddr::new(Some(3)))).unwrap()
     );
     assert!(i
-        .invoke::<(i32, FuncRefForInteropValue), ()>(
+        .invoke_typed::<(i32, FuncRefForInteropValue), ()>(
             set,
             (
                 4,
@@ -174,11 +179,12 @@ fn table_grow_test() {
         )
         .is_ok());
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 4).unwrap()
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 4)
+            .unwrap()
             == FuncRefForInteropValue::new(Ref::Func(FuncAddr::new(Some(4)))).unwrap()
     );
     assert!(
-        i.invoke::<(i32, FuncRefForInteropValue), ()>(
+        i.invoke_typed::<(i32, FuncRefForInteropValue), ()>(
             set,
             (
                 5,
@@ -190,7 +196,7 @@ fn table_grow_test() {
             == RuntimeError::TableAccessOutOfBounds
     );
     assert!(
-        i.invoke::<i32, FuncRefForInteropValue>(get, 5)
+        i.invoke_typed::<i32, FuncRefForInteropValue>(get, 5)
             .err()
             .unwrap()
             == RuntimeError::TableAccessOutOfBounds
@@ -216,7 +222,7 @@ fn table_grow_outside_i32_range() {
     let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
-    assert_eq!(i.invoke::<(), i32>(grow, ()).unwrap(), -1);
+    assert_eq!(i.invoke_typed::<(), i32>(grow, ()).unwrap(), -1);
 }
 
 #[test_log::test]
@@ -303,13 +309,13 @@ fn table_grow_check_null() {
     let check_table_null = get_func!(i, "check-table-null");
 
     assert_eq!(
-        i.invoke::<(i32, i32), FuncRefForInteropValue>(check_table_null, (0, 9))
+        i.invoke_typed::<(i32, i32), FuncRefForInteropValue>(check_table_null, (0, 9))
             .unwrap(),
         FuncRefForInteropValue::new(Ref::Func(FuncAddr::null())).unwrap()
     );
     assert_result!(i, grow, 10, 10);
     assert_eq!(
-        i.invoke::<(i32, i32), FuncRefForInteropValue>(check_table_null, (0, 19))
+        i.invoke_typed::<(i32, i32), FuncRefForInteropValue>(check_table_null, (0, 19))
             .unwrap(),
         FuncRefForInteropValue::new(Ref::Func(FuncAddr::null())).unwrap()
     );

--- a/tests/table_init.rs
+++ b/tests/table_init.rs
@@ -62,38 +62,72 @@ fn table_init_1_test() {
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
-    assert!(i.invoke::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(3, i.invoke(check, 2).unwrap());
-    assert_eq!(1, i.invoke(check, 3).unwrap());
-    assert_eq!(4, i.invoke(check, 4).unwrap());
-    assert_eq!(1, i.invoke(check, 5).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(2, i.invoke(check, 7).unwrap());
-    assert_eq!(7, i.invoke(check, 8).unwrap());
-    assert_eq!(1, i.invoke(check, 9).unwrap());
-    assert_eq!(8, i.invoke(check, 10).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 12).unwrap());
-    assert_eq!(5, i.invoke(check, 13).unwrap());
-    assert_eq!(2, i.invoke(check, 14).unwrap());
-    assert_eq!(3, i.invoke(check, 15).unwrap());
-    assert_eq!(6, i.invoke(check, 16).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 17).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 19).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 21).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 23).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 24).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement);
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(3, i.invoke_typed(check, 2).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 3).unwrap());
+    assert_eq!(4, i.invoke_typed(check, 4).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 5).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(2, i.invoke_typed(check, 7).unwrap());
+    assert_eq!(7, i.invoke_typed(check, 8).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 9).unwrap());
+    assert_eq!(8, i.invoke_typed(check, 10).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 12).unwrap());
+    assert_eq!(5, i.invoke_typed(check, 13).unwrap());
+    assert_eq!(2, i.invoke_typed(check, 14).unwrap());
+    assert_eq!(3, i.invoke_typed(check, 15).unwrap());
+    assert_eq!(6, i.invoke_typed(check, 16).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 17).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 19).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 21).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 23).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 24).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement
+    );
 }
 
 #[test_log::test]
@@ -137,38 +171,78 @@ fn table_init_2_test() {
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
-    assert!(i.invoke::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(3, i.invoke(check, 2).unwrap());
-    assert_eq!(1, i.invoke(check, 3).unwrap());
-    assert_eq!(4, i.invoke(check, 4).unwrap());
-    assert_eq!(1, i.invoke(check, 5).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 7).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 8).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 9).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 10).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 12).unwrap());
-    assert_eq!(5, i.invoke(check, 13).unwrap());
-    assert_eq!(2, i.invoke(check, 14).unwrap());
-    assert_eq!(9, i.invoke(check, 15).unwrap());
-    assert_eq!(2, i.invoke(check, 16).unwrap());
-    assert_eq!(7, i.invoke(check, 17).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 19).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 21).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 23).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 24).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement);
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(3, i.invoke_typed(check, 2).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 3).unwrap());
+    assert_eq!(4, i.invoke_typed(check, 4).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 5).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 7).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 8).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 9).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 10).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 12).unwrap());
+    assert_eq!(5, i.invoke_typed(check, 13).unwrap());
+    assert_eq!(2, i.invoke_typed(check, 14).unwrap());
+    assert_eq!(9, i.invoke_typed(check, 15).unwrap());
+    assert_eq!(2, i.invoke_typed(check, 16).unwrap());
+    assert_eq!(7, i.invoke_typed(check, 17).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 19).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 21).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 23).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 24).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement
+    );
 }
 
 #[test_log::test]
@@ -216,38 +290,64 @@ fn table_init_3_test() {
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
-    assert!(i.invoke::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(3, i.invoke(check, 2).unwrap());
-    assert_eq!(1, i.invoke(check, 3).unwrap());
-    assert_eq!(4, i.invoke(check, 4).unwrap());
-    assert_eq!(1, i.invoke(check, 5).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(2, i.invoke(check, 7).unwrap());
-    assert_eq!(7, i.invoke(check, 8).unwrap());
-    assert_eq!(1, i.invoke(check, 9).unwrap());
-    assert_eq!(8, i.invoke(check, 10).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 12).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 13).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 14).unwrap());
-    assert_eq!(5, i.invoke(check, 15).unwrap());
-    assert_eq!(2, i.invoke(check, 16).unwrap());
-    assert_eq!(7, i.invoke(check, 17).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(9, i.invoke(check, 19).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 21).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(8, i.invoke(check, 23).unwrap());
-    assert_eq!(8, i.invoke(check, 24).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement);
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(3, i.invoke_typed(check, 2).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 3).unwrap());
+    assert_eq!(4, i.invoke_typed(check, 4).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 5).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(2, i.invoke_typed(check, 7).unwrap());
+    assert_eq!(7, i.invoke_typed(check, 8).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 9).unwrap());
+    assert_eq!(8, i.invoke_typed(check, 10).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 12).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 13).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 14).unwrap());
+    assert_eq!(5, i.invoke_typed(check, 15).unwrap());
+    assert_eq!(2, i.invoke_typed(check, 16).unwrap());
+    assert_eq!(7, i.invoke_typed(check, 17).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(9, i.invoke_typed(check, 19).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 21).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(8, i.invoke_typed(check, 23).unwrap());
+    assert_eq!(8, i.invoke_typed(check, 24).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement
+    );
 }
 
 #[test_log::test]
@@ -287,40 +387,80 @@ fn table_init_4_test() {
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
     // println!("{:#?}", i.modules[0].store.tables[1]);
 
-    assert!(i.invoke::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(3, i.invoke(check, 2).unwrap());
-    assert_eq!(1, i.invoke(check, 3).unwrap());
-    assert_eq!(4, i.invoke(check, 4).unwrap());
-    assert_eq!(1, i.invoke(check, 5).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 7).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 8).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 9).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 10).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 12).unwrap());
-    assert_eq!(5, i.invoke(check, 13).unwrap());
-    assert_eq!(2, i.invoke(check, 14).unwrap());
-    assert_eq!(9, i.invoke(check, 15).unwrap());
-    assert_eq!(2, i.invoke(check, 16).unwrap());
-    assert_eq!(7, i.invoke(check, 17).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 19).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 21).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 23).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 24).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement);
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(3, i.invoke_typed(check, 2).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 3).unwrap());
+    assert_eq!(4, i.invoke_typed(check, 4).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 5).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 7).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 8).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 9).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 10).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 12).unwrap());
+    assert_eq!(5, i.invoke_typed(check, 13).unwrap());
+    assert_eq!(2, i.invoke_typed(check, 14).unwrap());
+    assert_eq!(9, i.invoke_typed(check, 15).unwrap());
+    assert_eq!(2, i.invoke_typed(check, 16).unwrap());
+    assert_eq!(7, i.invoke_typed(check, 17).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 19).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 21).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 23).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 24).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement
+    );
 }
 
 #[test_log::test]
@@ -368,38 +508,64 @@ fn table_init_5_test() {
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 
-    assert!(i.invoke::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(3, i.invoke(check, 2).unwrap());
-    assert_eq!(1, i.invoke(check, 3).unwrap());
-    assert_eq!(4, i.invoke(check, 4).unwrap());
-    assert_eq!(1, i.invoke(check, 5).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(2, i.invoke(check, 7).unwrap());
-    assert_eq!(7, i.invoke(check, 8).unwrap());
-    assert_eq!(1, i.invoke(check, 9).unwrap());
-    assert_eq!(8, i.invoke(check, 10).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 12).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 13).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 14).unwrap());
-    assert_eq!(5, i.invoke(check, 15).unwrap());
-    assert_eq!(2, i.invoke(check, 16).unwrap());
-    assert_eq!(7, i.invoke(check, 17).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(9, i.invoke(check, 19).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(7, i.invoke(check, 21).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement);
-    assert_eq!(8, i.invoke(check, 23).unwrap());
-    assert_eq!(8, i.invoke(check, 24).unwrap());
-    assert!(i.invoke::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement);
-    assert!(i.invoke::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement);
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 0).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 1).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(3, i.invoke_typed(check, 2).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 3).unwrap());
+    assert_eq!(4, i.invoke_typed(check, 4).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 5).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 6).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(2, i.invoke_typed(check, 7).unwrap());
+    assert_eq!(7, i.invoke_typed(check, 8).unwrap());
+    assert_eq!(1, i.invoke_typed(check, 9).unwrap());
+    assert_eq!(8, i.invoke_typed(check, 10).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 11).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 12).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 13).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 14).unwrap());
+    assert_eq!(5, i.invoke_typed(check, 15).unwrap());
+    assert_eq!(2, i.invoke_typed(check, 16).unwrap());
+    assert_eq!(7, i.invoke_typed(check, 17).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 18).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(9, i.invoke_typed(check, 19).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 20).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(7, i.invoke_typed(check, 21).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 22).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert_eq!(8, i.invoke_typed(check, 23).unwrap());
+    assert_eq!(8, i.invoke_typed(check, 24).unwrap());
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 25).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 26).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 27).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 28).err().unwrap() == RuntimeError::UninitializedElement
+    );
+    assert!(
+        i.invoke_typed::<i32, i32>(check, 29).err().unwrap() == RuntimeError::UninitializedElement
+    );
 }
 
 #[test_log::test]
@@ -487,7 +653,7 @@ fn table_init_10_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -523,7 +689,9 @@ fn table_init_11_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -559,7 +727,7 @@ fn table_init_12_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -595,7 +763,7 @@ fn table_init_13_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -631,7 +799,9 @@ fn table_init_14_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -667,7 +837,9 @@ fn table_init_15_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -703,7 +875,9 @@ fn table_init_16_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -739,7 +913,9 @@ fn table_init_17_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -775,7 +951,7 @@ fn table_init_18_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -811,7 +987,9 @@ fn table_init_19_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -847,7 +1025,7 @@ fn table_init_20_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -883,7 +1061,9 @@ fn table_init_21_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -919,7 +1099,7 @@ fn table_init_22_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -955,7 +1135,9 @@ fn table_init_23_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -991,7 +1173,9 @@ fn table_init_24_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -1027,7 +1211,7 @@ fn table_init_25_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -1063,7 +1247,9 @@ fn table_init_26_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -1099,7 +1285,7 @@ fn table_init_27_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -1135,7 +1321,9 @@ fn table_init_28_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -1171,7 +1359,7 @@ fn table_init_29_test() {
 
     let test = get_func!(i, "test");
 
-    i.invoke::<(), ()>(test, ()).unwrap();
+    i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
 
 #[test_log::test]
@@ -1207,7 +1395,9 @@ fn table_init_30_test() {
 
     let test = get_func!(i, "test");
 
-    assert!(i.invoke::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds);
+    assert!(
+        i.invoke_typed::<(), ()>(test, ()).err().unwrap() == RuntimeError::TableAccessOutOfBounds
+    );
 }
 
 #[test_log::test]
@@ -2384,12 +2574,15 @@ fn table_init_94_test() {
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
     assert!(
-        inst.invoke::<(i32, i32), ()>(run, (24, 16)).err().unwrap()
+        inst.invoke_typed::<(i32, i32), ()>(run, (24, 16))
+            .err()
+            .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
     for i in 0..32 {
         assert!(
-            inst.invoke::<i32, i32>(test, i).err().unwrap() == RuntimeError::UninitializedElement
+            inst.invoke_typed::<i32, i32>(test, i).err().unwrap()
+                == RuntimeError::UninitializedElement
         );
     }
 }
@@ -2434,12 +2627,15 @@ fn table_init_95_test() {
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
     assert!(
-        inst.invoke::<(i32, i32), ()>(run, (25, 16)).err().unwrap()
+        inst.invoke_typed::<(i32, i32), ()>(run, (25, 16))
+            .err()
+            .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
     for i in 0..32 {
         assert!(
-            inst.invoke::<i32, i32>(test, i).err().unwrap() == RuntimeError::UninitializedElement
+            inst.invoke_typed::<i32, i32>(test, i).err().unwrap()
+                == RuntimeError::UninitializedElement
         );
     }
 }
@@ -2484,12 +2680,15 @@ fn table_init_96_test() {
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
     assert!(
-        inst.invoke::<(i32, i32), ()>(run, (96, 32)).err().unwrap()
+        inst.invoke_typed::<(i32, i32), ()>(run, (96, 32))
+            .err()
+            .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
     for i in 0..160 {
         assert!(
-            inst.invoke::<i32, i32>(test, i).err().unwrap() == RuntimeError::UninitializedElement
+            inst.invoke_typed::<i32, i32>(test, i).err().unwrap()
+                == RuntimeError::UninitializedElement
         );
     }
 }
@@ -2534,12 +2733,15 @@ fn table_init_97_test() {
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
     assert!(
-        inst.invoke::<(i32, i32), ()>(run, (97, 31)).err().unwrap()
+        inst.invoke_typed::<(i32, i32), ()>(run, (97, 31))
+            .err()
+            .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
     for i in 0..160 {
         assert!(
-            inst.invoke::<i32, i32>(test, i).err().unwrap() == RuntimeError::UninitializedElement
+            inst.invoke_typed::<i32, i32>(test, i).err().unwrap()
+                == RuntimeError::UninitializedElement
         );
     }
 }
@@ -2584,14 +2786,15 @@ fn table_init_98_test() {
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
     assert!(
-        inst.invoke::<(i32, u32), ()>(run, (48, 4294967280_u32))
+        inst.invoke_typed::<(i32, u32), ()>(run, (48, 4294967280_u32))
             .err()
             .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
     for i in 0..64 {
         assert!(
-            inst.invoke::<i32, i32>(test, i).err().unwrap() == RuntimeError::UninitializedElement
+            inst.invoke_typed::<i32, i32>(test, i).err().unwrap()
+                == RuntimeError::UninitializedElement
         );
     }
 }
@@ -2636,14 +2839,15 @@ fn table_init_99_test() {
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
     assert!(
-        inst.invoke::<(i32, i32), ()>(run, (0, 4294967292_u32 as i32))
+        inst.invoke_typed::<(i32, i32), ()>(run, (0, 4294967292_u32 as i32))
             .err()
             .unwrap()
             == RuntimeError::TableAccessOutOfBounds
     );
     for i in 0..16 {
         assert!(
-            inst.invoke::<i32, i32>(test, i).err().unwrap() == RuntimeError::UninitializedElement
+            inst.invoke_typed::<i32, i32>(test, i).err().unwrap()
+                == RuntimeError::UninitializedElement
         );
     }
 }

--- a/tests/table_size.rs
+++ b/tests/table_size.rs
@@ -27,7 +27,7 @@ macro_rules! get_func {
 
 macro_rules! assert_result {
     ($instance:expr, $func:expr, $arg:expr, $result:expr) => {
-        assert_eq!($result, $instance.invoke($func, $arg).unwrap());
+        assert_eq!($result, $instance.invoke_typed($func, $arg).unwrap());
     };
 }
 


### PR DESCRIPTION
### Pull Request Overview

This PR follows suggestions / reviews in #216 .

~Currently there is no functional change.~ This refactor uncovered that start function type validation was missing. It also fixes it.

Unnecessary return type checking at the end of `invoke` was removed, since wasm validation guarantees that already.

Removes `Store/RuntimeInstance::invoke_dynamic`.
Removes `Store::invoke`.
Renames `RuntimeInstance/Store::invoke_dynamic_unchecked_return_ty` as `Store::invoke`.
Renames `RuntimeInstance::invoke` as `RuntimeInstance::invoke_typed`.

### TODO or Help Wanted

- move input type checking logic to `RuntimeInstance`, since store methods are to assume their inputs are validated.

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
