### PR TITLE
feat: add user data for host functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A minimal in-place interpreter for [WebAssembly](https://webassembly.org/) bytec
 - **`no_std` support**: The interpreter requires only Rust's `core` and `alloc` libraries allowing its use in various environments, such as bare-metal systems.
 - **Minimal dependencies**: The interpreter requires only two dependencies: `log`, `libm`.
 - **Compliance with specification**: The interpreter passes almost all test from the [official WebAssembly testsuite](https://github.com/WebAssembly/testsuite). Only SIMD instructions are missing.
+- **Host functions**: The host system can provide functions for Wasm code to call.
 
 _For information on other features, visit our [requirements page](https://dlr-ft.github.io/wasm-interpreter/main/requirements/html/index.html)._
 
@@ -27,7 +28,6 @@ _For information on other features, visit our [requirements page](https://dlr-ft
 
 - **Fuel & resumable execution**: A fuel mechanism is used to halt execution once fuel runs out. Then fuel can be refilled and execution resumed.
 - **C bindings**: The interpreter can be used from C code.
-- **Host functions**: A host system can provide functions for Wasm code to call.
 - **Migratability**: Wasm instances can be transferred between systems during their execution.
 - **Threading**: There are multiple threading proposals, but we have not yet chosen a specific one. Some options are [shared-everything-threads](https://github.com/WebAssembly/shared-everything-threads), [threads](https://github.com/WebAssembly/threads), [wasi-threads](https://github.com/WebAssembly/wasi-threads).
 

--- a/crates/benchmark/benches/general_purpose.rs
+++ b/crates/benchmark/benches/general_purpose.rs
@@ -48,7 +48,7 @@ macro_rules! bench_wasm {
 
             // Our interpreter
             let our_validation_info = validate(&wasm_bytes).unwrap();
-            let mut our_instance = RuntimeInstance::new_with_default_module(&our_validation_info).unwrap();
+            let mut our_instance = RuntimeInstance::new_with_default_module((), &our_validation_info).unwrap();
             let our_fn = our_instance
                 .get_function_by_name(wasm::DEFAULT_MODULE, $entry_function)
                 .unwrap();

--- a/crates/benchmark/benches/hook_performance_impact.rs
+++ b/crates/benchmark/benches/hook_performance_impact.rs
@@ -37,7 +37,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Set up an interpreter with the empty hook-set
     //
     let mut instance_empty_hookset =
-        RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+        RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 
     //
     // Set up an interpreter with an non-empty hook-set
@@ -52,7 +52,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
     }
 
-    let mut instance_non_empty_hookset = RuntimeInstance::new_with_hooks(MyCustomHookSet);
+    let mut instance_non_empty_hookset = RuntimeInstance::new_with_hooks((), MyCustomHookSet);
     instance_non_empty_hookset
         .add_module(DEFAULT_MODULE, &validation_info)
         .unwrap();

--- a/examples/stuff/main.rs
+++ b/examples/stuff/main.rs
@@ -45,7 +45,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let mut instance = match RuntimeInstance::new_with_default_module(&validation_info) {
+    let mut instance = match RuntimeInstance::new_with_default_module((), &validation_info) {
         Ok(instance) => instance,
         Err(err) => {
             error!("Instantiation failed: {err:?} [{err}]");

--- a/src/execution/const_interpreter_loop.rs
+++ b/src/execution/const_interpreter_loop.rs
@@ -20,11 +20,11 @@ use crate::{
 /// This function assumes that the expression has been validated. Passing unvalidated code will likely result in a
 /// panic, or undefined behaviour.
 // TODO this signature might change to support hooks or match the spec better
-pub(crate) fn run_const(
+pub(crate) fn run_const<T>(
     wasm: &mut WasmReader,
     stack: &mut Stack,
     module: &ModuleInst,
-    store: &Store,
+    store: &Store<T>,
 ) -> Result<(), RuntimeError> {
     use crate::core::reader::types::opcode::*;
     loop {
@@ -95,11 +95,11 @@ pub(crate) fn run_const(
     Ok(())
 }
 
-pub(crate) fn run_const_span(
+pub(crate) fn run_const_span<T>(
     wasm: &[u8],
     span: &Span,
     module: &ModuleInst,
-    store: &Store,
+    store: &Store<T>,
 ) -> Result<Option<Value>, RuntimeError> {
     let mut wasm = WasmReader::new(wasm);
 

--- a/src/execution/function_ref.rs
+++ b/src/execution/function_ref.rs
@@ -9,10 +9,10 @@ pub struct FunctionRef {
 }
 
 impl FunctionRef {
-    pub fn new_from_name(
+    pub fn new_from_name<T>(
         module_name: &str,
         function_name: &str,
-        store: &Store,
+        store: &Store<T>,
     ) -> CustomResult<Self> {
         // https://webassembly.github.io/spec/core/appendix/embedding.html#module-instances
         // inspired by instance_export
@@ -44,9 +44,9 @@ impl FunctionRef {
         runtime.invoke_typed(self, params /* , store */)
     }
 
-    pub fn invoke<H: HookSet + core::fmt::Debug>(
+    pub fn invoke<T, H: HookSet + core::fmt::Debug>(
         &self,
-        runtime: &mut RuntimeInstance<H>,
+        runtime: &mut RuntimeInstance<T, H>,
         params: Vec<Value>,
         // store: &mut Store,
     ) -> Result<Vec<Value>, RuntimeError> {

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -38,11 +38,11 @@ use crate::execution::hooks::HookSet;
 use super::store::Store;
 
 /// Interprets wasm native functions. Parameters and return values are passed on the stack.
-pub(super) fn run<H: HookSet>(
+pub(super) fn run<T, H: HookSet>(
     func_addr: usize,
     stack: &mut Stack,
     mut hooks: H,
-    store: &mut Store,
+    store: &mut Store<T>,
 ) -> Result<(), RuntimeError> {
     let mut current_func_addr = func_addr;
     let func_inst = &store.functions[current_func_addr];
@@ -196,7 +196,10 @@ pub(super) fn run<H: HookSet>(
 
                 match &store.functions[func_to_call_addr] {
                     FuncInst::HostFunc(host_func_to_call_inst) => {
-                        let returns = (host_func_to_call_inst.hostcode)(params.collect());
+                        let returns = (host_func_to_call_inst.hostcode)(
+                            &mut store.user_data,
+                            params.collect(),
+                        );
 
                         // Verify that the return parameters match the host function parameters
                         // since we have no validation guarantees for host functions
@@ -278,7 +281,10 @@ pub(super) fn run<H: HookSet>(
 
                 match &store.functions[func_to_call_addr] {
                     FuncInst::HostFunc(host_func_to_call_inst) => {
-                        let returns = (host_func_to_call_inst.hostcode)(params.collect());
+                        let returns = (host_func_to_call_inst.hostcode)(
+                            &mut store.user_data,
+                            params.collect(),
+                        );
 
                         // Verify that the return parameters match the host function parameters
                         // since we have no validation guarantees for host functions

--- a/tests/add_one.rs
+++ b/tests/add_one.rs
@@ -16,8 +16,8 @@ fn i32_add_one() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         12,
@@ -61,8 +61,8 @@ fn i64_add_one() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         12_i64,

--- a/tests/arithmetic/bitwise.rs
+++ b/tests/arithmetic/bitwise.rs
@@ -25,8 +25,8 @@ pub fn i32_bitwise_and() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -69,8 +69,8 @@ pub fn i32_bitwise_or() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         43,
@@ -113,8 +113,8 @@ pub fn i32_bitwise_xor() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         42,
@@ -157,8 +157,8 @@ pub fn i32_bitwise_shl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         67584,
@@ -201,8 +201,8 @@ pub fn i32_bitwise_shr_s() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         8881445,
@@ -382,8 +382,8 @@ pub fn i32_bitwise_shr_u() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         8881445,
@@ -563,8 +563,8 @@ pub fn i32_bitwise_rotl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -2021317328,
@@ -744,8 +744,8 @@ pub fn i32_bitwise_rotr() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         814187813,
@@ -925,8 +925,8 @@ pub fn i32_bitwise_clz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         26,
@@ -975,8 +975,8 @@ pub fn i32_bitwise_ctz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -1025,8 +1025,8 @@ pub fn i32_bitwise_popcnt() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2,
@@ -1092,8 +1092,8 @@ pub fn i64_bitwise_and() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1_i64,
@@ -1142,8 +1142,8 @@ pub fn i64_bitwise_or() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         43_i64,
@@ -1192,8 +1192,8 @@ pub fn i64_bitwise_xor() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         42_i64,
@@ -1242,8 +1242,8 @@ pub fn i64_bitwise_shl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         67584_i64,
@@ -1292,8 +1292,8 @@ pub fn i64_bitwise_shr_s() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         8881445_i64,
@@ -1500,8 +1500,8 @@ pub fn i64_bitwise_shr_u() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         8881445_i64,
@@ -1708,8 +1708,8 @@ pub fn i64_bitwise_rotl() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2273649968_i64,
@@ -1916,8 +1916,8 @@ pub fn i64_bitwise_rotr() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3458764513829422373_i64,
@@ -2124,8 +2124,8 @@ pub fn i64_bitwise_clz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         58_i64,
@@ -2174,8 +2174,8 @@ pub fn i64_bitwise_ctz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -2224,8 +2224,8 @@ pub fn i64_bitwise_popcnt() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2_i64,

--- a/tests/arithmetic/division.rs
+++ b/tests/arithmetic/division.rs
@@ -28,8 +28,8 @@ pub fn i32_division_signed_simple() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         10,
@@ -152,8 +152,8 @@ pub fn i32_division_signed_panic_dividend_0() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -174,8 +174,8 @@ pub fn i32_division_signed_panic_result_unrepresentable() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -196,8 +196,8 @@ pub fn i32_division_unsigned_simple() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         10,
@@ -299,8 +299,8 @@ pub fn i32_division_unsigned_panic_dividend_0() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -321,8 +321,8 @@ pub fn i64_division_signed_simple() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         10_i64,

--- a/tests/arithmetic/multiply.rs
+++ b/tests/arithmetic/multiply.rs
@@ -18,8 +18,8 @@ pub fn i32_multiply() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         33,
@@ -88,8 +88,8 @@ pub fn i64_multiply() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         33_i64,

--- a/tests/arithmetic/remainder.rs
+++ b/tests/arithmetic/remainder.rs
@@ -24,8 +24,8 @@ pub fn i64_remainder_signed_simple() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -107,8 +107,8 @@ pub fn i64_remainder_signed_panic_dividend_0() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i64, i64), i64>(
         &instance.get_function_by_index(0, 0).unwrap(),
@@ -124,8 +124,8 @@ pub fn i64_remainder_unsigned_simple() {
     let wat = String::from(REM_U_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -244,8 +244,8 @@ pub fn i64_remainder_unsigned_panic_dividend_0() {
     let wat = String::from(REM_U_WAT).replace("{{TYPE}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let result = instance
         .invoke_typed::<(i64, i64), i64>(&instance.get_function_by_index(0, 0).unwrap(), (222, 0));
@@ -259,8 +259,8 @@ pub fn i32_remainder_signed_simple() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -358,8 +358,8 @@ pub fn remainder_signed_panic_dividend_0() {
     let wat = String::from(REM_S_WAT).replace("{{TYPE}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance
@@ -378,8 +378,8 @@ pub fn i32_remainder_unsigned_simple() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -534,8 +534,8 @@ pub fn i32_remainder_unsigned_panic_dividend_0() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let result = instance.invoke_typed::<(i32, i32), i32>(
         &instance

--- a/tests/arithmetic/subtraction.rs
+++ b/tests/arithmetic/subtraction.rs
@@ -19,8 +19,8 @@ pub fn i64_subtract() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -10_i64,

--- a/tests/basic_memory.rs
+++ b/tests/basic_memory.rs
@@ -17,8 +17,8 @@ fn basic_memory() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let _ = instance.invoke_typed::<i32, ()>(
         &instance
@@ -46,8 +46,8 @@ fn f32_basic_memory() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     instance
         .invoke_typed::<f32, ()>(&instance.get_function_by_index(0, 0).unwrap(), 133.7_f32)

--- a/tests/conversions.rs
+++ b/tests/conversions.rs
@@ -37,8 +37,8 @@ pub fn i32_wrap_i64_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -57,8 +57,8 @@ pub fn i32_wrap_i64() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -170,8 +170,8 @@ pub fn i32_trunc_f32_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -190,8 +190,8 @@ pub fn i32_trunc_f32_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -360,8 +360,8 @@ pub fn i32_trunc_f32_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -524,8 +524,8 @@ pub fn i32_trunc_f64_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -544,8 +544,8 @@ pub fn i32_trunc_f64_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -729,8 +729,8 @@ pub fn i32_trunc_f64_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -935,8 +935,8 @@ pub fn i64_extend_i32_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -955,8 +955,8 @@ pub fn i64_extend_i32_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1008,8 +1008,8 @@ pub fn i64_extend_i32_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1061,8 +1061,8 @@ pub fn i64_trunc_f32_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1081,8 +1081,8 @@ pub fn i64_trunc_f32_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1269,8 +1269,8 @@ pub fn i64_trunc_f32_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1421,8 +1421,8 @@ pub fn i64_trunc_f64_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1441,8 +1441,8 @@ pub fn i64_trunc_f64_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1629,8 +1629,8 @@ pub fn i64_trunc_f64_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1811,8 +1811,8 @@ pub fn f32_convert_i32_s_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1831,8 +1831,8 @@ pub fn f32_convert_i32_s() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -1881,8 +1881,8 @@ pub fn f32_convert_i32_u() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -2000,8 +2000,8 @@ pub fn f32_convert_i64_s_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -2019,8 +2019,8 @@ pub fn f32_convert_i64_s() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -2145,8 +2145,8 @@ pub fn f32_convert_i64_u() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -2248,8 +2248,8 @@ pub fn f32_demote_f64_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -2268,8 +2268,8 @@ pub fn f32_demote_f64() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -2708,8 +2708,8 @@ pub fn f64_convert_i32_s_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -2728,8 +2728,8 @@ pub fn f64_convert_i32_s() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -2778,8 +2778,8 @@ pub fn f64_convert_i32_u() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -2825,8 +2825,8 @@ pub fn f64_convert_i64_s_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -2845,8 +2845,8 @@ pub fn f64_convert_i64_s() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -2940,8 +2940,8 @@ pub fn f64_convert_i64_u() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -3066,8 +3066,8 @@ pub fn f64_promote_f32_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3086,8 +3086,8 @@ pub fn f64_promote_f32() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0.0_f64,
@@ -3200,8 +3200,8 @@ pub fn i32_reinterpret_f32_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3220,8 +3220,8 @@ pub fn i32_reinterpret_f32() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -3331,8 +3331,8 @@ pub fn i64_reinterpret_f64_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3351,8 +3351,8 @@ pub fn i64_reinterpret_f64() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -3461,8 +3461,8 @@ pub fn f32_reinterpret_i32_let_it_die() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3481,8 +3481,8 @@ pub fn f32_reinterpret_i32() {
         .replace("{{2}}", "f32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -3563,8 +3563,8 @@ pub fn f64_reinterpret_i64_let_it_die() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -3583,8 +3583,8 @@ pub fn f64_reinterpret_i64() {
         .replace("{{2}}", "f64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0.0_f64,

--- a/tests/dynamic.rs
+++ b/tests/dynamic.rs
@@ -15,8 +15,8 @@ fn dynamic_add() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let func = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/f32.rs
+++ b/tests/f32.rs
@@ -18,8 +18,8 @@ pub fn f32_const() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3.141_592_7_f32,
@@ -48,8 +48,8 @@ pub fn f32_eq() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -78,8 +78,8 @@ pub fn f32_ne() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -117,8 +117,8 @@ pub fn f32_lt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -156,8 +156,8 @@ pub fn f32_gt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -195,8 +195,8 @@ pub fn f32_le() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -234,8 +234,8 @@ pub fn f32_ge() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -281,8 +281,8 @@ pub fn f32_abs() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -351,8 +351,8 @@ pub fn f32_neg() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -421,8 +421,8 @@ pub fn f32_ceil() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -451,8 +451,8 @@ pub fn f32_floor() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -481,8 +481,8 @@ pub fn f32_trunc() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f32,
@@ -511,8 +511,8 @@ pub fn f32_nearest() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -547,8 +547,8 @@ pub fn f32_sqrt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -584,8 +584,8 @@ pub fn f32_add() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3.0_f32,
@@ -623,8 +623,8 @@ pub fn f32_sub() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0.0_f32,
@@ -662,8 +662,8 @@ pub fn f32_mul() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         6.0_f32,
@@ -701,8 +701,8 @@ pub fn f32_div() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f32,
@@ -745,8 +745,8 @@ pub fn f32_min() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -838,8 +838,8 @@ pub fn f32_max() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -932,8 +932,8 @@ pub fn f32_copysign() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.5_f32,
@@ -985,8 +985,8 @@ pub fn f32_convert_i32_s() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let i32_s_val = -42_i32;
     let f32_result = instance
@@ -1007,8 +1007,8 @@ pub fn f32_convert_i32_u() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test_cases: Vec<(i32, f32)> = vec![
         (-2147483648, 2147483648.0),
@@ -1054,8 +1054,8 @@ pub fn f32_convert_i64_s() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let i64_s_val = i64::MIN; // Minimum i64 value
     let f32_result: f32 = instance
@@ -1095,8 +1095,8 @@ pub fn f32_convert_i64_u() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         9223373000000000000.0,
@@ -1130,8 +1130,8 @@ pub fn f32_reinterpret_i32() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test_cases = vec![
         (0x00000000, 0.0), // Positive zero

--- a/tests/f64.rs
+++ b/tests/f64.rs
@@ -18,8 +18,8 @@ pub fn f64_const() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3.14159265359_f64,
@@ -46,8 +46,8 @@ pub fn f64_eq() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -84,8 +84,8 @@ pub fn f64_ne() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -131,8 +131,8 @@ pub fn f64_lt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -178,8 +178,8 @@ pub fn f64_gt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -225,8 +225,8 @@ pub fn f64_le() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -272,8 +272,8 @@ pub fn f64_ge() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -318,8 +318,8 @@ pub fn f64_abs() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -395,8 +395,8 @@ pub fn f64_neg() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -472,8 +472,8 @@ pub fn f64_ceil() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -509,8 +509,8 @@ pub fn f64_floor() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -546,8 +546,8 @@ pub fn f64_trunc() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.0_f64,
@@ -583,8 +583,8 @@ pub fn f64_nearest() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -626,8 +626,8 @@ pub fn f64_sqrt() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -662,8 +662,8 @@ pub fn f64_add() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3.0_f64,
@@ -709,8 +709,8 @@ pub fn f64_sub() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0.0_f64,
@@ -756,8 +756,8 @@ pub fn f64_mul() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         6.0_f64,
@@ -803,8 +803,8 @@ pub fn f64_div() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2.0_f64,
@@ -855,8 +855,8 @@ pub fn f64_min() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -956,8 +956,8 @@ pub fn f64_max() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     {
         let result = instance
@@ -1058,8 +1058,8 @@ pub fn f64_copysign() {
 
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1.5_f64,

--- a/tests/fc_extensions.rs
+++ b/tests/fc_extensions.rs
@@ -36,8 +36,8 @@ pub fn i32_trunc_sat_f32_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -55,8 +55,8 @@ pub fn i32_trunc_sat_f32_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -221,8 +221,8 @@ pub fn i32_trunc_sat_f32_u_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -240,8 +240,8 @@ pub fn i32_trunc_sat_f32_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -400,8 +400,8 @@ pub fn i32_trunc_sat_f64_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -419,8 +419,8 @@ pub fn i32_trunc_sat_f64_s() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -579,8 +579,8 @@ pub fn i32_trunc_sat_f64_u_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -598,8 +598,8 @@ pub fn i32_trunc_sat_f64_u() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -779,8 +779,8 @@ pub fn i64_trunc_sat_f32_s_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -798,8 +798,8 @@ pub fn i64_trunc_sat_f32_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -982,8 +982,8 @@ pub fn i64_trunc_sat_f32_u_let_it_die() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1001,8 +1001,8 @@ pub fn i64_trunc_sat_f32_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1149,8 +1149,8 @@ pub fn i64_trunc_sat_f64_s_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1168,8 +1168,8 @@ pub fn i64_trunc_sat_f64_s() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,
@@ -1352,8 +1352,8 @@ pub fn i64_trunc_sat_f64_u_let_it_die() {
         .replace("{{2}}", "i32");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -1,
@@ -1371,8 +1371,8 @@ pub fn i64_trunc_sat_f64_u() {
         .replace("{{2}}", "i64");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0_i64,

--- a/tests/function_host.rs
+++ b/tests/function_host.rs
@@ -4,7 +4,7 @@ use wasm::{
     RuntimeError, RuntimeInstance, Value,
 };
 
-fn hello(_values: Vec<Value>) -> Vec<Value> {
+fn hello(_: &mut (), _values: Vec<Value>) -> Vec<Value> {
     println!("Host function says hello from wasm!");
     Vec::new()
 }
@@ -21,12 +21,12 @@ pub fn host_func_call_within_module() {
     )
 )"#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
-    fn hello(_values: Vec<Value>) -> Vec<Value> {
+    fn hello(_: &mut (), _values: Vec<Value>) -> Vec<Value> {
         println!("Host function says hello from wasm!");
         Vec::new()
     }
 
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<(), ()>("hello_mod", "hello", hello)
         .expect("function registration failed");
@@ -47,7 +47,7 @@ pub fn host_func_call_within_module() {
 
 #[test_log::test]
 pub fn host_func_call_as_first_func() {
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<(), ()>("hello_mod", "hello", hello)
         .expect("function registration failed");
@@ -66,7 +66,7 @@ pub fn host_func_call_as_start_func() {
 )"#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<(), ()>("hello_mod", "hello", hello)
         .expect("function registration failed");
@@ -91,7 +91,7 @@ pub fn host_func_call_within_start_func() {
     (start $hello_caller)
 )"#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<(), ()>("hello_mod", "hello", hello)
         .expect("function registration failed");
@@ -102,7 +102,7 @@ pub fn host_func_call_within_start_func() {
     assert_eq!(Ok(()), result);
 }
 
-fn fancy_add_mult(values: Vec<Value>) -> Vec<Value> {
+fn fancy_add_mult(_: &mut (), values: Vec<Value>) -> Vec<Value> {
     let x: u32 = values[0].into();
     let y: f64 = values[1].into();
 
@@ -125,7 +125,7 @@ const SIMPLE_MULTIVARIATE_MODULE_EXAMPLE: &str = r#"(module
 pub fn simple_multivariate_host_func_within_module() {
     let wasm_bytes = wat::parse_str(SIMPLE_MULTIVARIATE_MODULE_EXAMPLE).unwrap();
 
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<(i32, f64), (f64, i32)>(
             "hello_mod",
@@ -152,13 +152,13 @@ pub fn simple_multivariate_host_func_within_module() {
 pub fn simple_multivariate_host_func_with_host_func_wrapper() {
     let wasm_bytes = wat::parse_str(SIMPLE_MULTIVARIATE_MODULE_EXAMPLE).unwrap();
 
-    fn wrapped_add_mult(params: Vec<Value>) -> Vec<Value> {
+    fn wrapped_add_mult(_: &mut (), params: Vec<Value>) -> Vec<Value> {
         host_function_wrapper(params, |(x, y): (i32, f64)| -> (f64, i32) {
             (y + (x as f64), x * (y as i32))
         })
     }
 
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<(i32, f64), (f64, i32)>(
             "hello_mod",
@@ -183,7 +183,7 @@ pub fn simple_multivariate_host_func_with_host_func_wrapper() {
 
 #[test_log::test]
 pub fn simple_multivariate_host_func_as_first_func() {
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<(i32, f64), (f64, i32)>(
             "hello_mod",
@@ -213,7 +213,7 @@ pub fn weird_multi_typed_host_func() {
 ))"#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
-    fn weird_add_mult(values: Vec<Value>) -> Vec<Value> {
+    fn weird_add_mult(_: &mut (), values: Vec<Value>) -> Vec<Value> {
         Vec::from([match values[0] {
             Value::I32(val) => {
                 println!("host function saw I32");
@@ -227,7 +227,7 @@ pub fn weird_multi_typed_host_func() {
         }])
     }
 
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<i32, f64>("hello_mod", "weird_mult", weird_add_mult)
         .expect("function registration failed");
@@ -261,13 +261,13 @@ pub fn host_func_runtime_error() {
 )"#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
-    fn mult3(values: Vec<Value>) -> Vec<Value> {
+    fn mult3(_: &mut (), values: Vec<Value>) -> Vec<Value> {
         let val: i32 = values[0].into();
         println!("careless host function making type errors...");
         Vec::from([Value::I64((val * 3) as u64)])
     }
 
-    let mut runtime_instance = RuntimeInstance::new();
+    let mut runtime_instance = RuntimeInstance::new(());
     runtime_instance
         .add_host_function_typed::<i32, i32>("hello_mod", "mult3", mult3)
         .expect("function registration failed");

--- a/tests/function_recursion.rs
+++ b/tests/function_recursion.rs
@@ -19,8 +19,8 @@ fn simple_function_call() {
     let wasm_bytes = wat::parse_str(FUNCTION_CALL).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3 * 7 + 13,
@@ -57,8 +57,8 @@ fn recursion_valid() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         12,
@@ -143,8 +143,8 @@ fn multivalue_call() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let foo_fn = instance
         .get_function_by_name(DEFAULT_MODULE, "bar")

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -28,8 +28,8 @@ fn valid_global() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     // Set global to 17. 5 is returned as previous (default) value.
     assert_eq!(
@@ -105,8 +105,8 @@ fn imported_globals() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     // Set global to 17. 3 is returned as previous (default) value.
     assert_eq!(

--- a/tests/i32.rs
+++ b/tests/i32.rs
@@ -31,8 +31,8 @@ pub fn i32_add() {
     let wat = String::from(WAT).replace("{{0}}", "add");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         2,
@@ -106,8 +106,8 @@ pub fn i32_sub() {
     let wat = String::from(WAT).replace("{{0}}", "sub");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -182,8 +182,8 @@ pub fn i32_eqz_panic() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -209,8 +209,8 @@ pub fn i32_eqz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -267,8 +267,8 @@ pub fn i32_eq_panic_first_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -295,8 +295,8 @@ pub fn i32_eq_panic_second_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -312,8 +312,8 @@ pub fn i32_eq() {
     let wat = String::from(WAT).replace("{{0}}", "eq");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -431,8 +431,8 @@ pub fn i32_ne() {
     let wat = String::from(WAT).replace("{{0}}", "ne");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -550,8 +550,8 @@ pub fn i32_lt_s() {
     let wat = String::from(WAT).replace("{{0}}", "lt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -669,8 +669,8 @@ pub fn i32_lt_u() {
     let wat = String::from(WAT).replace("{{0}}", "lt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -788,8 +788,8 @@ pub fn i32_gt_s() {
     let wat = String::from(WAT).replace("{{0}}", "gt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -907,8 +907,8 @@ pub fn i32_gt_u() {
     let wat = String::from(WAT).replace("{{0}}", "gt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -1026,8 +1026,8 @@ pub fn i32_le_s() {
     let wat = String::from(WAT).replace("{{0}}", "le_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1146,8 +1146,8 @@ pub fn i32_le_u() {
     let wat = String::from(WAT).replace("{{0}}", "le_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1265,8 +1265,8 @@ pub fn i32_ge_s() {
     let wat = String::from(WAT).replace("{{0}}", "ge_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1384,8 +1384,8 @@ pub fn i32_ge_u() {
     let wat = String::from(WAT).replace("{{0}}", "ge_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,

--- a/tests/i64.rs
+++ b/tests/i64.rs
@@ -41,8 +41,8 @@ pub fn i64_eqz_panic() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -68,8 +68,8 @@ pub fn i64_eqz() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -129,8 +129,8 @@ pub fn i64_eq_panic_first_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -157,8 +157,8 @@ pub fn i64_eq_panic_second_arg() {
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
 
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -174,8 +174,8 @@ pub fn i64_eq() {
     let wat = String::from(WAT).replace("{{0}}", "eq");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -311,8 +311,8 @@ pub fn i64_ne() {
     let wat = String::from(WAT).replace("{{0}}", "ne");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -448,8 +448,8 @@ pub fn i64_lt_s() {
     let wat = String::from(WAT).replace("{{0}}", "lt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -585,8 +585,8 @@ pub fn i64_lt_u() {
     let wat = String::from(WAT).replace("{{0}}", "lt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -722,8 +722,8 @@ pub fn i64_gt_s() {
     let wat = String::from(WAT).replace("{{0}}", "gt_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -859,8 +859,8 @@ pub fn i64_gt_u() {
     let wat = String::from(WAT).replace("{{0}}", "gt_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         0,
@@ -996,8 +996,8 @@ pub fn i64_le_s() {
     let wat = String::from(WAT).replace("{{0}}", "le_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1134,8 +1134,8 @@ pub fn i64_le_u() {
     let wat = String::from(WAT).replace("{{0}}", "le_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1271,8 +1271,8 @@ pub fn i64_ge_s() {
     let wat = String::from(WAT).replace("{{0}}", "ge_s");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,
@@ -1408,8 +1408,8 @@ pub fn i64_ge_u() {
     let wat = String::from(WAT).replace("{{0}}", "ge_u");
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         1,

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -83,7 +83,7 @@ pub fn compile_simple_import() {
     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance =
-        RuntimeInstance::new_named("env", &validation_info).expect("instantiation failed");
+        RuntimeInstance::new_named((), "env", &validation_info).expect("instantiation failed");
 
     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
@@ -101,7 +101,7 @@ pub fn run_simple_import() {
     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance =
-        RuntimeInstance::new_named("env", &validation_info).expect("instantiation failed");
+        RuntimeInstance::new_named((), "env", &validation_info).expect("instantiation failed");
 
     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
@@ -122,7 +122,7 @@ pub fn run_call_indirect() {
     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let mut instance =
-        RuntimeInstance::new_named("env", &validation_info).expect("instantiation failed");
+        RuntimeInstance::new_named((), "env", &validation_info).expect("instantiation failed");
 
     let wasm_bytes = wat::parse_str(CALL_INDIRECT_BASE).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
@@ -139,7 +139,7 @@ pub fn run_call_indirect() {
 //     let wasm_bytes = wat::parse_str(CYCLICAL_IMPORT).unwrap();
 //     let validation_info = validate(&wasm_bytes).expect("validation failed");
 //     let mut instance =
-//         RuntimeInstance::new_named("env", &validation_info).expect("instantiation failed");
+//         RuntimeInstance::new_named((), "env", &validation_info).expect("instantiation failed");
 
 //     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
 //     let validation_info = validate(&wasm_bytes).expect("validation failed");

--- a/tests/linker.rs
+++ b/tests/linker.rs
@@ -19,7 +19,7 @@ const SIMPLE_IMPORT_ADDON: &str = r#"
 
 #[test_log::test]
 pub fn compile_simple_import() {
-    let mut store: Store = Default::default();
+    let mut store = Store::new(());
     // let mut linker: Linker = Default::default();
 
     let wasm_bytes_addon = wat::parse_str(SIMPLE_IMPORT_ADDON).unwrap();
@@ -39,7 +39,7 @@ pub fn compile_simple_import() {
     //     .instantiate(&mut store, &validation_info_base)
     //     .unwrap();
     // let mut instance =
-    //     RuntimeInstance::new_named("base", &validation_info_base).expect("instantiation failed");
+    //     RuntimeInstance::new_named((), "base", &validation_info_base).expect("instantiation failed");
 
     let &ExternVal::Func(func_addr) = store
         .registry

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -34,7 +34,8 @@ fn memory_basic() {
     w.iter().for_each(|wat| {
         let wasm_bytes = wat::parse_str(wat).unwrap();
         let validation_info = validate(&wasm_bytes).expect("validation failed");
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+        RuntimeInstance::new_with_default_module((), &validation_info)
+            .expect("instantiation failed");
     });
 }
 
@@ -186,8 +187,8 @@ fn i32_and_i64_loads() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let i32_load8_s = get_func!(i, "i32_load8_s");
     let i32_load8_u = get_func!(i, "i32_load8_u");
@@ -287,8 +288,8 @@ fn memory_test_exporting_rand_globals_doesnt_change_a_memory_s_semantics() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let load = get_func!(i, "load");
 

--- a/tests/memory_copy.rs
+++ b/tests/memory_copy.rs
@@ -46,8 +46,8 @@ fn memory_copy_test_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -78,8 +78,8 @@ fn memory_copy_test_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -110,8 +110,8 @@ fn memory_copy_test_3() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -146,8 +146,8 @@ fn memory_copy_test_4() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -182,8 +182,8 @@ fn memory_copy_test_5() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
@@ -217,8 +217,8 @@ fn memory_copy_test_6() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 0, 40));
@@ -290,8 +290,8 @@ fn memory_copy_test_7() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65515, 0, 39));
@@ -363,8 +363,8 @@ fn memory_copy_test_8() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65515, 0, 39));
@@ -436,8 +436,8 @@ fn memory_copy_test_9() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65516, 40));
@@ -510,8 +510,8 @@ fn memory_copy_test_10() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65515, 39));
@@ -584,8 +584,8 @@ fn memory_copy_test_11() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65486, 40));
@@ -658,8 +658,8 @@ fn memory_copy_test_12() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65486, 65516, 40));
@@ -732,8 +732,8 @@ fn memory_copy_test_13() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65506, 40));
@@ -806,8 +806,8 @@ fn memory_copy_test_14() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65506, 65516, 40));
@@ -880,8 +880,8 @@ fn memory_copy_test_15() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 65516, 40));
@@ -954,8 +954,8 @@ fn memory_copy_test_16() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (0, 65516, 4294963200_u32 as i32));
@@ -1028,8 +1028,8 @@ fn memory_copy_test_17() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let run = get_func!(i, "run");
     let err = i.invoke_typed::<(i32, i32, i32), ()>(run, (65516, 61440, 4294967040_u32 as i32));

--- a/tests/memory_fill.rs
+++ b/tests/memory_fill.rs
@@ -39,8 +39,8 @@ fn memory_fill() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let fill = get_func!(i, "fill");
     i.invoke_typed::<(), ()>(fill, ()).unwrap();

--- a/tests/memory_grow.rs
+++ b/tests/memory_grow.rs
@@ -57,8 +57,8 @@ fn memory_grow_test_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     // let x = i.invoke_typed(function_ref, params)
     assert_result!(i, get_func!(i, "size"), (), 0);
@@ -93,8 +93,8 @@ fn memory_grow_test_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_result!(i, get_func!(i, "grow"), 0, 0);
     assert_result!(i, get_func!(i, "grow"), 1, 0);
@@ -116,8 +116,8 @@ fn memory_grow_test_3() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_result!(i, get_func!(i, "grow"), 0, 0);
     assert_result!(i, get_func!(i, "grow"), 1, 0);

--- a/tests/memory_init.rs
+++ b/tests/memory_init.rs
@@ -56,8 +56,8 @@ fn memory_init_test_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -91,8 +91,8 @@ fn memory_init_test_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -126,8 +126,8 @@ fn memory_init_test_3() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -169,8 +169,8 @@ fn memory_init_test_4() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 
@@ -227,8 +227,8 @@ fn memory_init_test_7() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
@@ -245,8 +245,8 @@ fn memory_init_test_8() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     assert_error!(i, get_func!(i, "test"), (), Result<(), RuntimeError>, (), (), RuntimeError::MemoryAccessOutOfBounds);
 }
 
@@ -261,8 +261,8 @@ fn memory_init_test_9() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     assert_error!(i, get_func!(i, "test"), (), Result<(), RuntimeError>, (), (), RuntimeError::MemoryAccessOutOfBounds);
 }
 
@@ -306,8 +306,8 @@ fn memory_init_test_12() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     let test = get_func!(i, "test");
     i.invoke_typed::<(), ()>(test, ()).unwrap();
 }
@@ -323,7 +323,7 @@ fn memory_init_test_13() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     assert_error!(i, get_func!(i, "test"), (), Result<(), RuntimeError>, (), (), RuntimeError::MemoryAccessOutOfBounds);
 }

--- a/tests/memory_redundancy.rs
+++ b/tests/memory_redundancy.rs
@@ -90,8 +90,8 @@ fn memory_redundancy() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     let zero_everything = get_func!(i, "zero_everything");
     assert_result!(i, get_func!(i, "test_store_to_load"), (), 0x00000080);
     i.invoke_typed::<(), ()>(zero_everything, ()).unwrap();

--- a/tests/memory_size.rs
+++ b/tests/memory_size.rs
@@ -41,8 +41,8 @@ fn memory_size_1() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");
@@ -67,8 +67,8 @@ fn memory_size_2() {
   "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");
@@ -93,8 +93,8 @@ fn memory_size_3() {
 "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");
@@ -123,8 +123,8 @@ fn memory_size_4() {
 "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let size = get_func!(i, "size");
     let grow = get_func!(i, "grow");

--- a/tests/memory_trap.rs
+++ b/tests/memory_trap.rs
@@ -64,8 +64,8 @@ fn memory_trap_1() {
 "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let store = get_func!(i, "store");
     let load = get_func!(i, "load");

--- a/tests/return.rs
+++ b/tests/return.rs
@@ -24,8 +24,8 @@ fn return_valid() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         12,

--- a/tests/same_type_fn.rs
+++ b/tests/same_type_fn.rs
@@ -21,8 +21,8 @@ fn same_type_fn() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         -5,

--- a/tests/select.rs
+++ b/tests/select.rs
@@ -39,8 +39,8 @@ fn polymorphic_select_test() {
     validate(&wasm_bytes).expect("validation failed");
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let select_test_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -59,8 +59,8 @@ fn typed_select_test() {
     validate(&wasm_bytes).expect("validation failed");
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let select_test_fn = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/specification/run.rs
+++ b/tests/specification/run.rs
@@ -191,7 +191,7 @@ pub fn run_spec_test(filepath: &str) -> WastTestReport {
             .unwrap()
             .unwrap();
     let interpreter = &mut catch_unwind_and_suppress_panic_handler(|| {
-        RuntimeInstance::new_named("spectest", &spectest_validation_info)
+        RuntimeInstance::new_named((), "spectest", &spectest_validation_info)
     })
     .unwrap()
     .unwrap();

--- a/tests/start_function.rs
+++ b/tests/start_function.rs
@@ -25,8 +25,8 @@ fn start_function() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         42,

--- a/tests/structured_control_flow/block.rs
+++ b/tests/structured_control_flow/block.rs
@@ -14,8 +14,8 @@ fn empty() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     instance
         .invoke_typed::<(), ()>(&instance.get_function_by_index(0, 0).unwrap(), ())
@@ -44,8 +44,8 @@ fn branch() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         8,
@@ -87,8 +87,8 @@ fn branch2() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         13,
@@ -104,8 +104,8 @@ fn branch3() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         5,
@@ -134,8 +134,8 @@ fn param_and_result() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         7,
@@ -179,8 +179,8 @@ fn return_out_of_block() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3,
@@ -196,8 +196,8 @@ fn br_return_out_of_block() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         3,
@@ -213,8 +213,8 @@ fn return_out_of_block2() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         5,
@@ -230,8 +230,8 @@ fn br_return_out_of_block2() {
     let wasm_bytes = wat::parse_str(wat).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     assert_eq!(
         5,
@@ -265,8 +265,8 @@ fn branch_if() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let switch_case_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -328,8 +328,8 @@ fn recursive_fibonacci() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let fib_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -374,8 +374,8 @@ fn switch_case() {
     .unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let switch_case_fn = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/structured_control_flow/if.rs
+++ b/tests/structured_control_flow/if.rs
@@ -24,8 +24,8 @@ fn odd_with_if_else() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -57,8 +57,8 @@ fn odd_with_if() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -112,8 +112,8 @@ fn odd_with_if_else_recursive() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let even_odd_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -157,8 +157,8 @@ fn recursive_fibonacci_if_else() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let fibonacci_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -185,8 +185,8 @@ fn if_without_else_type_check1() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let empty_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -229,8 +229,8 @@ fn if_without_else_type_check3() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let add_one_if_true_fn = instance.get_function_by_index(0, 0).unwrap();
 
@@ -254,8 +254,8 @@ fn if_without_else_type_check4() {
     )
     .unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let add_one_if_true_fn = instance.get_function_by_index(0, 0).unwrap();
     assert_eq!(

--- a/tests/structured_control_flow/loop.rs
+++ b/tests/structured_control_flow/loop.rs
@@ -56,8 +56,8 @@ fn fibonacci_with_loop_and_br_if() {
     let wasm_bytes = wat::parse_str(FIBONACCI_WITH_LOOP_AND_BR_IF).unwrap();
 
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let fibonacci_fn = instance.get_function_by_index(0, 0).unwrap();
 

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -45,7 +45,8 @@ fn table_basic() {
     w.iter().for_each(|wat| {
         let wasm_bytes = wat::parse_str(wat).unwrap();
         let validation_info = validate(&wasm_bytes).expect("validation failed");
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+        RuntimeInstance::new_with_default_module((), &validation_info)
+            .expect("instantiation failed");
     });
 }
 
@@ -120,8 +121,8 @@ fn table_elem_test() {
     )"#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
     // let table = &instance.modules[0].store.tables[0];
     let table = &instance.store.tables[0];
     assert!(table.len() == 2);
@@ -159,8 +160,8 @@ fn table_get_set_test() {
     "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let get_funcref = get_func!(i, "get-funcref");
     let init = get_func!(i, "init");
@@ -251,8 +252,8 @@ fn call_indirect_type_check() {
     "#;
     let wasm_bytes = wat::parse_str(wat).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
-    let mut instance =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut instance = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let call_fn = instance
         .get_function_by_name(DEFAULT_MODULE, "call_function")

--- a/tests/table_fill.rs
+++ b/tests/table_fill.rs
@@ -56,8 +56,8 @@ fn table_fill_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let get = get_func!(i, "get");
     let fill = get_func!(i, "fill");

--- a/tests/table_get.rs
+++ b/tests/table_get.rs
@@ -69,8 +69,8 @@ fn table_funcref_test() {
     "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let init = get_func!(i, "init");
     let get_funcref = get_func!(i, "get-funcref");

--- a/tests/table_grow.rs
+++ b/tests/table_grow.rs
@@ -50,8 +50,8 @@ fn table_grow_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let get = get_func!(i, "get");
     let set = get_func!(i, "set");
@@ -220,8 +220,8 @@ fn table_grow_outside_i32_range() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     assert_eq!(i.invoke_typed::<(), i32>(grow, ()).unwrap(), -1);
@@ -240,8 +240,8 @@ fn table_grow_unlimited() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     assert_result!(i, grow, 0, 0);
@@ -264,8 +264,8 @@ fn table_grow_with_max() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     assert_result!(i, grow, 0, 0);
@@ -307,8 +307,8 @@ fn table_grow_check_null() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let grow = get_func!(i, "grow");
     let check_table_null = get_func!(i, "check-table-null");
@@ -340,7 +340,7 @@ fn table_grow_with_exported_table_test() {
 
     let wasm_bytes = wat::parse_str(target_wat).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut target_instance = RuntimeInstance::new_with_default_module(&validation_info)
+    let mut target_instance = RuntimeInstance::new_with_default_module((), &validation_info)
         .expect("target instantiation failed");
 
     let grow = get_func!(target_instance, "grow");

--- a/tests/table_init.rs
+++ b/tests/table_init.rs
@@ -57,8 +57,8 @@ fn table_init_1_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -167,8 +167,8 @@ fn table_init_2_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -287,8 +287,8 @@ fn table_init_3_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -385,8 +385,8 @@ fn table_init_4_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -507,8 +507,8 @@ fn table_init_5_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
     let check = get_func!(i, "check");
@@ -654,8 +654,8 @@ fn table_init_10_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -691,8 +691,8 @@ fn table_init_11_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -730,8 +730,8 @@ fn table_init_12_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -767,8 +767,8 @@ fn table_init_13_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -804,8 +804,8 @@ fn table_init_14_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -843,8 +843,8 @@ fn table_init_15_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -882,8 +882,8 @@ fn table_init_16_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -921,8 +921,8 @@ fn table_init_17_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -960,8 +960,8 @@ fn table_init_18_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -997,8 +997,8 @@ fn table_init_19_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1036,8 +1036,8 @@ fn table_init_20_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1073,8 +1073,8 @@ fn table_init_21_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1112,8 +1112,8 @@ fn table_init_22_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1149,8 +1149,8 @@ fn table_init_23_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1188,8 +1188,8 @@ fn table_init_24_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1227,8 +1227,8 @@ fn table_init_25_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1264,8 +1264,8 @@ fn table_init_26_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1303,8 +1303,8 @@ fn table_init_27_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1340,8 +1340,8 @@ fn table_init_28_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1379,8 +1379,8 @@ fn table_init_29_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -1416,8 +1416,8 @@ fn table_init_30_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     let test = get_func!(i, "test");
 
@@ -2595,7 +2595,7 @@ fn table_init_94_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2648,7 +2648,7 @@ fn table_init_95_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2701,7 +2701,7 @@ fn table_init_96_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2754,7 +2754,7 @@ fn table_init_97_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2807,7 +2807,7 @@ fn table_init_98_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2860,7 +2860,7 @@ fn table_init_99_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut inst = RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+    let mut inst = RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 
     let run = get_func!(inst, "run");
     let test = get_func!(inst, "test");
@@ -2907,5 +2907,5 @@ fn table_init_100_test() {
 
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    RuntimeInstance::new_with_default_module(&validation_info).unwrap();
+    RuntimeInstance::new_with_default_module((), &validation_info).unwrap();
 }

--- a/tests/table_size.rs
+++ b/tests/table_size.rs
@@ -61,8 +61,8 @@ fn table_size_test() {
     "#;
     let wasm_bytes = wat::parse_str(w).unwrap();
     let validation_info = validate(&wasm_bytes).unwrap();
-    let mut i =
-        RuntimeInstance::new_with_default_module(&validation_info).expect("instantiation failed");
+    let mut i = RuntimeInstance::new_with_default_module((), &validation_info)
+        .expect("instantiation failed");
 
     // let get_funcref = get_func!(i, "get-funcref");
     // let init = get_func!(i, "init");

--- a/tests/user_data.rs
+++ b/tests/user_data.rs
@@ -1,0 +1,56 @@
+use std::sync::mpsc::Sender;
+
+use wasm::{RuntimeInstance, Value};
+
+#[test_log::test]
+fn counter() {
+    fn add_one(user_data: &mut u32, _params: Vec<Value>) -> Vec<Value> {
+        *user_data += 1;
+
+        Vec::new()
+    }
+
+    let mut instance = RuntimeInstance::new(0);
+    instance
+        .add_host_function_typed::<(), ()>("host", "add_one", add_one)
+        .unwrap();
+
+    let add_one_func_ref = instance.get_function_by_name("host", "add_one").unwrap();
+
+    for _ in 0..5 {
+        instance
+            .invoke_typed::<(), ()>(&add_one_func_ref, ())
+            .unwrap();
+    }
+
+    assert_eq!(*instance.user_data(), 5);
+}
+
+#[test_log::test]
+fn channels() {
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+
+    std::thread::spawn(|| {
+        fn send_message(user_data: &mut Sender<String>, _params: Vec<Value>) -> Vec<Value> {
+            user_data
+                .send("Hello from host function!".to_owned())
+                .unwrap();
+
+            Vec::new()
+        }
+
+        let mut instance = RuntimeInstance::new(tx);
+        instance
+            .add_host_function_typed::<(), ()>("host", "send_message", send_message)
+            .unwrap();
+
+        let send_message_func_ref = instance
+            .get_function_by_name("host", "send_message")
+            .unwrap();
+        instance
+            .invoke_typed::<(), ()>(&send_message_func_ref, ())
+            .unwrap();
+    });
+
+    assert_eq!(rx.recv(), Ok("Hello from host function!".to_owned()));
+}


### PR DESCRIPTION
### Pull Request Overview

This PR adds generic user data `T` to the store.
It can be accessed by the user either directly through `RuntimeInstance::user_data` or in host functions as the first parameter.
The design is very similar to that of most other Wasm runtimes.

I also added new tests for user data in `tests/user_data.rs`.

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`