### PR TITLE
Dev/improve performance in do sidetable control transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,6 @@ dependencies = [
  "once_cell",
  "oorandom",
  "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2021"
 rust-version = "1.80.0"
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = ["html_reports"] }
+criterion = { version = "0.5.1", default-features = false, features = [
+  "cargo_bench_support",
+  "plotters",
+] }
 wasm-interpreter = { path = "../.." }
 wasmi = "0.40.0"
 wasmtime = { version = "27.0.0", default-features = false, features = [

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,7 @@
                   rust-analyzer
                   cargo-audit
                   cargo-expand
+                  cargo-flamegraph
                   cargo-llvm-cov
                   cargo-outdated
                   cargo-watch
@@ -164,6 +165,16 @@
                       critcmp --target-dir .main_clone/target -- "benchmark-main.baseline" "benchmark-current.baseline"
                     '';
                     help = "benchmark the current HEAD against the main branch";
+                    category = "benchmark";
+                  }
+                  {
+                    name = "bench-flamegraph";
+                    command = ''
+                      cd -- "$PRJ_ROOT"
+                      CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --package benchmark --bench general_purpose -- --bench
+                    '';
+                    help = "run the benchmarks and draw a flamegraph";
+                    category = "benchmark";
                   }
                   {
                     name = "requirements-export-excel";
@@ -173,6 +184,7 @@
                         "$PRJ_ROOT/requirements"
                     '';
                     help = "export the requirements to requirements/export";
+                    category = "requirements";
                   }
                   {
                     name = "requirements-export-html";
@@ -182,6 +194,7 @@
                         "$PRJ_ROOT/requirements"
                     '';
                     help = "export the requirements to requirements/export";
+                    category = "requirements";
                   }
                   {
                     name = "requirements-web-server";
@@ -189,6 +202,7 @@
                       strictdoc server "$PRJ_ROOT/requirements"
                     '';
                     help = "start the requirements editor web-ui";
+                    category = "requirements";
                   }
                   {
                     name = "cargo-watch-doc";

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -2437,15 +2437,7 @@ fn do_sidetable_control_transfer(
 ) -> Result<(), RuntimeError> {
     let sidetable_entry = &current_sidetable[*current_stp];
 
-    // TODO fix this corner cutting implementation
-    let jump_vals = stack
-        .pop_tail_iter(sidetable_entry.valcnt)
-        .collect::<Vec<_>>();
-    stack.pop_n_values(sidetable_entry.popcnt);
-
-    for val in jump_vals {
-        stack.push_value(val)?;
-    }
+    stack.remove_inbetween(sidetable_entry.popcnt, sidetable_entry.valcnt);
 
     *current_stp = (*current_stp as isize + sidetable_entry.delta_stp) as usize;
     wasm.pc = (wasm.pc as isize + sidetable_entry.delta_pc) as usize;

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -242,9 +242,21 @@ impl Stack {
         self.values.drain(start..)
     }
 
-    // TODO change this interface
-    pub fn pop_n_values(&mut self, n: usize) {
-        self.values.truncate(self.values.len() - n);
+    /// Remove `remove_count` values from the stack, keeping the topmost `keep_count` values
+    ///
+    /// From the stack, remove `remove_count` elements, by sliding down the `keep_count` topmost
+    /// values `remove_count` positions.
+    ///
+    /// **Effects**
+    ///
+    /// - after the operation, [`Stack`] will contain `remove_count` fewer elements
+    /// - `keep_count` topmost elements will be identical before and after the operation
+    /// - all elements below the `remove_count + keep_count` topmost stack entry remain
+    pub fn remove_inbetween(&mut self, remove_count: usize, keep_count: usize) {
+        let len = self.values.len();
+        self.values
+            .copy_within(len - keep_count.., len - keep_count - remove_count);
+        self.values.truncate(len - remove_count);
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

The `do_sidetable_control_transfer` function would temporarily allocate
a vector of values to do the popping at end of a control flow construct.

This commit removes the temporary allocation, thus unlocking a ~10%
performance improvement.

### TODO or Help Wanted

@cemonem I believe you wrote the initial TODO, a does this code address it to your liking?

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Benchmark Results

Edit: updated the benchmark results, before I benched main vs main by accident.
```console
group                          benchmark-current.baseline             benchmark-main.baseline
-----                          --------------------------             -----------------------
fibonacci_loop/our/1           1.00    190.9±3.19ns  5.0 MElem/sec    1.16    222.2±2.54ns  4.3 MElem/sec
fibonacci_loop/our/1024        1.00     79.4±1.00µs 12.3 MElem/sec    1.14     90.6±0.98µs 10.8 MElem/sec
fibonacci_loop/our/1048576     1.00     81.0±2.40ms 12.3 MElem/sec    1.17     94.7±2.72ms 10.6 MElem/sec
fibonacci_loop/our/128         1.00     10.1±0.20µs 12.1 MElem/sec    1.19     11.9±0.33µs 10.2 MElem/sec
fibonacci_loop/our/131072      1.00     10.3±0.83ms 12.1 MElem/sec    1.14     11.8±0.17ms 10.6 MElem/sec
fibonacci_loop/our/16          1.00  1361.1±85.37ns 11.2 MElem/sec    1.19  1620.3±31.02ns  9.4 MElem/sec
fibonacci_loop/our/16384       1.00  1260.5±21.46µs 12.4 MElem/sec    1.14  1436.9±16.34µs 10.9 MElem/sec
fibonacci_loop/our/2           1.00   291.0±59.02ns  6.6 MElem/sec    1.13   329.7±42.91ns  5.8 MElem/sec
fibonacci_loop/our/2048        1.00    158.5±1.64µs 12.3 MElem/sec    1.17   184.9±17.18µs 10.6 MElem/sec
fibonacci_loop/our/256         1.00     20.0±0.34µs 12.2 MElem/sec    1.17     23.5±0.67µs 10.4 MElem/sec
fibonacci_loop/our/262144      1.00     20.3±0.27ms 12.3 MElem/sec    1.17     23.6±0.51ms 10.6 MElem/sec
fibonacci_loop/our/32          1.00      2.6±0.15µs 11.6 MElem/sec    1.15      3.0±0.24µs 10.1 MElem/sec
fibonacci_loop/our/32768       1.00      2.5±0.04ms 12.4 MElem/sec    1.15      2.9±0.25ms 10.7 MElem/sec
fibonacci_loop/our/4           1.00   440.9±61.39ns  8.7 MElem/sec    1.19    523.4±6.85ns  7.3 MElem/sec
fibonacci_loop/our/4096        1.00    315.8±5.22µs 12.4 MElem/sec    1.15    362.0±4.10µs 10.8 MElem/sec
fibonacci_loop/our/512         1.00     39.8±0.51µs 12.3 MElem/sec    1.16     46.2±0.92µs 10.6 MElem/sec
fibonacci_loop/our/524288      1.00     40.2±1.13ms 12.4 MElem/sec    1.16     46.7±1.22ms 10.7 MElem/sec
fibonacci_loop/our/64          1.00      5.1±0.10µs 12.0 MElem/sec    1.15      5.8±0.48µs 10.5 MElem/sec
fibonacci_loop/our/65536       1.00      5.1±0.08ms 12.4 MElem/sec    1.17      5.9±0.07ms 10.5 MElem/sec
fibonacci_loop/our/8           1.00   749.4±78.87ns 10.2 MElem/sec    1.17   874.8±14.23ns  8.7 MElem/sec
fibonacci_loop/our/8192        1.00    636.5±9.50µs 12.3 MElem/sec    1.13    722.0±8.89µs 10.8 MElem/sec
fibonacci_recursive/our/1      1.00    243.7±3.81ns  3.9 MElem/sec    1.11   271.4±12.83ns  3.5 MElem/sec
fibonacci_recursive/our/128    1.00     14.5±0.34µs  8.4 MElem/sec    1.13     16.4±0.14µs  7.5 MElem/sec
fibonacci_recursive/our/16     1.00  1817.3±30.56ns  8.4 MElem/sec    1.10      2.0±0.03µs  7.6 MElem/sec
fibonacci_recursive/our/2      1.00    346.8±3.74ns  5.5 MElem/sec    1.13    392.5±8.38ns  4.9 MElem/sec
fibonacci_recursive/our/256    1.00     27.6±0.41µs  8.8 MElem/sec    1.15     31.6±1.53µs  7.7 MElem/sec
fibonacci_recursive/our/32     1.00      3.6±0.06µs  8.6 MElem/sec    1.10      3.9±0.16µs  7.8 MElem/sec
fibonacci_recursive/our/4      1.00    561.7±8.08ns  6.8 MElem/sec    1.13    632.1±8.70ns  6.0 MElem/sec
fibonacci_recursive/our/512    1.00     53.5±0.72µs  9.1 MElem/sec    1.11     59.6±0.99µs  8.2 MElem/sec
fibonacci_recursive/our/64     1.01      7.5±0.14µs  8.1 MElem/sec    1.00      7.4±0.11µs  8.2 MElem/sec
fibonacci_recursive/our/8      1.00   978.0±16.93ns  7.8 MElem/sec    1.13  1101.4±114.91ns  6.9 MElem/sec
```