### PR TITLE
feat: config methods for fuel for each instruction

### DIFF
--- a/src/execution/config.rs
+++ b/src/execution/config.rs
@@ -49,6 +49,47 @@ pub trait Config {
     fn get_fd_extension_flat_cost(_instr: u32) -> u32 {
         1
     }
+
+    /// Amount of fuel to be deducted per element of a single byte instruction `instr` that executes in asymptotically
+    /// linear time with respect to one of the values it pops from the stack.
+    ///
+    /// In Wasm 2.0 specification, this applies to the following instructions:
+    /// - `MEMORY.GROW` of type `[n: i32] -> [i32]`
+    ///
+    /// The cost of the instruction is calculated as `cost := get_flat_cost(instr) + n*get_cost_per_element(instr)`.
+    /// where `n` is the stack value marked in the instruction type signature above. Other instructions and bytes that
+    /// do not correspond to any instruction are ignored.
+    // It must always be checked that the calls to this method fold into a constant if it is just a match statement that
+    // yields constants.
+    #[inline(always)]
+    fn get_cost_per_element(_instr: u8) -> u32 {
+        0
+    }
+
+    /// Amount of fuel to be deducted per element of a  multi-byte instruction that starts with the byte 0xFC,
+    /// which executes in asymptotically linear time with respect to one of the values it pops from the stack. This
+    /// method should return the cost of an instruction obtained by prepending 0xFD to of an unsigned 32-bit LEB
+    /// representation of `instr`. Multi-byte sequences obtained this way that do not correspond to any Wasm instruction
+    /// are ignored.
+    ///
+    /// In Wasm 2.0 specification, this applies to the following instructions:
+    /// - `MEMORY.INIT x`  of type `[d:i32 s: i32 n: i32] -> []`
+    /// - `MEMORY.FILL`    of type `[d: i32 val: i32 n: i32] -> []`
+    /// - `MEMORY.COPY`    of type `[d: i32 s: i32 n: i32] -> []`
+    /// - `TABLE.GROW x`   of type `[val: ref n: i32] -> [i32]`
+    /// - `TABLE.INIT x y` of type `[d: i32 s: i32 n: i32] -> []`
+    /// - `TABLE.FILL x`   of type `[i: i32 val: ref n: i32] -> []`
+    /// - `TABLE.COPY x y` of type `[d: i32 s: i32 n: i32] -> []`
+    ///
+    /// The cost of the instruction is calculated as `cost := get_flat_cost(instr) + n*get_cost_per_element(instr)`.
+    /// where `n` is the stack value marked in the instruction type signature above. Other instructions and multi-byte
+    /// sequences that do not correspond to any instruction are ignored.
+    // It must always be checked that the calls to this method fold into a constant if it is just a match statement that
+    // yields constants.
+    #[inline(always)]
+    fn get_fc_extension_cost_per_element(_instr: u32) -> u32 {
+        0
+    }
 }
 
 /// Default implementation of the interpreter configuration, with all hooks empty

--- a/src/execution/store/mod.rs
+++ b/src/execution/store/mod.rs
@@ -336,7 +336,7 @@ impl<'b, T: Config> Store<'b, T> {
                     table_idx: table_idx_i,
                     init_expr: einstr_i,
                 }) => {
-                    let n = elem_items.len() as i32;
+                    let n = elem_items.len() as u32;
                     // equivalent to init.len() in spec
                     // instantiation step 14:
                     // TODO (for now, we are doing hopefully what is equivalent to it)
@@ -384,7 +384,7 @@ impl<'b, T: Config> Store<'b, T> {
                     memory_idx,
                     offset: dinstr_i,
                 }) => {
-                    let n = init.len() as i32;
+                    let n = init.len() as u32;
                     // assert: mem_idx is 0
                     if *memory_idx != 0 {
                         // TODO fix error


### PR DESCRIPTION
This commit adds `Config::*_flat_cost()` methods in which the user can supply the fuel to be deducted when a particular instruction is fetched. In order to make sure simple implementations that match the instructions into constants are folded into a constant themselves in the interpreter loop the method is called in each match arm in the interpreter fetch loop instead of once at the beginning.

### Pull Request Overview

<!--
This pull request adds/changes/fixes...
-->

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Benchmark Results

<!--
Remove this section if performance is likely unaffected

Put your benchmark results here
-->

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
