### PR TITLE
Require `SAFETY:` comment for all unsafe, optimize `LinearMemory`

### DIFF
--- a/src/core/rw_spinlock.rs
+++ b/src/core/rw_spinlock.rs
@@ -117,6 +117,7 @@ impl<T> RwSpinLock<T> {
     }
 }
 
+// SAFETY: When the inner `T` is `Sync`, the `RwSpinlock<T>` can be `Sync` as well
 unsafe impl<T> Sync for RwSpinLock<T> where T: Send + Sync {}
 
 /// Read guard for the [`RwSpinLock`]
@@ -127,6 +128,8 @@ pub struct ReadLockGuard<'a, T> {
 impl<T> Deref for ReadLockGuard<'_, T> {
     type Target = T;
     fn deref(&self) -> &T {
+        // SAFETY: For as long as a `ReadLockGuard` exists, it can dereference to a shared reference
+        // to the inner data can be handed out
         unsafe { &*self.lock.inner.get() }
     }
 }
@@ -145,12 +148,16 @@ pub struct WriteLockGuard<'a, T> {
 impl<T> Deref for WriteLockGuard<'_, T> {
     type Target = T;
     fn deref(&self) -> &T {
+        // SAFETY: For as long as a `WriteLockGuard` exists, it can derefence to a shared reference
+        // to the inner data
         unsafe { &*self.lock.inner.get() }
     }
 }
 
 impl<T> DerefMut for WriteLockGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: For as long as a `WriteLockGuard` exists, it can derefence to a mutable
+        // references to the inner data
         unsafe { &mut *self.lock.inner.get() }
     }
 }

--- a/src/execution/linear_memory.rs
+++ b/src/execution/linear_memory.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, iter, mem, ptr};
+use core::{cell::UnsafeCell, iter, ptr};
 
 use alloc::vec::Vec;
 
@@ -129,14 +129,6 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
         index: MemIdx,
         value: T,
     ) -> Result<(), RuntimeError> {
-        // Unless someone implements something wrong like `impl LittleEndianBytes<3> for f64`, this
-        // check is already guaranteed at the type level. Therefore only a debug_assert.
-        debug_assert_eq!(
-            mem::size_of::<T>(),
-            N,
-            "value size must match const generic N"
-        );
-
         let lock_guard = self.inner_data.read();
 
         /* check destination for out of bounds access */
@@ -185,14 +177,6 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
         &self,
         index: MemIdx,
     ) -> Result<T, RuntimeError> {
-        // Unless someone implementes something wrong like `LittleEndianBytes<3> for i8`, this
-        // check is already guaranteed at the type level. Therefore only a debug_assert.
-        debug_assert_eq!(
-            mem::size_of::<T>(),
-            N,
-            "value size must match const generic N"
-        );
-
         let lock_guard = self.inner_data.read();
 
         /* check source for out of bounds access */
@@ -372,7 +356,8 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
         Ok(())
     }
 
-    // Rationale behind having `source_index` and `count` when the callsite could also just create a subslice for `source_data`? Have all the index error checks in one place.
+    // Rationale behind having `source_index` and `count` when the callsite could also just create a
+    // subslice for `source_data`? Have all the index error checks in one place.
     //
     // <https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-init-x>
     pub fn init(
@@ -519,6 +504,7 @@ impl<const PAGE_SIZE: usize> Default for LinearMemory<PAGE_SIZE> {
 #[cfg(test)]
 mod test {
     use alloc::format;
+    use core::mem;
 
     use super::*;
 

--- a/src/execution/locals_new.rs
+++ b/src/execution/locals_new.rs
@@ -1,0 +1,41 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use crate::core::reader::types::ValType;
+use crate::execution::assert_validated::UnwrapValidatedExt;
+use crate::execution::value::Value;
+
+/// A helper for managing values of locals (and parameters) during function execution.
+///
+/// Note: As of now this stores the [Value]s. In the future storing the raw bytes without information
+/// about a value's type may be preferred to minimize memory usage.
+pub struct Locals<'a> {
+    data: &'a mut [Value],
+}
+
+impl Locals<'a> {
+    pub fn new(
+        parameters: impl Iterator<Item = Value>,
+        locals: impl Iterator<Item = ValType>,
+        stack: &mut Stack,
+    ) -> Self {
+        let data = parameters
+            .chain(locals.map(Value::default_from_ty))
+            .collect::<Vec<Value>>()
+            .into_boxed_slice();
+
+        Self { data }
+    }
+
+    pub fn get(&self, idx: usize) -> &Value {
+        self.data.get(idx).unwrap_validated()
+    }
+
+    pub fn get_ty(&self, idx: usize) -> ValType {
+        self.data.get(idx).unwrap_validated().to_ty()
+    }
+
+    pub fn get_mut(&mut self, idx: usize) -> &mut Value {
+        self.data.get_mut(idx).unwrap_validated()
+    }
+}

--- a/src/execution/value.rs
+++ b/src/execution/value.rs
@@ -654,7 +654,7 @@ impl InteropValue for FuncRefForInteropValue {
     #[allow(warnings)]
     fn from_value(value: Value) -> Self {
         match value {
-            Value::Ref(rref) => unsafe { FuncRefForInteropValue::new(rref).unwrap_unchecked() },
+            Value::Ref(rref) => FuncRefForInteropValue::new(rref).unwrap_validated(),
             _ => unreachable_validated!(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+#![deny(clippy::undocumented_unsafe_blocks)]
+
 extern crate alloc;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
### Pull Request Overview


### TODO or Help Wanted

Please review the safety arguments careful, there might be errors?

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Github Issue

Solves #240 
