### PR TITLE
Improve Wrapping Logic for Memory Instructions

### DIFF
--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -646,11 +646,7 @@ pub(super) fn run<T, H: HookSet>(
                 let data_to_store: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let wrapped_data: i8 = i8::from_le_bytes(
-                    data_to_store.rem_euclid(2_i32.pow(8)).to_le_bytes()[0..1]
-                        .try_into()
-                        .expect("array to be of length 1"),
-                );
+                let wrapped_data = data_to_store as i8;
 
                 let mem = &mut store.memories[store.modules[current_module_idx].mem_addrs[0]];
 
@@ -665,11 +661,7 @@ pub(super) fn run<T, H: HookSet>(
                 let data_to_store: i32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let wrapped_data: i16 = i16::from_le_bytes(
-                    data_to_store.rem_euclid(2_i32.pow(16)).to_le_bytes()[0..2]
-                        .try_into()
-                        .expect("array to be of length 2"),
-                );
+                let wrapped_data = data_to_store as i16;
 
                 let mem = &mut store.memories[store.modules[current_module_idx].mem_addrs[0]];
 
@@ -684,11 +676,7 @@ pub(super) fn run<T, H: HookSet>(
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let wrapped_data: i8 = i8::from_le_bytes(
-                    data_to_store.rem_euclid(2_i64.pow(8)).to_le_bytes()[0..1]
-                        .try_into()
-                        .expect("array to be of length 1"),
-                );
+                let wrapped_data = data_to_store as i8;
 
                 let mem = &mut store.memories[store.modules[current_module_idx].mem_addrs[0]];
 
@@ -703,11 +691,7 @@ pub(super) fn run<T, H: HookSet>(
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let wrapped_data: i16 = i16::from_le_bytes(
-                    data_to_store.rem_euclid(2_i64.pow(16)).to_le_bytes()[0..2]
-                        .try_into()
-                        .expect("array to be of length 2"),
-                );
+                let wrapped_data = data_to_store as i16;
 
                 let mem = &mut store.memories[store.modules[current_module_idx].mem_addrs[0]];
 
@@ -722,11 +706,7 @@ pub(super) fn run<T, H: HookSet>(
                 let data_to_store: i64 = stack.pop_value(ValType::NumType(NumType::I64)).into();
                 let relative_address: u32 = stack.pop_value(ValType::NumType(NumType::I32)).into();
 
-                let wrapped_data: i32 = i32::from_le_bytes(
-                    data_to_store.rem_euclid(2_i64.pow(32)).to_le_bytes()[0..4]
-                        .try_into()
-                        .expect("array to be of length 4"),
-                );
+                let wrapped_data = data_to_store as i32;
 
                 let mem = &mut store.memories[store.modules[current_module_idx].mem_addrs[0]];
 


### PR DESCRIPTION
Rust's `as` automatically truncates integers when the source type is larger than the destination type. This PR replaces manual wrapping logic with direct `as` conversions.

### Checks

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

