### PR TITLE
RuntimeInstance::new() refactors

### DIFF
--- a/crates/benchmark/benches/general_purpose.rs
+++ b/crates/benchmark/benches/general_purpose.rs
@@ -48,7 +48,7 @@ macro_rules! bench_wasm {
 
             // Our interpreter
             let our_validation_info = validate(&wasm_bytes).unwrap();
-            let mut our_instance = RuntimeInstance::new(&our_validation_info).unwrap();
+            let mut our_instance = RuntimeInstance::new_with_default_module(&our_validation_info).unwrap();
             let our_fn = our_instance
                 .get_function_by_name(wasm::DEFAULT_MODULE, $entry_function)
                 .unwrap();

--- a/crates/benchmark/benches/hook_performance_impact.rs
+++ b/crates/benchmark/benches/hook_performance_impact.rs
@@ -36,7 +36,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     //
     // Set up an interpreter with the empty hook-set
     //
-    let mut instance_empty_hookset = RuntimeInstance::new(&validation_info).unwrap();
+    let mut instance_empty_hookset =
+        RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 
     //
     // Set up an interpreter with an non-empty hook-set
@@ -51,8 +52,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
     }
 
-    let mut instance_non_empty_hookset =
-        RuntimeInstance::new_with_hooks(DEFAULT_MODULE, &validation_info, MyCustomHookSet).unwrap();
+    let mut instance_non_empty_hookset = RuntimeInstance::new_with_hooks(MyCustomHookSet);
+    instance_non_empty_hookset
+        .add_module(DEFAULT_MODULE, &validation_info)
+        .unwrap();
 
     let test_fn = instance_empty_hookset.get_function_by_index(0, 2).unwrap();
     c.bench_function("invoke_func EmptyHookSet", |b| {

--- a/examples/stuff/main.rs
+++ b/examples/stuff/main.rs
@@ -45,7 +45,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let mut instance = match RuntimeInstance::new(&validation_info) {
+    let mut instance = match RuntimeInstance::new_with_default_module(&validation_info) {
         Ok(instance) => instance,
         Err(err) => {
             error!("Instantiation failed: {err:?} [{err}]");

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -36,9 +36,21 @@ where
     pub store: Store<'b>,
 }
 
+impl Default for RuntimeInstance<'_, EmptyHookSet> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'b> RuntimeInstance<'b, EmptyHookSet> {
-    pub fn new(validation_info: &'_ ValidationInfo<'b>) -> CustomResult<Self> {
-        Self::new_with_hooks(DEFAULT_MODULE, validation_info, EmptyHookSet)
+    pub fn new() -> Self {
+        Self::new_with_hooks(EmptyHookSet)
+    }
+
+    pub fn new_with_default_module(validation_info: &'_ ValidationInfo<'b>) -> CustomResult<Self> {
+        let mut instance = Self::new_with_hooks(EmptyHookSet);
+        instance.add_module(DEFAULT_MODULE, validation_info)?;
+        Ok(instance)
     }
 
     pub fn new_named(
@@ -46,7 +58,9 @@ impl<'b> RuntimeInstance<'b, EmptyHookSet> {
         validation_info: &'_ ValidationInfo<'b>,
         // store: &mut Store,
     ) -> CustomResult<Self> {
-        Self::new_with_hooks(module_name, validation_info, EmptyHookSet)
+        let mut instance = Self::new_with_hooks(EmptyHookSet);
+        instance.add_module(module_name, validation_info)?;
+        Ok(instance)
     }
 }
 
@@ -63,19 +77,13 @@ where
     }
 
     pub fn new_with_hooks(
-        module_name: &str,
-        validation_info: &'_ ValidationInfo<'b>,
         hook_set: H,
         // store: &mut Store,
-    ) -> CustomResult<Self> {
-        trace!("Starting instantiation of bytecode");
-
-        let store = Store::default();
-
-        let mut instance = RuntimeInstance { hook_set, store };
-        instance.add_module(module_name, validation_info)?;
-
-        Ok(instance)
+    ) -> Self {
+        RuntimeInstance {
+            hook_set,
+            store: Store::default(),
+        }
     }
 
     pub fn get_function_by_name(

--- a/tests/add_one.rs
+++ b/tests/add_one.rs
@@ -16,7 +16,8 @@ fn i32_add_one() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         12,
@@ -60,7 +61,8 @@ fn i64_add_one() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         12_i64,

--- a/tests/arithmetic/bitwise.rs
+++ b/tests/arithmetic/bitwise.rs
@@ -25,7 +25,8 @@ pub fn i32_bitwise_and() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -68,7 +69,8 @@ pub fn i32_bitwise_or() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         43,
@@ -111,7 +113,8 @@ pub fn i32_bitwise_xor() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         42,
@@ -154,7 +157,8 @@ pub fn i32_bitwise_shl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         67584,
@@ -197,7 +201,8 @@ pub fn i32_bitwise_shr_s() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         8881445,
@@ -377,7 +382,8 @@ pub fn i32_bitwise_shr_u() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         8881445,
@@ -557,7 +563,8 @@ pub fn i32_bitwise_rotl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -2021317328,
@@ -737,7 +744,8 @@ pub fn i32_bitwise_rotr() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         814187813,
@@ -917,7 +925,8 @@ pub fn i32_bitwise_clz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         26,
@@ -966,7 +975,8 @@ pub fn i32_bitwise_ctz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -1015,7 +1025,8 @@ pub fn i32_bitwise_popcnt() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2,
@@ -1081,7 +1092,8 @@ pub fn i64_bitwise_and() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1_i64,
@@ -1130,7 +1142,8 @@ pub fn i64_bitwise_or() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         43_i64,
@@ -1179,7 +1192,8 @@ pub fn i64_bitwise_xor() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         42_i64,
@@ -1228,7 +1242,8 @@ pub fn i64_bitwise_shl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         67584_i64,
@@ -1277,7 +1292,8 @@ pub fn i64_bitwise_shr_s() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         8881445_i64,
@@ -1484,7 +1500,8 @@ pub fn i64_bitwise_shr_u() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         8881445_i64,
@@ -1691,7 +1708,8 @@ pub fn i64_bitwise_rotl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2273649968_i64,
@@ -1898,7 +1916,8 @@ pub fn i64_bitwise_rotr() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3458764513829422373_i64,
@@ -2105,7 +2124,8 @@ pub fn i64_bitwise_clz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         58_i64,
@@ -2154,7 +2174,8 @@ pub fn i64_bitwise_ctz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -2203,7 +2224,8 @@ pub fn i64_bitwise_popcnt() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2_i64,

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -28,7 +28,8 @@ pub fn i32_division_signed_simple() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         10,
@@ -151,7 +152,8 @@ pub fn i32_division_signed_panic_dividend_0() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -172,7 +174,8 @@ pub fn i32_division_signed_panic_result_unrepresentable() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -193,7 +196,8 @@ pub fn i32_division_unsigned_simple() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         10,
@@ -295,7 +299,8 @@ pub fn i32_division_unsigned_panic_dividend_0() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -316,7 +321,8 @@ pub fn i64_division_signed_simple() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         10_i64,

--- a/tests/arithmetic/multiply.rs
+++ b/tests/arithmetic/multiply.rs
@@ -18,7 +18,8 @@ pub fn i32_multiply() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         33,
@@ -87,7 +88,8 @@ pub fn i64_multiply() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         33_i64,

--- a/tests/arithmetic/remainder.rs
+++ b/tests/arithmetic/remainder.rs
@@ -24,7 +24,8 @@ pub fn i64_remainder_signed_simple() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -106,7 +107,8 @@ pub fn i64_remainder_signed_panic_dividend_0() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i64, i64), i64>(
         &instance.get_function_by_index(0, 0).unwrap(),
@@ -122,7 +124,8 @@ pub fn i64_remainder_unsigned_simple() {
     let wat = String::from(REM_U_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -241,7 +244,8 @@ pub fn i64_remainder_unsigned_panic_dividend_0() {
     let wat = String::from(REM_U_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let result = instance
         .invoke_typed::<(i64, i64), i64>(&instance.get_function_by_index(0, 0).unwrap(), (222, 0));
@@ -255,7 +259,8 @@ pub fn i32_remainder_signed_simple() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -353,7 +358,8 @@ pub fn remainder_signed_panic_dividend_0() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -372,7 +378,8 @@ pub fn i32_remainder_unsigned_simple() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -527,7 +534,8 @@ pub fn i32_remainder_unsigned_panic_dividend_0() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance

--- a/tests/arithmetic/subtraction.rs
+++ b/tests/arithmetic/subtraction.rs
@@ -19,7 +19,8 @@ pub fn i64_subtract() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -10_i64,

--- a/tests/basic_memory.rs
+++ b/tests/basic_memory.rs
@@ -17,7 +17,8 @@ fn basic_memory() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let _ = instance.invoke_typed::<i32, ()>(
         &instance
@@ -45,7 +46,8 @@ fn f32_basic_memory() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     instance
         .invoke_typed::<f32, ()>(&instance.get_function_by_index(0, 0).unwrap(), 133.7_f32)

--- a/tests/conversions.rs
+++ b/tests/conversions.rs
@@ -37,7 +37,8 @@ pub fn i32_wrap_i64_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -56,7 +57,8 @@ pub fn i32_wrap_i64() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -168,7 +170,8 @@ pub fn i32_trunc_f32_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -187,7 +190,8 @@ pub fn i32_trunc_f32_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -356,7 +360,8 @@ pub fn i32_trunc_f32_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -519,7 +524,8 @@ pub fn i32_trunc_f64_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -538,7 +544,8 @@ pub fn i32_trunc_f64_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -722,7 +729,8 @@ pub fn i32_trunc_f64_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -927,7 +935,8 @@ pub fn i64_extend_i32_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -946,7 +955,8 @@ pub fn i64_extend_i32_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -998,7 +1008,8 @@ pub fn i64_extend_i32_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1050,7 +1061,8 @@ pub fn i64_trunc_f32_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1069,7 +1081,8 @@ pub fn i64_trunc_f32_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1256,7 +1269,8 @@ pub fn i64_trunc_f32_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1407,7 +1421,8 @@ pub fn i64_trunc_f64_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1426,7 +1441,8 @@ pub fn i64_trunc_f64_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1613,7 +1629,8 @@ pub fn i64_trunc_f64_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1794,7 +1811,8 @@ pub fn f32_convert_i32_s_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1813,7 +1831,8 @@ pub fn f32_convert_i32_s() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -1862,7 +1881,8 @@ pub fn f32_convert_i32_u() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -1980,7 +2000,8 @@ pub fn f32_convert_i64_s_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1998,7 +2019,8 @@ pub fn f32_convert_i64_s() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -2123,7 +2145,8 @@ pub fn f32_convert_i64_u() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -2225,7 +2248,8 @@ pub fn f32_demote_f64_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -2244,7 +2268,8 @@ pub fn f32_demote_f64() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -2683,7 +2708,8 @@ pub fn f64_convert_i32_s_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -2702,7 +2728,8 @@ pub fn f64_convert_i32_s() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -2751,7 +2778,8 @@ pub fn f64_convert_i32_u() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -2797,7 +2825,8 @@ pub fn f64_convert_i64_s_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -2816,7 +2845,8 @@ pub fn f64_convert_i64_s() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -2910,7 +2940,8 @@ pub fn f64_convert_i64_u() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -3035,7 +3066,8 @@ pub fn f64_promote_f32_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3054,7 +3086,8 @@ pub fn f64_promote_f32() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0.0_f64,
@@ -3167,7 +3200,8 @@ pub fn i32_reinterpret_f32_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3186,7 +3220,8 @@ pub fn i32_reinterpret_f32() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -3296,7 +3331,8 @@ pub fn i64_reinterpret_f64_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3315,7 +3351,8 @@ pub fn i64_reinterpret_f64() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -3424,7 +3461,8 @@ pub fn f32_reinterpret_i32_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3443,7 +3481,8 @@ pub fn f32_reinterpret_i32() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -3524,7 +3563,8 @@ pub fn f64_reinterpret_i64_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3543,7 +3583,8 @@ pub fn f64_reinterpret_i64() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0.0_f64,

--- a/tests/dynamic.rs
+++ b/tests/dynamic.rs
@@ -15,7 +15,8 @@ fn dynamic_add() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let func = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/f32.rs
+++ b/tests/f32.rs
@@ -18,7 +18,8 @@ pub fn f32_const() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3.141_592_7_f32,
@@ -47,7 +48,8 @@ pub fn f32_eq() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -76,7 +78,8 @@ pub fn f32_ne() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -114,7 +117,8 @@ pub fn f32_lt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -152,7 +156,8 @@ pub fn f32_gt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -190,7 +195,8 @@ pub fn f32_le() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -228,7 +234,8 @@ pub fn f32_ge() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -274,7 +281,8 @@ pub fn f32_abs() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -343,7 +351,8 @@ pub fn f32_neg() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -412,7 +421,8 @@ pub fn f32_ceil() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -441,7 +451,8 @@ pub fn f32_floor() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -470,7 +481,8 @@ pub fn f32_trunc() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -499,7 +511,8 @@ pub fn f32_nearest() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -534,7 +547,8 @@ pub fn f32_sqrt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -570,7 +584,8 @@ pub fn f32_add() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3.0_f32,
@@ -608,7 +623,8 @@ pub fn f32_sub() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -646,7 +662,8 @@ pub fn f32_mul() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         6.0_f32,
@@ -684,7 +701,8 @@ pub fn f32_div() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -727,7 +745,8 @@ pub fn f32_min() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -819,7 +838,8 @@ pub fn f32_max() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -912,7 +932,8 @@ pub fn f32_copysign() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.5_f32,
@@ -964,7 +985,8 @@ pub fn f32_convert_i32_s() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let i32_s_val = -42_i32;
     let f32_result = instance
@@ -985,7 +1007,8 @@ pub fn f32_convert_i32_u() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test_cases: Vec<(i32, f32)> = vec![
         (-2147483648, 2147483648.0),
@@ -1031,7 +1054,8 @@ pub fn f32_convert_i64_s() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let i64_s_val = i64::MIN; // Minimum i64 value
     let f32_result: f32 = instance
@@ -1071,7 +1095,8 @@ pub fn f32_convert_i64_u() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         9223373000000000000.0,
@@ -1105,7 +1130,8 @@ pub fn f32_reinterpret_i32() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test_cases = vec![
         (0x00000000, 0.0), // Positive zero

--- a/tests/f64.rs
+++ b/tests/f64.rs
@@ -18,7 +18,8 @@ pub fn f64_const() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3.14159265359_f64,
@@ -45,7 +46,8 @@ pub fn f64_eq() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -82,7 +84,8 @@ pub fn f64_ne() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -128,7 +131,8 @@ pub fn f64_lt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -174,7 +178,8 @@ pub fn f64_gt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -220,7 +225,8 @@ pub fn f64_le() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -266,7 +272,8 @@ pub fn f64_ge() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -311,7 +318,8 @@ pub fn f64_abs() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -387,7 +395,8 @@ pub fn f64_neg() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -463,7 +472,8 @@ pub fn f64_ceil() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -499,7 +509,8 @@ pub fn f64_floor() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -535,7 +546,8 @@ pub fn f64_trunc() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -571,7 +583,8 @@ pub fn f64_nearest() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -613,7 +626,8 @@ pub fn f64_sqrt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -648,7 +662,8 @@ pub fn f64_add() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3.0_f64,
@@ -694,7 +709,8 @@ pub fn f64_sub() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0.0_f64,
@@ -740,7 +756,8 @@ pub fn f64_mul() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         6.0_f64,
@@ -786,7 +803,8 @@ pub fn f64_div() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -837,7 +855,8 @@ pub fn f64_min() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -937,7 +956,8 @@ pub fn f64_max() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     {
         let result = instance
@@ -1038,7 +1058,8 @@ pub fn f64_copysign() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1.5_f64,

--- a/tests/fc_extensions.rs
+++ b/tests/fc_extensions.rs
@@ -36,7 +36,8 @@ pub fn i32_trunc_sat_f32_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -54,7 +55,8 @@ pub fn i32_trunc_sat_f32_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -219,7 +221,8 @@ pub fn i32_trunc_sat_f32_u_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -237,7 +240,8 @@ pub fn i32_trunc_sat_f32_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -396,7 +400,8 @@ pub fn i32_trunc_sat_f64_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -414,7 +419,8 @@ pub fn i32_trunc_sat_f64_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -573,7 +579,8 @@ pub fn i32_trunc_sat_f64_u_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -591,7 +598,8 @@ pub fn i32_trunc_sat_f64_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -771,7 +779,8 @@ pub fn i64_trunc_sat_f32_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -789,7 +798,8 @@ pub fn i64_trunc_sat_f32_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -972,7 +982,8 @@ pub fn i64_trunc_sat_f32_u_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -990,7 +1001,8 @@ pub fn i64_trunc_sat_f32_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1137,7 +1149,8 @@ pub fn i64_trunc_sat_f64_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1155,7 +1168,8 @@ pub fn i64_trunc_sat_f64_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1338,7 +1352,8 @@ pub fn i64_trunc_sat_f64_u_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1356,7 +1371,8 @@ pub fn i64_trunc_sat_f64_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0_i64,

--- a/tests/function_recursion.rs
+++ b/tests/function_recursion.rs
@@ -19,7 +19,8 @@ fn simple_function_call() {
     let wasm_bytes = wat::parse_str(FUNCTION_CALL).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3 * 7 + 13,
@@ -56,7 +57,8 @@ fn recursion_valid() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         12,
@@ -141,7 +143,8 @@ fn multivalue_call() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let foo_fn = instance
         .get_function_by_name(DEFAULT_MODULE, "bar")

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -28,7 +28,8 @@ fn valid_global() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     // Set global to 17. 5 is returned as previous (default) value.
     assert_eq!(
@@ -104,7 +105,8 @@ fn imported_globals() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     // Set global to 17. 3 is returned as previous (default) value.
     assert_eq!(

--- a/tests/i32.rs
+++ b/tests/i32.rs
@@ -31,7 +31,8 @@ pub fn i32_add() {
     let wat = String::from(WAT).replace("{{0}}", "add");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         2,
@@ -105,7 +106,8 @@ pub fn i32_sub() {
     let wat = String::from(WAT).replace("{{0}}", "sub");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -180,7 +182,8 @@ pub fn i32_eqz_panic() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -206,7 +209,8 @@ pub fn i32_eqz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -263,7 +267,8 @@ pub fn i32_eq_panic_first_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -290,7 +295,8 @@ pub fn i32_eq_panic_second_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -306,7 +312,8 @@ pub fn i32_eq() {
     let wat = String::from(WAT).replace("{{0}}", "eq");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -424,7 +431,8 @@ pub fn i32_ne() {
     let wat = String::from(WAT).replace("{{0}}", "ne");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -542,7 +550,8 @@ pub fn i32_lt_s() {
     let wat = String::from(WAT).replace("{{0}}", "lt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -660,7 +669,8 @@ pub fn i32_lt_u() {
     let wat = String::from(WAT).replace("{{0}}", "lt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -778,7 +788,8 @@ pub fn i32_gt_s() {
     let wat = String::from(WAT).replace("{{0}}", "gt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -896,7 +907,8 @@ pub fn i32_gt_u() {
     let wat = String::from(WAT).replace("{{0}}", "gt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -1014,7 +1026,8 @@ pub fn i32_le_s() {
     let wat = String::from(WAT).replace("{{0}}", "le_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1133,7 +1146,8 @@ pub fn i32_le_u() {
     let wat = String::from(WAT).replace("{{0}}", "le_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1251,7 +1265,8 @@ pub fn i32_ge_s() {
     let wat = String::from(WAT).replace("{{0}}", "ge_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1369,7 +1384,8 @@ pub fn i32_ge_u() {
     let wat = String::from(WAT).replace("{{0}}", "ge_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,

--- a/tests/i64.rs
+++ b/tests/i64.rs
@@ -41,7 +41,8 @@ pub fn i64_eqz_panic() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -67,7 +68,8 @@ pub fn i64_eqz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -127,7 +129,8 @@ pub fn i64_eq_panic_first_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -154,7 +157,8 @@ pub fn i64_eq_panic_second_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -170,7 +174,8 @@ pub fn i64_eq() {
     let wat = String::from(WAT).replace("{{0}}", "eq");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -306,7 +311,8 @@ pub fn i64_ne() {
     let wat = String::from(WAT).replace("{{0}}", "ne");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -442,7 +448,8 @@ pub fn i64_lt_s() {
     let wat = String::from(WAT).replace("{{0}}", "lt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -578,7 +585,8 @@ pub fn i64_lt_u() {
     let wat = String::from(WAT).replace("{{0}}", "lt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -714,7 +722,8 @@ pub fn i64_gt_s() {
     let wat = String::from(WAT).replace("{{0}}", "gt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -850,7 +859,8 @@ pub fn i64_gt_u() {
     let wat = String::from(WAT).replace("{{0}}", "gt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -986,7 +996,8 @@ pub fn i64_le_s() {
     let wat = String::from(WAT).replace("{{0}}", "le_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1123,7 +1134,8 @@ pub fn i64_le_u() {
     let wat = String::from(WAT).replace("{{0}}", "le_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1259,7 +1271,8 @@ pub fn i64_ge_s() {
     let wat = String::from(WAT).replace("{{0}}", "ge_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1395,7 +1408,8 @@ pub fn i64_ge_u() {
     let wat = String::from(WAT).replace("{{0}}", "ge_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         1,

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -34,7 +34,7 @@ fn memory_basic() {
     w.iter().for_each(|wat| {
         let wasm_bytes = wat::parse_str(wat).unwrap();
         let validation_info = validate(&wasm_bytes).expect("validation failed");
-        RuntimeInstance::new(&validation_info).expect("instantiation failed");
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     });
 }
 
@@ -186,7 +186,8 @@ fn i32_and_i64_loads() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let i32_load8_s = get_func!(i, "i32_load8_s");
     let i32_load8_u = get_func!(i, "i32_load8_u");
@@ -286,7 +287,8 @@ fn memory_test_exporting_rand_globals_doesnt_change_a_memory_s_semantics() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let load = get_func!(i, "load");
 

--- a/tests/memory_copy.rs
+++ b/tests/memory_copy.rs
@@ -46,7 +46,8 @@ fn memory_copy_test_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -77,7 +78,8 @@ fn memory_copy_test_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -108,7 +110,8 @@ fn memory_copy_test_3() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -143,7 +146,8 @@ fn memory_copy_test_4() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -178,7 +182,8 @@ fn memory_copy_test_5() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -212,7 +217,8 @@ fn memory_copy_test_6() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 0, 40));
@@ -284,7 +290,8 @@ fn memory_copy_test_7() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65515, 0, 39));
@@ -356,7 +363,8 @@ fn memory_copy_test_8() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65515, 0, 39));
@@ -428,7 +436,8 @@ fn memory_copy_test_9() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65516, 40));
@@ -501,7 +510,8 @@ fn memory_copy_test_10() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65515, 39));
@@ -574,7 +584,8 @@ fn memory_copy_test_11() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65486, 40));
@@ -647,7 +658,8 @@ fn memory_copy_test_12() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65486, 65516, 40));
@@ -720,7 +732,8 @@ fn memory_copy_test_13() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65506, 40));
@@ -793,7 +806,8 @@ fn memory_copy_test_14() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65506, 65516, 40));
@@ -866,7 +880,8 @@ fn memory_copy_test_15() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65516, 40));
@@ -939,7 +954,8 @@ fn memory_copy_test_16() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65516, 4294963200_u32 as i32));
@@ -1012,7 +1028,8 @@ fn memory_copy_test_17() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 61440, 4294967040_u32 as i32));

--- a/tests/memory_fill.rs
+++ b/tests/memory_fill.rs
@@ -39,7 +39,8 @@ fn memory_fill() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let fill = get_func!(i, "fill");
     i.invoke_typed::<(), ()>(fill, ()).unwrap();

--- a/tests/memory_fill.rs
+++ b/tests/memory_fill.rs
@@ -43,7 +43,7 @@ fn memory_fill() {
 
     let fill = get_func!(i, "fill");
     i.invoke_typed::<(), ()>(fill, ()).unwrap();
-    let mem_inst = &i.store.as_ref().unwrap().memories[0];
+    let mem_inst = &i.store.memories[0];
 
     let expected = [vec![217u8; 100], vec![0u8; 5]].concat();
     for (idx, expected_byte) in expected.into_iter().enumerate() {

--- a/tests/memory_grow.rs
+++ b/tests/memory_grow.rs
@@ -57,7 +57,8 @@ fn memory_grow_test_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     // let x = i.invoke_typed(function_ref, params)
     assert_result!(i, get_func!(i, "size"), (), 0);
@@ -92,7 +93,8 @@ fn memory_grow_test_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_result!(i, get_func!(i, "grow"), 0, 0);
     assert_result!(i, get_func!(i, "grow"), 1, 0);
@@ -114,7 +116,8 @@ fn memory_grow_test_3() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_result!(i, get_func!(i, "grow"), 0, 0);
     assert_result!(i, get_func!(i, "grow"), 1, 0);

--- a/tests/memory_init.rs
+++ b/tests/memory_init.rs
@@ -56,7 +56,8 @@ fn memory_init_test_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -90,7 +91,8 @@ fn memory_init_test_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -124,7 +126,8 @@ fn memory_init_test_3() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -166,7 +169,8 @@ fn memory_init_test_4() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -223,7 +227,8 @@ fn memory_init_test_7() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
@@ -240,7 +245,8 @@ fn memory_init_test_8() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     assert_error!(i, get_func!(i, "test"), (), Result<(), RuntimeError>, (), (), RuntimeError::MemoryAccessOutOfBounds);
 }
 
@@ -255,7 +261,8 @@ fn memory_init_test_9() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     assert_error!(i, get_func!(i, "test"), (), Result<(), RuntimeError>, (), (), RuntimeError::MemoryAccessOutOfBounds);
 }
 
@@ -299,7 +306,8 @@ fn memory_init_test_12() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
@@ -315,6 +323,7 @@ fn memory_init_test_13() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     assert_error!(i, get_func!(i, "test"), (), Result<(), RuntimeError>, (), (), RuntimeError::MemoryAccessOutOfBounds);
 }

--- a/tests/memory_redundancy.rs
+++ b/tests/memory_redundancy.rs
@@ -90,7 +90,8 @@ fn memory_redundancy() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     let zero_everything = get_func!(i, "zero_everything");
     assert_result!(i, get_func!(i, "test_store_to_load"), (), 0x00000080);
     i.invoke_typed::<(), ()>(zero_everything, ()).unwrap();

--- a/tests/memory_size.rs
+++ b/tests/memory_size.rs
@@ -41,7 +41,8 @@ fn memory_size_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");
@@ -66,7 +67,8 @@ fn memory_size_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");
@@ -91,7 +93,8 @@ fn memory_size_3() {
 "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");
@@ -120,7 +123,8 @@ fn memory_size_4() {
 "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");

--- a/tests/memory_trap.rs
+++ b/tests/memory_trap.rs
@@ -64,7 +64,8 @@ fn memory_trap_1() {
 "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let store = get_func!(i, "store");
     let load = get_func!(i, "load");

--- a/tests/return.rs
+++ b/tests/return.rs
@@ -24,7 +24,8 @@ fn return_valid() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         12,

--- a/tests/same_type_fn.rs
+++ b/tests/same_type_fn.rs
@@ -21,7 +21,8 @@ fn same_type_fn() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         -5,

--- a/tests/select.rs
+++ b/tests/select.rs
@@ -39,7 +39,8 @@ fn polymorphic_select_test() {
     validate(&wasm_bytes).expect("validation failed");
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let select_test_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -58,7 +59,8 @@ fn typed_select_test() {
     validate(&wasm_bytes).expect("validation failed");
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let select_test_fn = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/specification/run.rs
+++ b/tests/specification/run.rs
@@ -135,10 +135,7 @@ fn validate_instantiate<'a, 'b: 'a>(
         .map_err(WasmInterpreterError::new_boxed)?;
 
     // TODO change hacky hidden name that uses interpreter internals
-    let module_name = format!(
-        "module_{}",
-        interpreter.store.as_ref().unwrap().modules.len()
-    );
+    let module_name = format!("module_{}", interpreter.store.modules.len());
     catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
         interpreter.add_module(module_name.as_str(), &validation_info)
     }))
@@ -224,10 +221,8 @@ pub fn run_spec_test(filepath: &str) -> WastTestReport {
                     | QuoteWat::Wat(wast::Wat::Component(wast::component::Component {
                         id: _maybe_id @ Some(id),
                         ..
-                    })) => visible_modules.insert(
-                        id.name().to_owned(),
-                        interpreter.store.as_ref().unwrap().modules.len(),
-                    ),
+                    })) => visible_modules
+                        .insert(id.name().to_owned(), interpreter.store.modules.len()),
                     _ => None,
                 };
 
@@ -344,7 +339,7 @@ pub fn run_spec_test(filepath: &str) -> WastTestReport {
 
                 // spec tests tells us to use the last defined module if module name is not specified
                 // TODO this ugly chunk might need to be refactored out
-                let store = interpreter.store.as_mut().unwrap();
+                let store = &mut interpreter.store;
                 let module_addr = match modulee {
                     None => store.modules.len() - 1,
                     Some(id) => {
@@ -450,7 +445,7 @@ pub fn run_spec_test(filepath: &str) -> WastTestReport {
 
                 let function_ref_attempt =
                     catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                        let store = interpreter.store.as_ref().unwrap();
+                        let store = &mut interpreter.store;
                         let module_inst = match invoke.module {
                             None => store.modules.last().unwrap(),
                             Some(id) => {
@@ -557,7 +552,7 @@ fn execute_assert_return(
             // spec tests tells us to use the last defined module if module name is not specified
             // TODO this ugly chunk might need to be refactored out
             let func = catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                let store = interpreter.store.as_ref().unwrap();
+                let store = &mut interpreter.store;
                 let module_inst = match invoke_info.module {
                     None => store.modules.last().unwrap(),
                     Some(id) => {
@@ -604,7 +599,7 @@ fn execute_assert_return(
                 .map(result_to_value)
                 .collect::<Result<Vec<_>, _>>()?;
             let actual = catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                let store = interpreter.store.as_ref().unwrap();
+                let store = &mut interpreter.store;
                 let module_inst = match module {
                     None => store.modules.last().unwrap(),
                     Some(id) => {
@@ -655,7 +650,7 @@ fn execute_assert_trap<'a>(
             // spec tests tells us to use the last defined module if module name is not specified
             // TODO this ugly chunk might need to be refactored out
             let func = catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                let store = interpreter.store.as_ref().unwrap();
+                let store = &mut interpreter.store;
                 let module_inst = match invoke_info.module {
                     None => store.modules.last().unwrap(),
                     Some(id) => {
@@ -707,10 +702,7 @@ fn execute_assert_trap<'a>(
                 .map_err(WasmInterpreterError::new_boxed)?;
 
             // TODO change hacky hidden name that uses interpreter internals
-            let module_name = format!(
-                "module_{}",
-                interpreter.store.as_ref().unwrap().modules.len()
-            );
+            let module_name = format!("module_{}", interpreter.store.modules.len());
             let instantiation_result =
                 catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
                     interpreter.add_module(module_name.as_str(), &validation_info)

--- a/tests/start_function.rs
+++ b/tests/start_function.rs
@@ -25,7 +25,8 @@ fn start_function() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         42,

--- a/tests/structured_control_flow/block.rs
+++ b/tests/structured_control_flow/block.rs
@@ -14,7 +14,8 @@ fn empty() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     instance
         .invoke_typed::<(), ()>(&instance.get_function_by_index(0, 0).unwrap(), ())
@@ -43,7 +44,8 @@ fn branch() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         8,
@@ -85,7 +87,8 @@ fn branch2() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         13,
@@ -101,7 +104,8 @@ fn branch3() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         5,
@@ -130,7 +134,8 @@ fn param_and_result() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         7,
@@ -174,7 +179,8 @@ fn return_out_of_block() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3,
@@ -190,7 +196,8 @@ fn br_return_out_of_block() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         3,
@@ -206,7 +213,8 @@ fn return_out_of_block2() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         5,
@@ -222,7 +230,8 @@ fn br_return_out_of_block2() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     assert_eq!(
         5,
@@ -256,7 +265,8 @@ fn branch_if() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let switch_case_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -318,7 +328,8 @@ fn recursive_fibonacci() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let fib_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -363,7 +374,8 @@ fn switch_case() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let switch_case_fn = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/structured_control_flow/if.rs
+++ b/tests/structured_control_flow/if.rs
@@ -24,7 +24,8 @@ fn odd_with_if_else() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -56,7 +57,8 @@ fn odd_with_if() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -110,7 +112,8 @@ fn odd_with_if_else_recursive() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let even_odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -154,7 +157,8 @@ fn recursive_fibonacci_if_else() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let fibonacci_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -181,7 +185,8 @@ fn if_without_else_type_check1() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let empty_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -224,7 +229,8 @@ fn if_without_else_type_check3() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let add_one_if_true_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -248,7 +254,8 @@ fn if_without_else_type_check4() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let add_one_if_true_fn = instance.get_function_by_index(0, 0).unwrap();
     assert_eq!(

--- a/tests/structured_control_flow/loop.rs
+++ b/tests/structured_control_flow/loop.rs
@@ -56,7 +56,8 @@ fn fibonacci_with_loop_and_br_if() {
     let wasm_bytes = wat::parse_str(FIBONACCI_WITH_LOOP_AND_BR_IF).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let fibonacci_fn = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -122,7 +122,7 @@ fn table_elem_test() {
     let validation_info = validate(&wasm_bytes).unwrap();
     let instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
     // let table = &instance.modules[0].store.tables[0];
-    let table = &instance.store.as_ref().unwrap().tables[0];
+    let table = &instance.store.tables[0];
     assert!(table.len() == 2);
     let wanted: [usize; 2] = [0, 2];
     table

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -45,7 +45,7 @@ fn table_basic() {
     w.iter().for_each(|wat| {
         let wasm_bytes = wat::parse_str(wat).unwrap();
         let validation_info = validate(&wasm_bytes).expect("validation failed");
-        RuntimeInstance::new(&validation_info).expect("instantiation failed");
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     });
 }
 
@@ -120,7 +120,8 @@ fn table_elem_test() {
     )"#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
     // let table = &instance.modules[0].store.tables[0];
     let table = &instance.store.tables[0];
     assert!(table.len() == 2);
@@ -158,7 +159,8 @@ fn table_get_set_test() {
     "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let get_funcref = get_func!(i, "get-funcref");
     let init = get_func!(i, "init");
@@ -249,7 +251,8 @@ fn call_indirect_type_check() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut instance =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let call_fn = instance
         .get_function_by_name(DEFAULT_MODULE, "call_function")

--- a/tests/table_fill.rs
+++ b/tests/table_fill.rs
@@ -56,7 +56,8 @@ fn table_fill_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let get = get_func!(i, "get");
     let fill = get_func!(i, "fill");

--- a/tests/table_get.rs
+++ b/tests/table_get.rs
@@ -69,7 +69,8 @@ fn table_funcref_test() {
     "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let init = get_func!(i, "init");
     let get_funcref = get_func!(i, "get-funcref");

--- a/tests/table_grow.rs
+++ b/tests/table_grow.rs
@@ -50,7 +50,8 @@ fn table_grow_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let get = get_func!(i, "get");
     let set = get_func!(i, "set");
@@ -219,7 +220,8 @@ fn table_grow_outside_i32_range() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     assert_eq!(i.invoke_typed::<(), i32>(grow, ()).unwrap(), -1);
@@ -238,7 +240,8 @@ fn table_grow_unlimited() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     assert_result!(i, grow, 0, 0);
@@ -261,7 +264,8 @@ fn table_grow_with_max() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     assert_result!(i, grow, 0, 0);
@@ -303,7 +307,8 @@ fn table_grow_check_null() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     let check_table_null = get_func!(i, "check-table-null");
@@ -335,8 +340,8 @@ fn table_grow_with_exported_table_test() {
 
     let wasm_bytes = wat::parse_str(target_wat).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut target_instance =
-        RuntimeInstance::new(&validation_info).expect("target instantiation failed");
+    let mut target_instance = RuntimeInstance::new_with_default_module(&validation_info)
+        .expect("target instantiation failed");
 
     let grow = get_func!(target_instance, "grow");
     assert_result!(target_instance, grow, (), 1);

--- a/tests/table_init.rs
+++ b/tests/table_init.rs
@@ -57,7 +57,8 @@ fn table_init_1_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -166,7 +167,8 @@ fn table_init_2_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -285,7 +287,8 @@ fn table_init_3_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -382,7 +385,8 @@ fn table_init_4_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -503,7 +507,8 @@ fn table_init_5_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -649,7 +654,8 @@ fn table_init_10_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -685,7 +691,8 @@ fn table_init_11_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -723,7 +730,8 @@ fn table_init_12_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -759,7 +767,8 @@ fn table_init_13_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -795,7 +804,8 @@ fn table_init_14_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -833,7 +843,8 @@ fn table_init_15_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -871,7 +882,8 @@ fn table_init_16_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -909,7 +921,8 @@ fn table_init_17_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -947,7 +960,8 @@ fn table_init_18_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -983,7 +997,8 @@ fn table_init_19_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1021,7 +1036,8 @@ fn table_init_20_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1057,7 +1073,8 @@ fn table_init_21_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1095,7 +1112,8 @@ fn table_init_22_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1131,7 +1149,8 @@ fn table_init_23_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1169,7 +1188,8 @@ fn table_init_24_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1207,7 +1227,8 @@ fn table_init_25_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1243,7 +1264,8 @@ fn table_init_26_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1281,7 +1303,8 @@ fn table_init_27_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1317,7 +1340,8 @@ fn table_init_28_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1355,7 +1379,8 @@ fn table_init_29_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1391,7 +1416,8 @@ fn table_init_30_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -2569,7 +2595,7 @@ fn table_init_94_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2622,7 +2648,7 @@ fn table_init_95_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2675,7 +2701,7 @@ fn table_init_96_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2728,7 +2754,7 @@ fn table_init_97_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2781,7 +2807,7 @@ fn table_init_98_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2834,7 +2860,7 @@ fn table_init_99_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2881,5 +2907,5 @@ fn table_init_100_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    RuntimeInstance::new(&validation_info).unwrap();
+    RuntimeInstance::new_with_default_module(&validation_info).unwrap();
 }

--- a/tests/table_size.rs
+++ b/tests/table_size.rs
@@ -61,7 +61,8 @@ fn table_size_test() {
     "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i = RuntimeInstance::new(&validation_info).expect("instantiation failed");
+    let mut i =
+        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
 
     // let get_funcref = get_func!(i, "get-funcref");
     // let init = get_func!(i, "init");


### PR DESCRIPTION
### Pull Request Overview

Stacked on #219.

Store can contain entities added by hand without even instantiating a default module. The RuntimeInstance having Store struct initialized possibly later also serves no function. The changes are:

- RuntimeInstance contains Store instead of Option(Store)
- Rename RuntimeInstance::new into RuntimeInstance::new_with_default_module
- New RuntimeInstance::new/RuntimeInstance::new_with_hooks with no validation_info

### TODO or Help Wanted

- Possible discussion point is whether RuntimeInstance::new/RuntimeInstance::new_with_hooks are appropriately named and have appropriate arguments.

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
