### PR TITLE
Configuration Items for Execution Stack

### DIFF
--- a/src/execution/config.rs
+++ b/src/execution/config.rs
@@ -5,6 +5,12 @@
 /// The default implementation of all trait methods have the least overhead, i. e. most can be optimized out fully.
 // It must always be checked that there is no additional performance penalty for the default config!
 pub trait Config {
+    /// Maximum number of values in the value stack
+    const MAX_VALUE_STACK_SIZE: usize = 0xf0000; // 64 Kibi-Values
+
+    /// Maximum number of cascading function invocations
+    const MAX_CALL_STACK_SIZE: usize = 0x1000; // 4 Kibi-Functions
+
     /// A hook which is called before every wasm instruction
     ///
     /// This allows the most intricate insight into the interpreters behavior, at the cost of a

--- a/src/execution/const_interpreter_loop.rs
+++ b/src/execution/const_interpreter_loop.rs
@@ -53,39 +53,39 @@ pub(crate) fn run_const<T: Config>(
                     "Constant instruction: global.get [{global_idx}] -> [{:?}]",
                     global
                 );
-                stack.push_value(global.value)?;
+                stack.push_value::<T>(global.value)?;
             }
             I32_CONST => {
                 let constant = wasm.read_var_i32().unwrap_validated();
                 trace!("Constant instruction: i32.const [] -> [{constant}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             F32_CONST => {
                 let constant = value::F32::from_bits(wasm.read_var_f32().unwrap_validated());
                 trace!("Constanting instruction: f32.const [] -> [{constant}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             F64_CONST => {
                 let constant = value::F64::from_bits(wasm.read_var_f64().unwrap_validated());
                 trace!("Constanting instruction: f64.const [] -> [{constant}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             I64_CONST => {
                 let constant = wasm.read_var_i64().unwrap_validated();
                 trace!("Constant instruction: i64.const [] -> [{constant}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             REF_NULL => {
                 let reftype = RefType::read(wasm).unwrap_validated();
 
-                stack.push_value(Value::Ref(Ref::Null(reftype)))?;
+                stack.push_value::<T>(Value::Ref(Ref::Null(reftype)))?;
                 trace!("Instruction: ref.null '{:?}' -> [{:?}]", reftype, reftype);
             }
             REF_FUNC => {
                 // we already checked for the func_idx to be in bounds during validation
                 let func_idx = wasm.read_var_u32().unwrap_validated() as usize;
                 let func_addr = *module.func_addrs.get(func_idx).unwrap_validated();
-                stack.push_value(Value::Ref(Ref::Func(FuncAddr(func_addr))))?;
+                stack.push_value::<T>(Value::Ref(Ref::Func(FuncAddr(func_addr))))?;
             }
 
             FD_EXTENSIONS => {
@@ -98,7 +98,7 @@ pub(crate) fn run_const<T: Config>(
                             *byte_ref = wasm.read_u8().unwrap_validated();
                         }
 
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
                     0x00..=0x0B | 0x0D.. => unreachable_validated!(),
                 }

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -226,13 +226,13 @@ pub(super) fn run<T: Config>(
                             if value.to_ty() != ty {
                                 return Err(RuntimeError::HostFunctionSignatureMismatch);
                             }
-                            stack.push_value(value)?;
+                            stack.push_value::<T>(value)?;
                         }
                     }
                     FuncInst::WasmFunc(wasm_func_to_call_inst) => {
                         let remaining_locals = &wasm_func_to_call_inst.locals;
 
-                        stack.push_call_frame(
+                        stack.push_call_frame::<T>(
                             current_func_addr,
                             &func_to_call_ty,
                             remaining_locals,
@@ -315,13 +315,13 @@ pub(super) fn run<T: Config>(
                             if value.to_ty() != ty {
                                 return Err(RuntimeError::HostFunctionSignatureMismatch);
                             }
-                            stack.push_value(value)?;
+                            stack.push_value::<T>(value)?;
                         }
                     }
                     FuncInst::WasmFunc(wasm_func_to_call_inst) => {
                         let remaining_locals = &wasm_func_to_call_inst.locals;
 
-                        stack.push_call_frame(
+                        stack.push_call_frame::<T>(
                             current_func_addr,
                             &func_to_call_ty,
                             remaining_locals,
@@ -352,9 +352,9 @@ pub(super) fn run<T: Config>(
                 let val2 = stack.pop_value();
                 let val1 = stack.pop_value();
                 if test_val != 0 {
-                    stack.push_value(val1)?;
+                    stack.push_value::<T>(val1)?;
                 } else {
-                    stack.push_value(val2)?;
+                    stack.push_value::<T>(val2)?;
                 }
                 trace!("Instruction: SELECT");
             }
@@ -364,16 +364,16 @@ pub(super) fn run<T: Config>(
                 let val2 = stack.pop_value();
                 let val1 = stack.pop_value();
                 if test_val != 0 {
-                    stack.push_value(val1)?;
+                    stack.push_value::<T>(val1)?;
                 } else {
-                    stack.push_value(val2)?;
+                    stack.push_value::<T>(val2)?;
                 }
                 trace!("Instruction: SELECT_T");
             }
             LOCAL_GET => {
                 let local_idx = wasm.read_var_u32().unwrap_validated() as LocalIdx;
                 let value = *stack.get_local(local_idx);
-                stack.push_value(value)?;
+                stack.push_value::<T>(value)?;
                 trace!("Instruction: local.get {} [] -> [t]", local_idx);
             }
             LOCAL_SET => {
@@ -396,7 +396,7 @@ pub(super) fn run<T: Config>(
                     .unwrap_validated();
                 let global = &store.globals[global_addr];
 
-                stack.push_value(global.value)?;
+                stack.push_value::<T>(global.value)?;
 
                 trace!(
                     "Instruction: global.get '{}' [<GLOBAL>] -> [{:?}]",
@@ -429,7 +429,7 @@ pub(super) fn run<T: Config>(
                     .get(i as usize)
                     .ok_or(TrapError::TableOrElementAccessOutOfBounds)?;
 
-                stack.push_value((*val).into())?;
+                stack.push_value::<T>((*val).into())?;
                 trace!(
                     "Instruction: table.get '{}' [{}] -> [{}]",
                     table_idx,
@@ -475,7 +475,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem_inst.mem.load(idx)?;
 
-                stack.push_value(Value::I32(data))?;
+                stack.push_value::<T>(Value::I32(data))?;
                 trace!("Instruction: i32.load [{relative_address}] -> [{data}]");
             }
             I64_LOAD => {
@@ -491,7 +491,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I64(data))?;
+                stack.push_value::<T>(Value::I64(data))?;
                 trace!("Instruction: i64.load [{relative_address}] -> [{data}]");
             }
             F32_LOAD => {
@@ -507,7 +507,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem.mem.load(idx)?;
 
-                stack.push_value(Value::F32(data))?;
+                stack.push_value::<T>(Value::F32(data))?;
                 trace!("Instruction: f32.load [{relative_address}] -> [{data}]");
             }
             F64_LOAD => {
@@ -523,7 +523,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem.mem.load(idx)?;
 
-                stack.push_value(Value::F64(data))?;
+                stack.push_value::<T>(Value::F64(data))?;
                 trace!("Instruction: f64.load [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_S => {
@@ -539,7 +539,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i8 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I32(data as u32))?;
+                stack.push_value::<T>(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load8_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_U => {
@@ -555,7 +555,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u8 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I32(data as u32))?;
+                stack.push_value::<T>(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load8_u [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_S => {
@@ -571,7 +571,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i16 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I32(data as u32))?;
+                stack.push_value::<T>(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load16_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_U => {
@@ -587,7 +587,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u16 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I32(data as u32))?;
+                stack.push_value::<T>(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_S => {
@@ -603,7 +603,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i8 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I64(data as u64))?;
+                stack.push_value::<T>(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load8_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_U => {
@@ -619,7 +619,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u8 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I64(data as u64))?;
+                stack.push_value::<T>(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load8_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_S => {
@@ -635,7 +635,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i16 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I64(data as u64))?;
+                stack.push_value::<T>(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load16_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_U => {
@@ -651,7 +651,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u16 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I64(data as u64))?;
+                stack.push_value::<T>(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_S => {
@@ -667,7 +667,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i32 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I64(data as u64))?;
+                stack.push_value::<T>(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load32_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_U => {
@@ -683,7 +683,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u32 = mem.mem.load(idx)?;
 
-                stack.push_value(Value::I64(data as u64))?;
+                stack.push_value::<T>(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load32_u [{relative_address}] -> [{data}]");
             }
             I32_STORE => {
@@ -857,7 +857,7 @@ pub(super) fn run<T: Config>(
                     .unwrap_validated();
                 let mem = &mut store.memories[mem_addr];
                 let size = mem.size() as u32;
-                stack.push_value(Value::I32(size))?;
+                stack.push_value::<T>(Value::I32(size))?;
                 trace!("Instruction: memory.size [] -> [{}]", size);
             }
             MEMORY_GROW => {
@@ -878,18 +878,18 @@ pub(super) fn run<T: Config>(
                     Ok(_) => sz,
                     Err(_) => u32::MAX,
                 };
-                stack.push_value(Value::I32(pushed_value))?;
+                stack.push_value::<T>(Value::I32(pushed_value))?;
                 trace!("Instruction: memory.grow [{}] -> [{}]", n, pushed_value);
             }
             I32_CONST => {
                 let constant = wasm.read_var_i32().unwrap_validated();
                 trace!("Instruction: i32.const [] -> [{constant}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             F32_CONST => {
                 let constant = F32::from_bits(wasm.read_var_f32().unwrap_validated());
                 trace!("Instruction: f32.const [] -> [{constant:.7}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             I32_EQZ => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -897,7 +897,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == 0 { 1 } else { 0 };
 
                 trace!("Instruction: i32.eqz [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_EQ => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -906,7 +906,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_NE => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -915,7 +915,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_LT_S => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -924,7 +924,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.lt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I32_LT_U => {
@@ -934,7 +934,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) < (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.lt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_GT_S => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -943,7 +943,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.gt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_GT_U => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -952,7 +952,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) > (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.gt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_LE_S => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -961,7 +961,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.le_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_LE_U => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -970,7 +970,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) <= (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.le_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_GE_S => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -979,7 +979,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.ge_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_GE_U => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -988,7 +988,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) >= (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.ge_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_EQZ => {
                 let v1: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -996,7 +996,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == 0 { 1 } else { 0 };
 
                 trace!("Instruction: i64.eqz [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_EQ => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1005,7 +1005,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_NE => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1014,7 +1014,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_LT_S => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1023,7 +1023,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.lt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I64_LT_U => {
@@ -1033,7 +1033,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) < (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.lt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_GT_S => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1042,7 +1042,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.gt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_GT_U => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1051,7 +1051,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) > (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.gt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_LE_S => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1060,7 +1060,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.le_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_LE_U => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1069,7 +1069,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) <= (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.le_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_GE_S => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1078,7 +1078,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.ge_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_GE_U => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1087,7 +1087,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) >= (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.ge_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_EQ => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1096,7 +1096,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_NE => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1105,7 +1105,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_LT => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1114,7 +1114,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.lt [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_GT => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1123,7 +1123,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.gt [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_LE => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1132,7 +1132,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.le [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_GE => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1141,7 +1141,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.ge [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             F64_EQ => {
@@ -1151,7 +1151,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_NE => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1160,7 +1160,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_LT => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1169,7 +1169,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.lt [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_GT => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1178,7 +1178,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.gt [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_LE => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1187,7 +1187,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.le [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_GE => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1196,7 +1196,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.ge [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I32_CLZ => {
@@ -1204,31 +1204,31 @@ pub(super) fn run<T: Config>(
                 let res = v1.leading_zeros() as i32;
 
                 trace!("Instruction: i32.clz [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_CTZ => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
                 let res = v1.trailing_zeros() as i32;
 
                 trace!("Instruction: i32.ctz [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_POPCNT => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
                 let res = v1.count_ones() as i32;
 
                 trace!("Instruction: i32.popcnt [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_CONST => {
                 let constant = wasm.read_var_i64().unwrap_validated();
                 trace!("Instruction: i64.const [] -> [{constant}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             F64_CONST => {
                 let constant = F64::from_bits(wasm.read_var_f64().unwrap_validated());
                 trace!("Instruction: f64.const [] -> [{constant}]");
-                stack.push_value(constant.into())?;
+                stack.push_value::<T>(constant.into())?;
             }
             I32_ADD => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1236,7 +1236,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_add(v2);
 
                 trace!("Instruction: i32.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_SUB => {
                 let v2: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1244,7 +1244,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_sub(v2);
 
                 trace!("Instruction: i32.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_MUL => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1252,7 +1252,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_mul(v2);
 
                 trace!("Instruction: i32.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_DIV_S => {
                 let dividend: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1268,7 +1268,7 @@ pub(super) fn run<T: Config>(
                 let res = divisor / dividend;
 
                 trace!("Instruction: i32.div_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_DIV_U => {
                 let dividend: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1284,7 +1284,7 @@ pub(super) fn run<T: Config>(
                 let res = (divisor / dividend) as i32;
 
                 trace!("Instruction: i32.div_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_REM_S => {
                 let dividend: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1298,28 +1298,28 @@ pub(super) fn run<T: Config>(
                 let res = res.unwrap_or_default();
 
                 trace!("Instruction: i32.rem_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_CLZ => {
                 let v1: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res = v1.leading_zeros() as i64;
 
                 trace!("Instruction: i64.clz [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_CTZ => {
                 let v1: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res = v1.trailing_zeros() as i64;
 
                 trace!("Instruction: i64.ctz [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_POPCNT => {
                 let v1: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res = v1.count_ones() as i64;
 
                 trace!("Instruction: i64.popcnt [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_ADD => {
                 let v1: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1327,7 +1327,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_add(v2);
 
                 trace!("Instruction: i64.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_SUB => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1335,7 +1335,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_sub(v2);
 
                 trace!("Instruction: i64.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_MUL => {
                 let v1: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1343,7 +1343,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_mul(v2);
 
                 trace!("Instruction: i64.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_DIV_S => {
                 let dividend: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1359,7 +1359,7 @@ pub(super) fn run<T: Config>(
                 let res = divisor / dividend;
 
                 trace!("Instruction: i64.div_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_DIV_U => {
                 let dividend: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1375,7 +1375,7 @@ pub(super) fn run<T: Config>(
                 let res = (divisor / dividend) as i64;
 
                 trace!("Instruction: i64.div_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_REM_S => {
                 let dividend: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1389,7 +1389,7 @@ pub(super) fn run<T: Config>(
                 let res = res.unwrap_or_default();
 
                 trace!("Instruction: i64.rem_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_REM_U => {
                 let dividend: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1405,7 +1405,7 @@ pub(super) fn run<T: Config>(
                 let res = (divisor % dividend) as i64;
 
                 trace!("Instruction: i64.rem_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_AND => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1414,7 +1414,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 & v2;
 
                 trace!("Instruction: i64.and [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_OR => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1423,7 +1423,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 | v2;
 
                 trace!("Instruction: i64.or [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_XOR => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1432,7 +1432,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 ^ v2;
 
                 trace!("Instruction: i64.xor [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_SHL => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1441,7 +1441,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_shl((v2 & 63) as u32);
 
                 trace!("Instruction: i64.shl [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_SHR_S => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1450,7 +1450,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_shr((v2 & 63) as u32);
 
                 trace!("Instruction: i64.shr_s [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_SHR_U => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1459,7 +1459,7 @@ pub(super) fn run<T: Config>(
                 let res = (v1 as u64).wrapping_shr((v2 & 63) as u32);
 
                 trace!("Instruction: i64.shr_u [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_ROTL => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1468,7 +1468,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.rotate_left((v2 & 63) as u32);
 
                 trace!("Instruction: i64.rotl [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_ROTR => {
                 let v2: i64 = stack.pop_value().try_into().unwrap_validated();
@@ -1477,7 +1477,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.rotate_right((v2 & 63) as u32);
 
                 trace!("Instruction: i64.rotr [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_REM_U => {
                 let dividend: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1494,7 +1494,7 @@ pub(super) fn run<T: Config>(
                 let res = res.unwrap_or_default() as i32;
 
                 trace!("Instruction: i32.rem_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_AND => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1502,7 +1502,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 & v2;
 
                 trace!("Instruction: i32.and [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_OR => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1510,7 +1510,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 | v2;
 
                 trace!("Instruction: i32.or [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_XOR => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1518,7 +1518,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 ^ v2;
 
                 trace!("Instruction: i32.xor [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_SHL => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1526,7 +1526,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.wrapping_shl(v1 as u32);
 
                 trace!("Instruction: i32.shl [{v2} {v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_SHR_S => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1535,7 +1535,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.wrapping_shr(v1 as u32);
 
                 trace!("Instruction: i32.shr_s [{v2} {v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_SHR_U => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1544,7 +1544,7 @@ pub(super) fn run<T: Config>(
                 let res = (v2 as u32).wrapping_shr(v1 as u32) as i32;
 
                 trace!("Instruction: i32.shr_u [{v2} {v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_ROTL => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1553,7 +1553,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.rotate_left(v1 as u32);
 
                 trace!("Instruction: i32.rotl [{v2} {v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_ROTR => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
@@ -1562,7 +1562,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.rotate_right(v1 as u32);
 
                 trace!("Instruction: i32.rotr [{v2} {v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             F32_ABS => {
@@ -1570,49 +1570,49 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.abs();
 
                 trace!("Instruction: f32.abs [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_NEG => {
                 let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = v1.neg();
 
                 trace!("Instruction: f32.neg [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_CEIL => {
                 let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = v1.ceil();
 
                 trace!("Instruction: f32.ceil [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_FLOOR => {
                 let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = v1.floor();
 
                 trace!("Instruction: f32.floor [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_TRUNC => {
                 let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = v1.trunc();
 
                 trace!("Instruction: f32.trunc [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_NEAREST => {
                 let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = v1.nearest();
 
                 trace!("Instruction: f32.nearest [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_SQRT => {
                 let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = v1.sqrt();
 
                 trace!("Instruction: f32.sqrt [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_ADD => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1620,7 +1620,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 + v2;
 
                 trace!("Instruction: f32.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_SUB => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1628,7 +1628,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 - v2;
 
                 trace!("Instruction: f32.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_MUL => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1636,7 +1636,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 * v2;
 
                 trace!("Instruction: f32.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_DIV => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1644,7 +1644,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 / v2;
 
                 trace!("Instruction: f32.div [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_MIN => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1652,7 +1652,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.min(v2);
 
                 trace!("Instruction: f32.min [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_MAX => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1660,7 +1660,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.max(v2);
 
                 trace!("Instruction: f32.max [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_COPYSIGN => {
                 let v2: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1668,7 +1668,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.copysign(v2);
 
                 trace!("Instruction: f32.copysign [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             F64_ABS => {
@@ -1676,49 +1676,49 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.abs();
 
                 trace!("Instruction: f64.abs [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_NEG => {
                 let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = v1.neg();
 
                 trace!("Instruction: f64.neg [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_CEIL => {
                 let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = v1.ceil();
 
                 trace!("Instruction: f64.ceil [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_FLOOR => {
                 let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = v1.floor();
 
                 trace!("Instruction: f64.floor [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_TRUNC => {
                 let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = v1.trunc();
 
                 trace!("Instruction: f64.trunc [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_NEAREST => {
                 let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = v1.nearest();
 
                 trace!("Instruction: f64.nearest [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_SQRT => {
                 let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = v1.sqrt();
 
                 trace!("Instruction: f64.sqrt [{v1}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_ADD => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1726,7 +1726,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 + v2;
 
                 trace!("Instruction: f64.add [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_SUB => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1734,7 +1734,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 - v2;
 
                 trace!("Instruction: f64.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_MUL => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1742,7 +1742,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 * v2;
 
                 trace!("Instruction: f64.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_DIV => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1750,7 +1750,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 / v2;
 
                 trace!("Instruction: f64.div [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_MIN => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1758,7 +1758,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.min(v2);
 
                 trace!("Instruction: f64.min [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_MAX => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1766,7 +1766,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.max(v2);
 
                 trace!("Instruction: f64.max [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_COPYSIGN => {
                 let v2: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1774,14 +1774,14 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.copysign(v2);
 
                 trace!("Instruction: f64.copysign [{v1} {v2}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_WRAP_I64 => {
                 let v: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res: i32 = v as i32;
 
                 trace!("Instruction: i32.wrap_i64 [{v}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_TRUNC_F32_S => {
                 let v: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1798,7 +1798,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_i32();
 
                 trace!("Instruction: i32.trunc_f32_s [{v:.7}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_TRUNC_F32_U => {
                 let v: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1815,7 +1815,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_u32() as i32;
 
                 trace!("Instruction: i32.trunc_f32_u [{v:.7}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I32_TRUNC_F64_S => {
@@ -1833,7 +1833,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_i32();
 
                 trace!("Instruction: i32.trunc_f64_s [{v:.7}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_TRUNC_F64_U => {
                 let v: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1850,7 +1850,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_u32() as i32;
 
                 trace!("Instruction: i32.trunc_f32_u [{v:.7}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I64_EXTEND_I32_S => {
@@ -1859,7 +1859,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v as i64;
 
                 trace!("Instruction: i64.extend_i32_s [{v}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I64_EXTEND_I32_U => {
@@ -1868,7 +1868,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v as u32 as i64;
 
                 trace!("Instruction: i64.extend_i32_u [{v}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I64_TRUNC_F32_S => {
@@ -1887,7 +1887,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_i64();
 
                 trace!("Instruction: i64.trunc_f32_s [{v:.7}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_TRUNC_F32_U => {
                 let v: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -1904,7 +1904,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_u64() as i64;
 
                 trace!("Instruction: i64.trunc_f32_u [{v:.7}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
 
             I64_TRUNC_F64_S => {
@@ -1923,7 +1923,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_i64();
 
                 trace!("Instruction: i64.trunc_f64_s [{v:.17}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_TRUNC_F64_U => {
                 let v: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -1940,110 +1940,110 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_u64() as i64;
 
                 trace!("Instruction: i64.trunc_f64_u [{v:.17}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_CONVERT_I32_S => {
                 let v: i32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = value::F32(v as f32);
 
                 trace!("Instruction: f32.convert_i32_s [{v}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_CONVERT_I32_U => {
                 let v: i32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = value::F32(v as u32 as f32);
 
                 trace!("Instruction: f32.convert_i32_u [{v}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_CONVERT_I64_S => {
                 let v: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = value::F32(v as f32);
 
                 trace!("Instruction: f32.convert_i64_s [{v}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_CONVERT_I64_U => {
                 let v: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = value::F32(v as u64 as f32);
 
                 trace!("Instruction: f32.convert_i64_u [{v}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_DEMOTE_F64 => {
                 let v: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = v.as_f32();
 
                 trace!("Instruction: f32.demote_f64 [{v:.17}] -> [{res:.7}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_CONVERT_I32_S => {
                 let v: i32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = value::F64(v as f64);
 
                 trace!("Instruction: f64.convert_i32_s [{v}] -> [{res:.17}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_CONVERT_I32_U => {
                 let v: i32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = value::F64(v as u32 as f64);
 
                 trace!("Instruction: f64.convert_i32_u [{v}] -> [{res:.17}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_CONVERT_I64_S => {
                 let v: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = value::F64(v as f64);
 
                 trace!("Instruction: f64.convert_i64_s [{v}] -> [{res:.17}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_CONVERT_I64_U => {
                 let v: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = value::F64(v as u64 as f64);
 
                 trace!("Instruction: f64.convert_i64_u [{v}] -> [{res:.17}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_PROMOTE_F32 => {
                 let v: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = v.as_f64();
 
                 trace!("Instruction: f64.promote_f32 [{v:.7}] -> [{res:.17}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I32_REINTERPRET_F32 => {
                 let v: value::F32 = stack.pop_value().try_into().unwrap_validated();
                 let res: i32 = v.reinterpret_as_i32();
 
                 trace!("Instruction: i32.reinterpret_f32 [{v:.7}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             I64_REINTERPRET_F64 => {
                 let v: value::F64 = stack.pop_value().try_into().unwrap_validated();
                 let res: i64 = v.reinterpret_as_i64();
 
                 trace!("Instruction: i64.reinterpret_f64 [{v:.17}] -> [{res}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F32_REINTERPRET_I32 => {
                 let v1: i32 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F32 = value::F32::from_bits(v1 as u32);
 
                 trace!("Instruction: f32.reinterpret_i32 [{v1}] -> [{res:.7}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             F64_REINTERPRET_I64 => {
                 let v1: i64 = stack.pop_value().try_into().unwrap_validated();
                 let res: value::F64 = value::F64::from_bits(v1 as u64);
 
                 trace!("Instruction: f64.reinterpret_i64 [{v1}] -> [{res:.17}]");
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
             }
             REF_NULL => {
                 let reftype = RefType::read(wasm).unwrap_validated();
 
-                stack.push_value(Value::Ref(Ref::Null(reftype)))?;
+                stack.push_value::<T>(Value::Ref(Ref::Null(reftype)))?;
                 trace!("Instruction: ref.null '{:?}' -> [{:?}]", reftype, reftype);
             }
             REF_IS_NULL => {
@@ -2052,7 +2052,7 @@ pub(super) fn run<T: Config>(
 
                 let res = if is_null { 1 } else { 0 };
                 trace!("Instruction: ref.is_null [{}] -> [{}]", rref, res);
-                stack.push_value(Value::I32(res))?;
+                stack.push_value::<T>(Value::I32(res))?;
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-ref-mathsf-ref-func-x
             REF_FUNC => {
@@ -2061,7 +2061,7 @@ pub(super) fn run<T: Config>(
                     .func_addrs
                     .get(func_idx)
                     .unwrap_validated();
-                stack.push_value(Value::Ref(Ref::Func(FuncAddr(func_addr))))?;
+                stack.push_value::<T>(Value::Ref(Ref::Func(FuncAddr(func_addr))))?;
             }
             FC_EXTENSIONS => {
                 // Should we call instruction hook here as well? Multibyte instruction
@@ -2084,7 +2084,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f32_s [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     I32_TRUNC_SAT_F32_U => {
                         let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -2099,7 +2099,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f32_u [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     I32_TRUNC_SAT_F64_S => {
                         let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -2116,7 +2116,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f64_s [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     I32_TRUNC_SAT_F64_U => {
                         let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -2131,7 +2131,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f64_u [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     I64_TRUNC_SAT_F32_S => {
                         let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -2148,7 +2148,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f32_s [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     I64_TRUNC_SAT_F32_U => {
                         let v1: value::F32 = stack.pop_value().try_into().unwrap_validated();
@@ -2163,7 +2163,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f32_u [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     I64_TRUNC_SAT_F64_S => {
                         let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -2180,7 +2180,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f64_s [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     I64_TRUNC_SAT_F64_U => {
                         let v1: value::F64 = stack.pop_value().try_into().unwrap_validated();
@@ -2195,7 +2195,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f64_u [{v1}] -> [{res}]");
-                        stack.push_value(res.into())?;
+                        stack.push_value::<T>(res.into())?;
                     }
                     // See https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-init-x
                     // Copy a region from a data segment into memory
@@ -2426,10 +2426,10 @@ pub(super) fn run<T: Config>(
                         // if the grow operation fails, err := Value::I32(2^32-1) is pushed to the stack per spec
                         match tab.grow(n, val) {
                             Ok(_) => {
-                                stack.push_value(Value::I32(sz))?;
+                                stack.push_value::<T>(Value::I32(sz))?;
                             }
                             Err(_) => {
-                                stack.push_value(Value::I32(u32::MAX))?;
+                                stack.push_value::<T>(Value::I32(u32::MAX))?;
                             }
                         }
                     }
@@ -2443,7 +2443,7 @@ pub(super) fn run<T: Config>(
 
                         let sz = tab.elem.len() as u32;
 
-                        stack.push_value(Value::I32(sz))?;
+                        stack.push_value::<T>(Value::I32(sz))?;
 
                         trace!("Instruction: table.size '{}' [] -> [{}]", table_idx, sz);
                     }
@@ -2490,7 +2490,7 @@ pub(super) fn run<T: Config>(
 
                 let res = if v | 0x7F != 0x7F { v | 0xFFFFFF00 } else { v };
 
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
 
                 trace!("Instruction i32.extend8_s [{}] -> [{}]", v, res);
             }
@@ -2508,7 +2508,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
 
                 trace!("Instruction i32.extend16_s [{}] -> [{}]", v, res);
             }
@@ -2526,7 +2526,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
 
                 trace!("Instruction i64.extend8_s [{}] -> [{}]", v, res);
             }
@@ -2544,7 +2544,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
 
                 trace!("Instruction i64.extend16_s [{}] -> [{}]", v, res);
             }
@@ -2562,7 +2562,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value(res.into())?;
+                stack.push_value::<T>(res.into())?;
 
                 trace!("Instruction i64.extend32_s [{}] -> [{}]", v, res);
             }
@@ -2584,7 +2584,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let data: u128 = memory.mem.load(idx)?;
-                        stack.push_value(data.to_le_bytes().into())?;
+                        stack.push_value::<T>(data.to_le_bytes().into())?;
                     }
                     V128_STORE => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2622,7 +2622,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as i16);
 
-                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD8X8_U => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2644,7 +2644,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as u16);
 
-                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD16X4_S => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2666,7 +2666,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as i32);
 
-                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD16X4_U => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2688,7 +2688,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as u32);
 
-                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD32X2_S => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2710,7 +2710,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as i64);
 
-                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD32X2_U => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2732,7 +2732,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as u64);
 
-                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
                     }
 
                     // v128.loadN_splat
@@ -2747,7 +2747,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<1, u8>(idx)?;
-                        stack.push_value(Value::V128(from_lanes([lane; 16])))?;
+                        stack.push_value::<T>(Value::V128(from_lanes([lane; 16])))?;
                     }
                     V128_LOAD16_SPLAT => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2760,7 +2760,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<2, u16>(idx)?;
-                        stack.push_value(Value::V128(from_lanes([lane; 8])))?;
+                        stack.push_value::<T>(Value::V128(from_lanes([lane; 8])))?;
                     }
                     V128_LOAD32_SPLAT => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2773,7 +2773,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<4, u32>(idx)?;
-                        stack.push_value(Value::V128(from_lanes([lane; 4])))?;
+                        stack.push_value::<T>(Value::V128(from_lanes([lane; 4])))?;
                     }
                     V128_LOAD64_SPLAT => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2786,7 +2786,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<8, u64>(idx)?;
-                        stack.push_value(Value::V128(from_lanes([lane; 2])))?;
+                        stack.push_value::<T>(Value::V128(from_lanes([lane; 2])))?;
                     }
 
                     // v128.loadN_zero
@@ -2802,7 +2802,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let data = memory.mem.load::<4, u32>(idx)? as u128;
-                        stack.push_value(Value::V128(data.to_le_bytes()))?;
+                        stack.push_value::<T>(Value::V128(data.to_le_bytes()))?;
                     }
                     V128_LOAD64_ZERO => {
                         let memarg = MemArg::read(wasm).unwrap_validated();
@@ -2816,7 +2816,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let data = memory.mem.load::<8, u64>(idx)? as u128;
-                        stack.push_value(Value::V128(data.to_le_bytes()))?;
+                        stack.push_value::<T>(Value::V128(data.to_le_bytes()))?;
                     }
 
                     // v128.loadN_lane
@@ -2834,7 +2834,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u8; 16] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<1, u8>(idx)?;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
 
                     V128_LOAD16_LANE => {
@@ -2851,7 +2851,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u16; 8] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<2, u16>(idx)?;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
                     V128_LOAD32_LANE => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -2867,7 +2867,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u32; 4] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<4, u32>(idx)?;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
                     V128_LOAD64_LANE => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -2883,7 +2883,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u64; 2] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<8, u64>(idx)?;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
 
                     // v128.storeN_lane
@@ -2958,13 +2958,13 @@ pub(super) fn run<T: Config>(
                             *byte_ref = wasm.read_u8().unwrap_validated();
                         }
 
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
 
                     // vvunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvunop>
                     V128_NOT => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
-                        stack.push_value(Value::V128(data.map(|byte| !byte)))?;
+                        stack.push_value::<T>(Value::V128(data.map(|byte| !byte)))?;
                     }
 
                     // vvbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvbinop>
@@ -2972,25 +2972,25 @@ pub(super) fn run<T: Config>(
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] & data2[i]);
-                        stack.push_value(Value::V128(result))?;
+                        stack.push_value::<T>(Value::V128(result))?;
                     }
                     V128_ANDNOT => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] & !data2[i]);
-                        stack.push_value(Value::V128(result))?;
+                        stack.push_value::<T>(Value::V128(result))?;
                     }
                     V128_OR => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] | data2[i]);
-                        stack.push_value(Value::V128(result))?;
+                        stack.push_value::<T>(Value::V128(result))?;
                     }
                     V128_XOR => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] ^ data2[i]);
-                        stack.push_value(Value::V128(result))?;
+                        stack.push_value::<T>(Value::V128(result))?;
                     }
 
                     // vvternop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvternop>
@@ -3000,14 +3000,14 @@ pub(super) fn run<T: Config>(
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result =
                             array::from_fn(|i| (data1[i] & data3[i]) | (data2[i] & !data3[i]));
-                        stack.push_value(Value::V128(result))?;
+                        stack.push_value::<T>(Value::V128(result))?;
                     }
 
                     // vvtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvtestop>
                     V128_ANY_TRUE => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let any_true = data.into_iter().any(|byte| byte > 0);
-                        stack.push_value(Value::I32(any_true as u32))?;
+                        stack.push_value::<T>(Value::I32(any_true as u32))?;
                     }
 
                     I8X16_SWIZZLE => {
@@ -3015,7 +3015,7 @@ pub(super) fn run<T: Config>(
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result =
                             array::from_fn(|i| *data1.get(data2[i] as usize).unwrap_or(&0));
-                        stack.push_value(Value::V128(result))?;
+                        stack.push_value::<T>(Value::V128(result))?;
                     }
 
                     I8X16_SHUFFLE => {
@@ -3032,7 +3032,7 @@ pub(super) fn run<T: Config>(
                                 .unwrap_validated()
                         });
 
-                        stack.push_value(Value::V128(result))?;
+                        stack.push_value::<T>(Value::V128(result))?;
                     }
 
                     // shape.splat
@@ -3040,33 +3040,33 @@ pub(super) fn run<T: Config>(
                         let value: u32 = stack.pop_value().try_into().unwrap_validated();
                         let lane = value as u8;
                         let data = from_lanes([lane; 16]);
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
                     I16X8_SPLAT => {
                         let value: u32 = stack.pop_value().try_into().unwrap_validated();
                         let lane = value as u16;
                         let data = from_lanes([lane; 8]);
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
                     I32X4_SPLAT => {
                         let lane: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 4]);
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
                     I64X2_SPLAT => {
                         let lane: u64 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 2]);
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
                     F32X4_SPLAT => {
                         let lane: F32 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 4]);
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
                     F64X2_SPLAT => {
                         let lane: F64 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 2]);
-                        stack.push_value(Value::V128(data))?;
+                        stack.push_value::<T>(Value::V128(data))?;
                     }
 
                     // shape.extract_lane
@@ -3075,56 +3075,56 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::I32(lane as u32))?;
+                        stack.push_value::<T>(Value::I32(lane as u32))?;
                     }
                     I8X16_EXTRACT_LANE_U => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::I32(lane as u32))?;
+                        stack.push_value::<T>(Value::I32(lane as u32))?;
                     }
                     I16X8_EXTRACT_LANE_S => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::I32(lane as u32))?;
+                        stack.push_value::<T>(Value::I32(lane as u32))?;
                     }
                     I16X8_EXTRACT_LANE_U => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::I32(lane as u32))?;
+                        stack.push_value::<T>(Value::I32(lane as u32))?;
                     }
                     I32X4_EXTRACT_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::I32(lane))?;
+                        stack.push_value::<T>(Value::I32(lane))?;
                     }
                     I64X2_EXTRACT_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::I64(lane))?;
+                        stack.push_value::<T>(Value::I64(lane))?;
                     }
                     F32X4_EXTRACT_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::F32(lane))?;
+                        stack.push_value::<T>(Value::F32(lane))?;
                     }
                     F64X2_EXTRACT_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value(Value::F64(lane))?;
+                        stack.push_value::<T>(Value::F64(lane))?;
                     }
 
                     // shape.replace_lane
@@ -3135,7 +3135,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u8; 16] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
                     I16X8_REPLACE_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
@@ -3144,7 +3144,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u16; 8] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
                     I32X4_REPLACE_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
@@ -3152,7 +3152,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u32; 4] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
                     I64X2_REPLACE_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
@@ -3160,7 +3160,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u64; 2] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
                     F32X4_REPLACE_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
@@ -3168,7 +3168,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [F32; 4] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
                     F64X2_REPLACE_LANE => {
                         let lane_idx = wasm.read_u8().unwrap_validated() as usize;
@@ -3176,7 +3176,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [F64; 2] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
 
                     // Group vunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vunop>
@@ -3185,141 +3185,141 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let result: [i8; 16] = lanes.map(i8::wrapping_abs);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ABS => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let result: [i16; 8] = lanes.map(i16::wrapping_abs);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_ABS => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [i32; 4] = lanes.map(i32::wrapping_abs);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_ABS => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i64; 2] = to_lanes(data);
                         let result: [i64; 2] = lanes.map(i64::wrapping_abs);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_NEG => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let result: [i8; 16] = lanes.map(i8::wrapping_neg);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NEG => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let result: [i16; 8] = lanes.map(i16::wrapping_neg);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_NEG => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [i32; 4] = lanes.map(i32::wrapping_neg);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_NEG => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i64; 2] = to_lanes(data);
                         let result: [i64; 2] = lanes.map(i64::wrapping_neg);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     // vfunop
                     F32X4_ABS => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.abs());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_ABS => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.abs());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_NEG => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_NEG => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_SQRT => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.sqrt());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_SQRT => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.sqrt());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_CEIL => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.ceil());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_CEIL => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.ceil());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_FLOOR => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.floor());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_FLOOR => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.floor());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_TRUNC => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.trunc());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_TRUNC => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.trunc());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_NEAREST => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.nearest());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_NEAREST => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.nearest());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     // others
                     I8X16_POPCNT => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let result: [u8; 16] = lanes.map(|lane| lane.count_ones() as u8);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vbinop>
@@ -3331,7 +3331,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ADD => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3340,7 +3340,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_ADD => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3349,7 +3349,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_ADD => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3358,7 +3358,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [u64; 2] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SUB => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3367,7 +3367,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SUB => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3376,7 +3376,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SUB => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3385,7 +3385,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SUB => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3394,7 +3394,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [u64; 2] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     // vfbinop
                     F32X4_ADD => {
@@ -3403,7 +3403,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_ADD => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3411,7 +3411,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_SUB => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3419,7 +3419,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_SUB => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3427,7 +3427,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_MUL => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3435,7 +3435,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].mul(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_MUL => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3443,7 +3443,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].mul(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_DIV => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3451,7 +3451,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].div(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_DIV => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3459,7 +3459,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].div(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_MIN => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3467,7 +3467,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_MIN => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3475,7 +3475,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_MAX => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3483,7 +3483,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_MAX => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3491,7 +3491,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_PMIN => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3507,7 +3507,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_PMIN => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3523,7 +3523,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_PMAX => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3539,7 +3539,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_PMAX => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3555,7 +3555,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     // viminmaxop
                     I8X16_MIN_S => {
@@ -3564,7 +3564,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i8; 16] = to_lanes(data2);
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MIN_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3572,7 +3572,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i16; 8] = to_lanes(data2);
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MIN_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3580,7 +3580,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i32; 4] = to_lanes(data2);
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_MIN_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3588,7 +3588,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u8; 16] = to_lanes(data2);
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MIN_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3596,7 +3596,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u16; 8] = to_lanes(data2);
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MIN_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3604,7 +3604,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u32; 4] = to_lanes(data2);
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_MAX_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3612,7 +3612,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i8; 16] = to_lanes(data2);
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MAX_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3620,7 +3620,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i16; 8] = to_lanes(data2);
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MAX_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3628,7 +3628,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i32; 4] = to_lanes(data2);
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_MAX_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3636,7 +3636,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u8; 16] = to_lanes(data2);
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MAX_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3644,7 +3644,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u16; 8] = to_lanes(data2);
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MAX_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3652,7 +3652,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u32; 4] = to_lanes(data2);
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     // visatbinop
@@ -3663,7 +3663,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ADD_SAT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3672,7 +3672,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_ADD_SAT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3681,7 +3681,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ADD_SAT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3690,7 +3690,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SUB_SAT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3699,7 +3699,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SUB_SAT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3708,7 +3708,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SUB_SAT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3717,7 +3717,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SUB_SAT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3726,7 +3726,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     // others
                     I16X8_MUL => {
@@ -3736,7 +3736,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].wrapping_mul(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MUL => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3745,7 +3745,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] =
                             array::from_fn(|i| lanes1[i].wrapping_mul(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_MUL => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3754,7 +3754,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [u64; 2] =
                             array::from_fn(|i| lanes1[i].wrapping_mul(lanes2[i]));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_AVGR_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3764,7 +3764,7 @@ pub(super) fn run<T: Config>(
                         let result: [u8; 16] = array::from_fn(|i| {
                             (lanes1[i] as u16 + lanes2[i] as u16).div_ceil(2) as u8
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_AVGR_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3774,7 +3774,7 @@ pub(super) fn run<T: Config>(
                         let result: [u16; 8] = array::from_fn(|i| {
                             (lanes1[i] as u32 + lanes2[i] as u32).div_ceil(2) as u16
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_Q15MULRSAT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3786,7 +3786,7 @@ pub(super) fn run<T: Config>(
                                 .clamp(i16::MIN as i64, i16::MAX as i64)
                                 as i16
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vrelop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vrelop>
@@ -3798,7 +3798,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EQ => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3807,7 +3807,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EQ => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3816,7 +3816,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EQ => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3825,7 +3825,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_NE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3834,7 +3834,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3843,7 +3843,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_NE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3852,7 +3852,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_NE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3861,7 +3861,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3870,7 +3870,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3879,7 +3879,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3888,7 +3888,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_LT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3897,7 +3897,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3906,7 +3906,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3915,7 +3915,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3924,7 +3924,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_GT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3933,7 +3933,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3942,7 +3942,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3951,7 +3951,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_GT_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3960,7 +3960,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_GT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3969,7 +3969,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3978,7 +3978,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GT_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3987,7 +3987,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LE_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3996,7 +3996,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LE_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4005,7 +4005,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LE_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4014,7 +4014,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_LE_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4023,7 +4023,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LE_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4032,7 +4032,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LE_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4041,7 +4041,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LE_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4050,7 +4050,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     I8X16_GE_S => {
@@ -4060,7 +4060,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GE_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4069,7 +4069,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GE_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4078,7 +4078,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_GE_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4087,7 +4087,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_GE_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4096,7 +4096,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i8).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GE_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4105,7 +4105,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i16).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GE_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4114,7 +4114,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     // vfrelop
                     F32X4_EQ => {
@@ -4124,7 +4124,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_EQ => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4133,7 +4133,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_NE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4142,7 +4142,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_NE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4151,7 +4151,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_LT => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4160,7 +4160,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_LT => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4169,7 +4169,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_GT => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4178,7 +4178,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_GT => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4187,7 +4187,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_LE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4196,7 +4196,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_LE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4205,7 +4205,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_GE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4214,7 +4214,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i32).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_GE => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4223,7 +4223,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i64).neg());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vishiftop
@@ -4232,84 +4232,84 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let result: [u8; 16] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SHL => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let result: [u16; 8] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SHL => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let result: [u32; 4] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SHL => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let result: [u64; 2] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SHR_S => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let result: [i8; 16] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SHR_U => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let result: [u8; 16] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SHR_S => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let result: [i16; 8] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SHR_U => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let result: [u16; 8] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SHR_S => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [i32; 4] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SHR_U => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let result: [u32; 4] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SHR_S => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i64; 2] = to_lanes(data);
                         let result: [i64; 2] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SHR_U => {
                         let shift: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let result: [u64; 2] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vtestop>
@@ -4318,25 +4318,25 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value(Value::I32(all_true as u32))?;
+                        stack.push_value::<T>(Value::I32(all_true as u32))?;
                     }
                     I16X8_ALL_TRUE => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value(Value::I32(all_true as u32))?;
+                        stack.push_value::<T>(Value::I32(all_true as u32))?;
                     }
                     I32X4_ALL_TRUE => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value(Value::I32(all_true as u32))?;
+                        stack.push_value::<T>(Value::I32(all_true as u32))?;
                     }
                     I64X2_ALL_TRUE => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value(Value::I32(all_true as u32))?;
+                        stack.push_value::<T>(Value::I32(all_true as u32))?;
                     }
 
                     // Group vcvtop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vcvtop>
@@ -4345,84 +4345,84 @@ pub(super) fn run<T: Config>(
                         let lanes: [i8; 16] = to_lanes(data);
                         let high_lanes: [i8; 8] = lanes[8..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as i16);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EXTEND_HIGH_I8X16_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let high_lanes: [u8; 8] = lanes[8..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as u16);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EXTEND_LOW_I8X16_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let low_lanes: [i8; 8] = lanes[..8].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as i16);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EXTEND_LOW_I8X16_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let low_lanes: [u8; 8] = lanes[..8].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as u16);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_HIGH_I16X8_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let high_lanes: [i16; 4] = lanes[4..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as i32);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_HIGH_I16X8_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let high_lanes: [u16; 4] = lanes[4..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as u32);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_LOW_I16X8_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let low_lanes: [i16; 4] = lanes[..4].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as i32);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_LOW_I16X8_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let low_lanes: [u16; 4] = lanes[..4].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as u32);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_HIGH_I32X4_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let high_lanes: [i32; 2] = lanes[2..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as i64);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_HIGH_I32X4_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let high_lanes: [u32; 2] = lanes[2..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as u64);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_LOW_I32X4_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let low_lanes: [i32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as i64);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_LOW_I32X4_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let low_lanes: [u32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as u64);
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_TRUNC_SAT_F32X4_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4438,7 +4438,7 @@ pub(super) fn run<T: Config>(
                                 lane.as_i32()
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_TRUNC_SAT_F32X4_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4454,7 +4454,7 @@ pub(super) fn run<T: Config>(
                                 lane.as_u32()
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_TRUNC_SAT_F64X2_S_ZERO => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4470,7 +4470,9 @@ pub(super) fn run<T: Config>(
                                 lane.as_i32()
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes([result[0], result[1], 0, 0])))?;
+                        stack.push_value::<T>(Value::V128(from_lanes([
+                            result[0], result[1], 0, 0,
+                        ])))?;
                     }
                     I32X4_TRUNC_SAT_F64X2_U_ZERO => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4486,47 +4488,49 @@ pub(super) fn run<T: Config>(
                                 lane.as_u32()
                             }
                         });
-                        stack.push_value(Value::V128(from_lanes([result[0], result[1], 0, 0])))?;
+                        stack.push_value::<T>(Value::V128(from_lanes([
+                            result[0], result[1], 0, 0,
+                        ])))?;
                     }
                     F32X4_CONVERT_I32X4_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| F32(lane as f32));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_CONVERT_I32X4_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| F32(lane as f32));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_CONVERT_LOW_I32X4_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let low_lanes: [i32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| F64(lane as f64));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_CONVERT_LOW_I32X4_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let low_lanes: [u32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| F64(lane as f64));
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_DEMOTE_F64X2_ZERO => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes = to_lanes::<8, 2, F64>(data);
                         let half_lanes = lanes.map(|lane| lane.as_f32());
                         let result = [half_lanes[0], half_lanes[1], F32(0.0), F32(0.0)];
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_PROMOTE_LOW_F32X4 => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let half_lanes: [F32; 2] = lanes[..2].try_into().unwrap();
                         let result = half_lanes.map(|lane| lane.as_f64());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     // ishape.narrow_ishape_sx
@@ -4541,7 +4545,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(i8::MIN as i16, i8::MAX as i16) as i8);
                         let result: [i8; 16] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_NARROW_I16X8_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4554,7 +4558,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(u8::MIN as i16, u8::MAX as i16) as u8);
                         let result: [u8; 16] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NARROW_I32X4_S => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4567,7 +4571,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(i16::MIN as i32, i16::MAX as i32) as i16);
                         let result: [i16; 8] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NARROW_I32X4_U => {
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4580,7 +4584,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(u16::MIN as i32, u16::MAX as i32) as u16);
                         let result: [u16; 8] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value(Value::V128(from_lanes(result)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
                     // ishape.bitmask
@@ -4592,7 +4596,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value(Value::I32(bitmask))?;
+                        stack.push_value::<T>(Value::I32(bitmask))?;
                     }
                     I16X8_BITMASK => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4602,7 +4606,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value(Value::I32(bitmask))?;
+                        stack.push_value::<T>(Value::I32(bitmask))?;
                     }
                     I32X4_BITMASK => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4612,7 +4616,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value(Value::I32(bitmask))?;
+                        stack.push_value::<T>(Value::I32(bitmask))?;
                     }
                     I64X2_BITMASK => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4622,7 +4626,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value(Value::I32(bitmask))?;
+                        stack.push_value::<T>(Value::I32(bitmask))?;
                     }
 
                     // ishape.dot_ishape_s
@@ -4641,7 +4645,7 @@ pub(super) fn run<T: Config>(
                             let v2 = multiplied[2 * i + 1];
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(added)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(added)))?;
                     }
 
                     // ishape.extmul_half_ishape_sx
@@ -4657,7 +4661,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I16X8_EXTMUL_HIGH_I8X16_U => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4671,7 +4675,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I16X8_EXTMUL_LOW_I8X16_S => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4685,7 +4689,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I16X8_EXTMUL_LOW_I8X16_U => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4699,7 +4703,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_HIGH_I16X8_S => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4713,7 +4717,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_HIGH_I16X8_U => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4727,7 +4731,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_LOW_I16X8_S => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4741,7 +4745,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_LOW_I16X8_U => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4755,7 +4759,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_HIGH_I32X4_S => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4769,7 +4773,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_HIGH_I32X4_U => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4783,7 +4787,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_LOW_I32X4_S => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4797,7 +4801,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_LOW_I32X4_U => {
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4811,7 +4815,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
                     }
 
                     // ishape.extadd_pairwise_ishape_sx
@@ -4823,7 +4827,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as i16;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
                     }
                     I16X8_EXTADD_PAIRWISE_I8X16_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4833,7 +4837,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as u16;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
                     }
                     I32X4_EXTADD_PAIRWISE_I16X8_S => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4843,7 +4847,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as i32;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
                     }
                     I32X4_EXTADD_PAIRWISE_I16X8_U => {
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -4853,7 +4857,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as u32;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
                     }
 
                     // Unimplemented or invalid instructions

--- a/src/execution/store.rs
+++ b/src/execution/store.rs
@@ -605,7 +605,7 @@ impl<'b, T: Config> Store<'b, T> {
                         // Prepare a new stack with the locals for the entry function
                         let mut stack = Stack::new_with_values(params);
 
-                        stack.push_call_frame(
+                        stack.push_call_frame::<T>(
                             usize::MAX,
                             &wasm_func_inst.function_type,
                             &wasm_func_inst.locals,

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -1,14 +1,11 @@
 use alloc::vec::{Drain, Vec};
 
+use crate::config::Config;
 use crate::core::indices::LocalIdx;
 use crate::core::reader::types::{FuncType, ValType};
 use crate::execution::assert_validated::UnwrapValidatedExt;
 use crate::execution::value::Value;
 use crate::RuntimeError;
-
-// TODO make these configurable
-const MAX_VALUE_STACK_SIZE: usize = 0xf0000; // 64 Kibi-Values
-const MAX_CALL_STACK_SIZE: usize = 0x1000; // 4 Kibi-Functions
 
 /// The stack at runtime containing
 /// 1. Values
@@ -67,9 +64,9 @@ impl Stack {
     }
 
     /// Push a value to the value stack
-    pub fn push_value(&mut self, value: Value) -> Result<(), RuntimeError> {
+    pub fn push_value<C: Config>(&mut self, value: Value) -> Result<(), RuntimeError> {
         // check for value stack exhaustion
-        if self.values.len() > MAX_VALUE_STACK_SIZE {
+        if self.values.len() > C::MAX_VALUE_STACK_SIZE {
             return Err(RuntimeError::StackExhaustion);
         }
 
@@ -127,7 +124,7 @@ impl Stack {
     /// Push a call frame to the call stack
     ///
     /// Takes the current [`Self::values`]'s length as [`CallFrame::value_stack_base_idx`].
-    pub fn push_call_frame(
+    pub fn push_call_frame<C: Config>(
         &mut self,
         return_func_addr: usize,
         func_ty: &FuncType,
@@ -136,7 +133,7 @@ impl Stack {
         return_stp: usize,
     ) -> Result<(), RuntimeError> {
         // check for call stack exhaustion
-        if self.call_frame_count() > MAX_CALL_STACK_SIZE {
+        if self.call_frame_count() > C::MAX_CALL_STACK_SIZE {
             return Err(RuntimeError::StackExhaustion);
         }
 


### PR DESCRIPTION
### Pull Request Overview

Stacked on top of #278 

Moves maximum value stack size and call frame stack size into `Config`. I wrapped them in a separate Trait since the addition of the type variable on top of the stack percolated into `Resumable` and other related structures.

`StackConfig` requires to have implemented `Default` since `mem::take` within resume works only with types that implement it. 

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Benchmark Results

<!--
Remove this section if performance is likely unaffected

Put your benchmark results here
-->

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
