### PR TITLE
feat: extend readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A minimal in-place interpreter for [WebAssembly](https://webassembly.org/) bytec
 
 ## Features
 
-- **In-place interpretation**: No intermediate parsing step. This allows for fast start-up times.
+- **In-place interpretation**: No intermediate representation, directly interprets WebAssembly bytecode. This allows for fast start-up times.
 - **`no_std` support**: The interpreter requires only Rust's `core` and `alloc` libraries allowing its use in various environments, such as bare-metal systems.
 - **Minimal dependencies**: The interpreter requires only two dependencies: `log`, `libm`.
-- **Compliance with specification**: The interpreter passes almost all test from the [official WebAssembly testsuite](https://github.com/WebAssembly/testsuite). Only SIMD instructions are missing.
+- **Compliance with specification**: The interpreter passes all tests from the [official WebAssembly testsuite](https://github.com/WebAssembly/testsuite), except for the SIMD instruction tests and the unfinished proposal tests. See [`GlobalConfig` in `tests/specification/mod.rs`](tests/specification/mod.rs) for the default spec-test filter regex.
 - **Host functions**: The host system can provide functions for Wasm code to call.
 
 _For information on other features, visit our [requirements page](https://dlr-ft.github.io/wasm-interpreter/main/requirements/html/index.html)._


### PR DESCRIPTION
### Pull Request Overview

- Be more precise about the parsing step, we still do parse once, but we do not create an intermediate representation.
- Be more precise about passing "almost all tests" from the testsuite

### TODO or Help Wanted

Do you agree to the new information in the README?

### Checks

- Using Nix
  - [x] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`