### PR TITLE
Fix panic handling in testsuite

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -71,6 +71,7 @@ pub enum ValidationError {
     UnknownGlobal,
     DuplicateExportName,
     UnsupportedMultipleMemoriesProposal,
+    ExprHasTrailingInstructions,
 }
 
 impl Display for ValidationError {
@@ -215,6 +216,7 @@ impl Display for ValidationError {
             ValidationError::UnknownTable => f.write_str("Unknown table"),
             ValidationError::DuplicateExportName => f.write_str("Duplicate export name"),
             ValidationError::UnsupportedMultipleMemoriesProposal => f.write_str("Proposal for multiple memories is not yet supported"),
+            ValidationError::ExprHasTrailingInstructions => f.write_str("A code expression has invalid trailing instructions"),
         }
     }
 }

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -69,9 +69,7 @@ pub fn validate_code_section(
 
         // Check if there were unread trailing instructions after the last END
         if previous_pc + func_size as usize != wasm.pc {
-            todo!(
-                "throw error because there are trailing unreachable instructions in the code block"
-            )
+            return Err(ValidationError::ExprHasTrailingInstructions);
         }
 
         Ok((func_block, stp))

--- a/src/validation/data.rs
+++ b/src/validation/data.rs
@@ -34,6 +34,11 @@ pub(super) fn validate_data_section(
             0 => {
                 // active { memory 0, offset e }
                 trace!("Data section: active {{ memory 0, offset e }}");
+
+                if no_of_total_memories == 0 {
+                    return Err(ValidationError::UnknownMemory);
+                }
+
                 let mut valid_stack = ValidationStack::new();
                 let (offset, _) = {
                     read_constant_expression(

--- a/tests/specification/reports.rs
+++ b/tests/specification/reports.rs
@@ -86,7 +86,7 @@ impl AssertReport {
     pub fn passed_asserts(&self) -> u32 {
         self.results
             .iter()
-            .filter(|el| el.maybe_error.is_some())
+            .filter(|el| el.maybe_error.is_none())
             .count() as u32
     }
 

--- a/tests/specification/run.rs
+++ b/tests/specification/run.rs
@@ -312,10 +312,24 @@ fn run_directive<'a>(
                 validate_instantiate(interpreter, bytes)
             });
 
+            let maybe_assert_error = match result {
+                Ok(()) => Some(WastError::AssertInvalidButValid),
+                Err(panic_err @ WastError::Panic(_)) => {
+                    return Err(ScriptError::new(
+                        filepath,
+                        panic_err,
+                        "Module directive (WAT) failed in validation or instantiation.",
+                        line_number,
+                        cmd,
+                    ))
+                }
+                Err(_other) => None,
+            };
+
             Ok(Some(AssertOutcome {
                 line_number,
                 command: cmd.to_owned(),
-                maybe_error: result.is_ok().then_some(WastError::AssertInvalidButValid),
+                maybe_error: maybe_assert_error,
             }))
         }
 


### PR DESCRIPTION
Before these changes `assert_malformed` and `assert_invalid` interpreted the interpreter panicking as success. However, this is incorrect. This PR makes these assertions fail on panics and fixes bugs in the interpreter to get the spec compliance back up to 100%.

### Pull Request Overview

<!--
This pull request adds/changes/fixes...
-->

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`