### PR TITLE
feat: add flamegraph to report

### DIFF
--- a/pkgs/flamegraph.nix
+++ b/pkgs/flamegraph.nix
@@ -1,0 +1,23 @@
+{ wasm-interpreter, cargo-flamegraph }:
+
+wasm-interpreter.overrideAttrs (old: {
+  pname = old.pname + "-flamegraph";
+  nativeBuildInputs = old.nativeBuildInputs ++ [ cargo-flamegraph ];
+  cargoBuildFlags = [ "--package=benchmark" ];
+
+  postBuild = ''
+    pushd crates/benchmark
+    CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --package benchmark --bench general_purpose \
+      --deterministic -- --bench
+    popd
+  '';
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -- "$out"
+    mv -- flamegraph.svg "$out/"
+    runHook postInstall
+  '';
+})

--- a/pkgs/report/package.nix
+++ b/pkgs/report/package.nix
@@ -21,6 +21,7 @@ stdenvNoCC.mkDerivation {
 
     cp --recursive -- ${wasm-interpreter-pkgs.benchmark} bench
     cp --recursive -- ${wasm-interpreter-pkgs.coverage}/lcov-html coverage
+    cp --recursive -- ${wasm-interpreter-pkgs.flamegraph} flamegraph
     cp --recursive -- ${wasm-interpreter-pkgs.requirements} requirements
     cp --recursive -- ${
       wasm-interpreter-pkgs.wasm-interpreter.override { doDoc = true; }

--- a/pkgs/report/report_index.html
+++ b/pkgs/report/report_index.html
@@ -24,7 +24,7 @@
       @media (orientation: landscape) {
         body {
           flex-flow: row;
-          font-size: calc(min(10vw / 5, 25vh));
+          font-size: calc(min(10vw / 6, 25vh));
         }
         a {
           flex-basis: 0;
@@ -35,7 +35,7 @@
         body {
           flex-flow: column;
           align-items: stretch;
-          font-size: calc(min(30vh / 5, 8vw));
+          font-size: calc(min(30vh / 6, 8vw));
         }
       }
     </style>
@@ -47,6 +47,7 @@
     <a href="test/index.html">Tests</a>
     <a href="coverage/html/index.html">Coverage</a>
     <a href="bench/report/index.html">Benchmark</a>
+    <a href="flamegraph/flamegraph.svg">Flamegraph</a>
     <a href="whitepaper.pdf">Whitepaper</a>
   </body>
 </html>


### PR DESCRIPTION
### Pull Request Overview

Its useful to also have a rough idea in the report, which benchmark spends how much time in which part of the interpreter.

### TODO or Help Wanted

Do we want any other settings set to flamegraph? Maybe a flamechart, a different color palette or a reverse rendering?

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
