### PR TITLE
feat: required_fuel field to continue execution

### DIFF
--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -14,7 +14,6 @@ pub enum RuntimeError {
     InvalidImportType,
     UnknownImport,
     MoreThanOneMemory,
-    OutOfFuel,
 }
 
 impl Display for RuntimeError {
@@ -36,7 +35,6 @@ impl Display for RuntimeError {
             RuntimeError::MoreThanOneMemory => {
                 f.write_str("As of not only one memory is allowed per module.")
             }
-            RuntimeError::OutOfFuel => f.write_str("ran out of fuel"),
         }
     }
 }

--- a/src/execution/resumable.rs
+++ b/src/execution/resumable.rs
@@ -1,4 +1,4 @@
-use core::mem;
+use core::{mem, num::NonZeroU32};
 
 use alloc::{
     sync::{Arc, Weak},
@@ -22,6 +22,7 @@ pub struct Resumable {
     pub(crate) pc: usize,
     pub(crate) stp: usize,
     pub(crate) current_func_addr: usize,
+    pub(crate) maybe_fuel: Option<u32>,
 }
 
 #[derive(Default)]
@@ -49,10 +50,58 @@ pub struct ResumableRef {
 }
 
 impl ResumableRef {
+    /// calls its argument `f` with a mutable reference of the fuel of the respective [`ResumableRef`].
+    ///
+    /// Fuel is stored as an [`Option<u32>`], where `None` means that fuel is disabled and `Some(x)` means that `x` units of fuel is left.
+    /// A ubiquitious use of this method would be using `f` to read or mutate the current fuel amount of the respective [`ResumableRef`].
+    /// # Example
+    /// ```
+    /// use wasm::{resumable::RunState, validate, RuntimeInstance};
+    /// let wasm = [ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    ///             0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x03, 0x02,
+    ///             0x01, 0x00, 0x07, 0x09, 0x01, 0x05, 0x6c, 0x6f,
+    ///             0x6f, 0x70, 0x73, 0x00, 0x00, 0x0a, 0x09, 0x01,
+    ///             0x07, 0x00, 0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b ];
+    /// // a simple module with a single function looping forever
+    /// let mut instance = RuntimeInstance::new_named((), "module", &validate(&wasm).unwrap()).unwrap();
+    /// let func_ref = instance.get_function_by_name("module", "loops").unwrap();
+    /// let resumable = instance.invoke_resumable(&func_ref, vec![], 0).unwrap();
+    /// match resumable {
+    ///     RunState::Resumable { resumable_ref, .. } => {
+    ///         // inspect and modify fuel content
+    ///         resumable_ref.access_fuel_mut(&mut instance, |x| { assert_eq!(*x, Some(0)); *x = None; }).unwrap();
+    ///     }
+    ///     _ => unreachable!("this function loops forever")
+    /// }
+    /// ```
+    pub fn access_fuel_mut<T, R>(
+        &self,
+        runtime_instance: &mut RuntimeInstance<T>,
+        f: impl FnOnce(&mut Option<u32>) -> R,
+    ) -> Result<R, RuntimeError> {
+        // Resuming requires `self`'s dormitory to still be alive
+        let Some(dormitory) = self.dormitory.upgrade() else {
+            return Err(RuntimeError::ResumableNotFound);
+        };
+
+        // Check the given `RuntimeInstance` is the same one used to create `self`
+        if !Arc::ptr_eq(&dormitory, &runtime_instance.store.dormitory.0) {
+            return Err(RuntimeError::ResumableNotFound);
+        }
+
+        let mut dormitory = dormitory.write();
+
+        let resumable = dormitory
+            .get_mut(&self.key)
+            .expect("the key to always be valid as self was not dropped yet");
+
+        Ok(f(&mut resumable.maybe_fuel))
+    }
+
+    /// resumes execution of the resumable.
     pub fn resume<T>(
         mut self,
         runtime_instance: &mut RuntimeInstance<T>,
-        fuel: u32,
     ) -> Result<RunState, RuntimeError> {
         // Resuming requires `self`'s dormitory to still be alive
         let Some(dormitory) = self.dormitory.upgrade() else {
@@ -74,15 +123,10 @@ impl ResumableRef {
             .expect("the key to always be valid as self was not dropped yet");
 
         // Resume execution
-        let result = interpreter_loop::run(
-            resumable,
-            &mut runtime_instance.store,
-            EmptyHookSet,
-            Some(fuel),
-        );
+        let result = interpreter_loop::run(resumable, &mut runtime_instance.store, EmptyHookSet)?;
 
         match result {
-            Ok(()) => {
+            None => {
                 let resumable = dormitory.remove(&self.key)
                     .expect("that the resumable could not have been removed already, because then this self could not exist");
 
@@ -92,8 +136,10 @@ impl ResumableRef {
 
                 Ok(RunState::Finished(resumable.stack.into_values()))
             }
-            Err(RuntimeError::OutOfFuel) => Ok(RunState::Resumable(self)),
-            Err(err) => Err(err),
+            Some(required_fuel) => Ok(RunState::Resumable {
+                resumable_ref: self,
+                required_fuel,
+            }),
         }
     }
 }
@@ -112,7 +158,10 @@ impl Drop for ResumableRef {
 
 pub enum RunState {
     Finished(Vec<Value>),
-    Resumable(ResumableRef),
+    Resumable {
+        resumable_ref: ResumableRef,
+        required_fuel: NonZeroU32,
+    },
 }
 
 #[cfg(test)]
@@ -131,6 +180,7 @@ mod test {
             pc: 11,
             stp: 13,
             current_func_addr: 17,
+            maybe_fuel: None,
         };
 
         dorm.insert(resumable);

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -594,28 +594,24 @@ impl<'b, T> Store<'b, T> {
                     stack,
                     pc: wasm_func_inst.code_expr.from,
                     stp: wasm_func_inst.stp,
+                    maybe_fuel,
                 };
 
                 // Run the interpreter
-                let result = interpreter_loop::run(
-                    // &mut self.modules,
-                    &mut resumable,
-                    // self.lut.as_ref().ok_or(RuntimeError::UnmetImport)?,
-                    self,
-                    EmptyHookSet,
-                    maybe_fuel,
-                );
+                let result = interpreter_loop::run(&mut resumable, self, EmptyHookSet)?;
 
                 match result {
-                    Ok(()) => {
+                    None => {
                         debug!("Successfully invoked function");
                         Ok(RunState::Finished(resumable.stack.into_values()))
                     }
-                    Err(RuntimeError::OutOfFuel) => {
+                    Some(required_fuel) => {
                         debug!("Successfully invoked function, but ran out of fuel");
-                        Ok(RunState::Resumable(self.dormitory.insert(resumable)))
+                        Ok(RunState::Resumable {
+                            resumable_ref: self.dormitory.insert(resumable),
+                            required_fuel,
+                        })
                     }
-                    Err(err) => Err(err),
                 }
             }
         }


### PR DESCRIPTION
Resumables might be supplied with fuel that is too little to continue execution. This addition suggests a simple change to the Resumable API to inform the user with the minimum required fuel amount to continue execution, and also supplies a method to inspect/modify the remaining fuel within the resumable.

### Pull Request Overview

<!--
This pull request adds/changes/fixes...
-->

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Benchmark Results

<!--
Remove this section if performance is likely unaffected

Put your benchmark results here
-->

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
