### PR TITLE
move resumable methods into store, create resumables without invoking them

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,4 +1,4 @@
-use crate::resumable::RunState;
+use crate::resumable::{ResumableRef, RunState};
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
@@ -144,14 +144,49 @@ where
             })
     }
 
-    pub fn invoke_resumable(
-        &mut self,
+    /// Creates a new resumable, which when resumed for the first time invokes the function `function_ref` is associated
+    /// to, with the arguments `params`. The newly created resumable initially stores `fuel` units of fuel. Returns a
+    /// `[ResumableRef]` associated to the newly created resumable on success.
+    pub fn create_resumable(
+        &self,
         function_ref: &FunctionRef,
         params: Vec<Value>,
         fuel: u32,
-    ) -> Result<RunState, RuntimeError> {
+    ) -> Result<ResumableRef, RuntimeError> {
         let FunctionRef { func_addr } = *function_ref;
-        self.store.invoke(func_addr, params, Some(fuel))
+        self.store.create_resumable(func_addr, params, Some(fuel))
+    }
+
+    /// resumes the resumable associated to `resumable_ref`. Returns a `[RunState]` associated to this resumable  if the
+    /// resumable ran out of fuel or completely executed.
+    pub fn resume(&mut self, resumable_ref: ResumableRef) -> Result<RunState, RuntimeError> {
+        self.store.resume(resumable_ref)
+    }
+
+    /// calls its argument `f` with a mutable reference of the fuel of the respective [`ResumableRef`].
+    ///
+    /// Fuel is stored as an [`Option<u32>`], where `None` means that fuel is disabled and `Some(x)` means that `x` units of fuel is left.
+    /// A ubiquitious use of this method would be using `f` to read or mutate the current fuel amount of the respective [`ResumableRef`].
+    /// # Example
+    /// ```
+    /// use wasm::{resumable::RunState, validate, RuntimeInstance};
+    /// let wasm = [ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    ///             0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x03, 0x02,
+    ///             0x01, 0x00, 0x07, 0x09, 0x01, 0x05, 0x6c, 0x6f,
+    ///             0x6f, 0x70, 0x73, 0x00, 0x00, 0x0a, 0x09, 0x01,
+    ///             0x07, 0x00, 0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b ];
+    /// // a simple module with a single function looping forever
+    /// let mut instance = RuntimeInstance::new_named((), "module", &validate(&wasm).unwrap()).unwrap();
+    /// let func_ref = instance.get_function_by_name("module", "loops").unwrap();
+    /// let mut resumable_ref = instance.create_resumable(&func_ref, vec![], 0).unwrap();
+    /// instance.access_fuel_mut(&mut resumable_ref, |x| { assert_eq!(*x, Some(0)); *x = None; }).unwrap();
+    /// ```
+    pub fn access_fuel_mut<R>(
+        &mut self,
+        resumable_ref: &mut ResumableRef,
+        f: impl FnOnce(&mut Option<u32>) -> R,
+    ) -> Result<R, RuntimeError> {
+        self.store.access_fuel_mut(resumable_ref, f)
     }
 
     /// Adds a host function under module namespace `module_name` with name `name`.

--- a/src/execution/resumable.rs
+++ b/src/execution/resumable.rs
@@ -1,4 +1,4 @@
-use core::{mem, num::NonZeroU32};
+use core::num::NonZeroU32;
 
 use alloc::{
     sync::{Arc, Weak},
@@ -7,17 +7,13 @@ use alloc::{
 
 use crate::{
     core::slotmap::{SlotMap, SlotMapKey},
-    execution::interpreter_loop,
-    hooks::EmptyHookSet,
     rw_spinlock::RwSpinLock,
     value_stack::Stack,
-    RuntimeError, Value,
+    Value,
 };
 
-use super::RuntimeInstance;
-
 #[derive(Debug)]
-pub struct Resumable {
+pub(crate) struct Resumable {
     pub(crate) stack: Stack,
     pub(crate) pc: usize,
     pub(crate) stp: usize,
@@ -26,125 +22,44 @@ pub struct Resumable {
 }
 
 #[derive(Default)]
-pub struct Dormitory(Arc<RwSpinLock<SlotMap<Resumable>>>);
+pub(crate) struct Dormitory(pub(crate) Arc<RwSpinLock<SlotMap<Resumable>>>);
 
 impl Dormitory {
     #[allow(unused)]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    pub fn insert(&self, resumable: Resumable) -> ResumableRef {
+    pub(crate) fn insert(&self, resumable: Resumable) -> InvokedResumableRef {
         let key = self.0.write().insert(resumable);
 
-        ResumableRef {
+        InvokedResumableRef {
             dormitory: Arc::downgrade(&self.0),
             key,
         }
     }
 }
 
-pub struct ResumableRef {
-    dormitory: Weak<RwSpinLock<SlotMap<Resumable>>>,
-    key: SlotMapKey<Resumable>,
+pub struct InvokedResumableRef {
+    pub(crate) dormitory: Weak<RwSpinLock<SlotMap<Resumable>>>,
+    pub(crate) key: SlotMapKey<Resumable>,
 }
 
-impl ResumableRef {
-    /// calls its argument `f` with a mutable reference of the fuel of the respective [`ResumableRef`].
-    ///
-    /// Fuel is stored as an [`Option<u32>`], where `None` means that fuel is disabled and `Some(x)` means that `x` units of fuel is left.
-    /// A ubiquitious use of this method would be using `f` to read or mutate the current fuel amount of the respective [`ResumableRef`].
-    /// # Example
-    /// ```
-    /// use wasm::{resumable::RunState, validate, RuntimeInstance};
-    /// let wasm = [ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
-    ///             0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x03, 0x02,
-    ///             0x01, 0x00, 0x07, 0x09, 0x01, 0x05, 0x6c, 0x6f,
-    ///             0x6f, 0x70, 0x73, 0x00, 0x00, 0x0a, 0x09, 0x01,
-    ///             0x07, 0x00, 0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b ];
-    /// // a simple module with a single function looping forever
-    /// let mut instance = RuntimeInstance::new_named((), "module", &validate(&wasm).unwrap()).unwrap();
-    /// let func_ref = instance.get_function_by_name("module", "loops").unwrap();
-    /// let resumable = instance.invoke_resumable(&func_ref, vec![], 0).unwrap();
-    /// match resumable {
-    ///     RunState::Resumable { resumable_ref, .. } => {
-    ///         // inspect and modify fuel content
-    ///         resumable_ref.access_fuel_mut(&mut instance, |x| { assert_eq!(*x, Some(0)); *x = None; }).unwrap();
-    ///     }
-    ///     _ => unreachable!("this function loops forever")
-    /// }
-    /// ```
-    pub fn access_fuel_mut<T, R>(
-        &self,
-        runtime_instance: &mut RuntimeInstance<T>,
-        f: impl FnOnce(&mut Option<u32>) -> R,
-    ) -> Result<R, RuntimeError> {
-        // Resuming requires `self`'s dormitory to still be alive
-        let Some(dormitory) = self.dormitory.upgrade() else {
-            return Err(RuntimeError::ResumableNotFound);
-        };
-
-        // Check the given `RuntimeInstance` is the same one used to create `self`
-        if !Arc::ptr_eq(&dormitory, &runtime_instance.store.dormitory.0) {
-            return Err(RuntimeError::ResumableNotFound);
-        }
-
-        let mut dormitory = dormitory.write();
-
-        let resumable = dormitory
-            .get_mut(&self.key)
-            .expect("the key to always be valid as self was not dropped yet");
-
-        Ok(f(&mut resumable.maybe_fuel))
-    }
-
-    /// resumes execution of the resumable.
-    pub fn resume<T>(
-        mut self,
-        runtime_instance: &mut RuntimeInstance<T>,
-    ) -> Result<RunState, RuntimeError> {
-        // Resuming requires `self`'s dormitory to still be alive
-        let Some(dormitory) = self.dormitory.upgrade() else {
-            return Err(RuntimeError::ResumableNotFound);
-        };
-
-        // Check the given `RuntimeInstance` is the same one used to create `self`
-        if !Arc::ptr_eq(&dormitory, &runtime_instance.store.dormitory.0) {
-            return Err(RuntimeError::ResumableNotFound);
-        }
-
-        // Obtain a write lock to the `Dormitory`
-        let mut dormitory = dormitory.write();
-
-        // TODO We might want to remove the `Resumable` here already and later reinsert it.
-        // This would prevent holding the lock across the interpreter loop.
-        let resumable = dormitory
-            .get_mut(&self.key)
-            .expect("the key to always be valid as self was not dropped yet");
-
-        // Resume execution
-        let result = interpreter_loop::run(resumable, &mut runtime_instance.store, EmptyHookSet)?;
-
-        match result {
-            None => {
-                let resumable = dormitory.remove(&self.key)
-                    .expect("that the resumable could not have been removed already, because then this self could not exist");
-
-                // Take the `Weak` pointing to the dormitory out of `self` and replace it with a default `Weak`.
-                // This causes the `Drop` impl of `self` to directly quit preventing it from unnecessarily locking the dormitory.
-                let _dormitory = mem::take(&mut self.dormitory);
-
-                Ok(RunState::Finished(resumable.stack.into_values()))
-            }
-            Some(required_fuel) => Ok(RunState::Resumable {
-                resumable_ref: self,
-                required_fuel,
-            }),
-        }
-    }
+pub struct FreshResumableRef {
+    pub(crate) func_addr: usize,
+    pub(crate) params: Vec<Value>,
+    pub(crate) maybe_fuel: Option<u32>,
 }
 
-impl Drop for ResumableRef {
+/// An object associated to a resumable that is held internally. The variant `ResumableRef::Fresh` indicates this
+/// resumable has never been invoked/resumed to. `ResumableRef::Invoked` indicates this resumable has been
+/// invoked/resumed to at least once.
+pub enum ResumableRef {
+    Fresh(FreshResumableRef),
+    Invoked(InvokedResumableRef),
+}
+
+impl Drop for InvokedResumableRef {
     fn drop(&mut self) {
         let Some(dormitory) = self.dormitory.upgrade() else {
             // Either the dormitory was already dropped or `self` was used to finish execution.
@@ -156,6 +71,9 @@ impl Drop for ResumableRef {
     }
 }
 
+/// Represents the state of a possibly interrupted resumable. `RunState::Finished` represents a resumable that has
+/// executed completely. `RunState::Resumable` represents a resumable that has ran out of fuel during execution, missing
+/// at least `required_fuel` units of fuel to continue further execution.
 pub enum RunState {
     Finished(Vec<Value>),
     Resumable {


### PR DESCRIPTION
### Pull Request Overview

ResumableRef objects require the owning RuntimeInstance to be operated on. Moving them back to Store provides cleaner interface along with create_resumable method for cases when we want to create one without invoking it.

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Benchmark Results

<!--
Remove this section if performance is likely unaffected

Put your benchmark results here
-->

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
