### PR TITLE
fix: remove u32::pow from memarg.align

### DIFF
--- a/src/core/reader/types/memarg.rs
+++ b/src/core/reader/types/memarg.rs
@@ -11,16 +11,14 @@ pub struct MemArg {
 
 impl WasmReadable for MemArg {
     fn read(wasm: &mut WasmReader) -> crate::Result<Self> {
-        let align_log2 = wasm.read_var_u32()?;
+        let align = wasm.read_var_u32()?;
         let offset = wasm.read_var_u32()?;
-        let align = u32::pow(2, align_log2);
         Ok(Self { offset, align })
     }
 
     fn read_unvalidated(wasm: &mut WasmReader) -> Self {
-        let align_log2 = wasm.read_var_u32().unwrap_validated();
+        let align = wasm.read_var_u32().unwrap_validated();
         let offset = wasm.read_var_u32().unwrap_validated();
-        let align = u32::pow(2, align_log2);
         Self { offset, align }
     }
 }

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -569,8 +569,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 4 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 4));
+                if memarg.align > 2 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 2));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I32));
@@ -580,8 +580,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 8 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 8));
+                if memarg.align > 3 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 3));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
@@ -591,8 +591,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 4 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 4));
+                if memarg.align > 2 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 2));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::F32));
@@ -602,8 +602,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 8 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 8));
+                if memarg.align > 3 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 3));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::F64));
@@ -613,8 +613,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 1 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 1));
+                if memarg.align > 0 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 0));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I32));
@@ -624,8 +624,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 1 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 1));
+                if memarg.align > 0 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 0));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I32));
@@ -635,8 +635,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 2 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 2));
+                if memarg.align > 1 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 1));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I32));
@@ -646,8 +646,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 2 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 2));
+                if memarg.align > 1 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 1));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I32));
@@ -657,8 +657,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 1 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 1));
+                if memarg.align > 0 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 0));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
@@ -668,8 +668,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 1 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 1));
+                if memarg.align > 0 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 0));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
@@ -679,8 +679,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 2 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 2));
+                if memarg.align > 1 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 1));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
@@ -690,8 +690,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 2 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 2));
+                if memarg.align > 1 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 1));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
@@ -701,8 +701,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 4 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 4));
+                if memarg.align > 2 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 2));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
@@ -712,8 +712,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 4 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 4));
+                if memarg.align > 2 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 2));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.push_valtype(ValType::NumType(NumType::I64));
@@ -723,8 +723,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 4 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 4));
+                if memarg.align > 2 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 2));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
@@ -734,8 +734,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 8 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 8));
+                if memarg.align > 3 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 3));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
@@ -745,8 +745,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 4 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 4));
+                if memarg.align > 2 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 2));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::F32))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
@@ -756,8 +756,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 8 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 8));
+                if memarg.align > 3 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 3));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::F64))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
@@ -767,8 +767,8 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 1 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 1));
+                if memarg.align > 0 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 0));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
@@ -778,13 +778,24 @@ fn read_instructions(
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
-                if memarg.align > 2 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 2));
+                if memarg.align > 1 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 1));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
             }
             I64_STORE8 => {
+                if memories.is_empty() {
+                    return Err(Error::MemoryIsNotDefined(0));
+                }
+                let memarg = MemArg::read(wasm)?;
+                if memarg.align > 0 {
+                    return Err(Error::ErroneousAlignment(memarg.align, 0));
+                }
+                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
+                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
+            }
+            I64_STORE16 => {
                 if memories.is_empty() {
                     return Err(Error::MemoryIsNotDefined(0));
                 }
@@ -795,24 +806,13 @@ fn read_instructions(
                 stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
             }
-            I64_STORE16 => {
+            I64_STORE32 => {
                 if memories.is_empty() {
                     return Err(Error::MemoryIsNotDefined(0));
                 }
                 let memarg = MemArg::read(wasm)?;
                 if memarg.align > 2 {
                     return Err(Error::ErroneousAlignment(memarg.align, 2));
-                }
-                stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
-                stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
-            }
-            I64_STORE32 => {
-                if memories.is_empty() {
-                    return Err(Error::MemoryIsNotDefined(0));
-                }
-                let memarg = MemArg::read(wasm)?;
-                if memarg.align > 4 {
-                    return Err(Error::ErroneousAlignment(memarg.align, 4));
                 }
                 stack.assert_pop_val_type(ValType::NumType(NumType::I64))?;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;


### PR DESCRIPTION
### Pull Request Overview

Removes u32::pow from alignment calculation. This is up to the spec, it is also represented there that way:

https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions

closes #242 

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Benchmark Results

<!--
Remove this section if performance is likely unaffected

Put your benchmark results here
-->

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
