### PR TITLE
feat: fuel metering in instantiation

### DIFF
--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -24,6 +24,8 @@ pub enum RuntimeError {
     /// It was attempted to register a symbol under a name for which a symbol already exists.
     RegistrySymbolAlreadyExists,
     MoreThanOneMemory,
+    /// Fueled execution that is not resumable has ran out of fuel.
+    OutOfFuel,
     /// The number of module exports did not match the number of extern values
     /// provided for instantiation.
     ExternValsLenMismatch,
@@ -73,6 +75,9 @@ impl Display for RuntimeError {
             ),
             RuntimeError::GlobalTypeMismatch => {
                 f.write_str("An alloc/write operation on a global failed due to a type mismatch")
+            }
+            RuntimeError::OutOfFuel => {
+                f.write_str("Fueled execution that is not resumable has ran out of fuel")
             }
             RuntimeError::ExternValsLenMismatch => {
                 f.write_str("The number of module exports did not match the number of extern values provided for instantiation.")

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -58,7 +58,7 @@ impl<'b, T: Config> RuntimeInstance<'b, T> {
         validation_info: &'_ ValidationInfo<'b>,
     ) -> Result<(Self, ModuleAddr), RuntimeError> {
         let mut instance = Self::new(user_data);
-        let module_addr = instance.add_module(DEFAULT_MODULE, validation_info)?;
+        let module_addr = instance.add_module(DEFAULT_MODULE, validation_info, None)?;
         Ok((instance, module_addr))
     }
 
@@ -70,17 +70,20 @@ impl<'b, T: Config> RuntimeInstance<'b, T> {
         // store: &mut Store,
     ) -> Result<(Self, ModuleAddr), RuntimeError> {
         let mut instance = Self::new(user_data);
-        let module_addr = instance.add_module(module_name, validation_info)?;
+        let module_addr = instance.add_module(module_name, validation_info, None)?;
         Ok((instance, module_addr))
     }
 
-    // Returns the module addr
+    // Returns the module addr. Invocation of the start function is optionally metered if `Some(fuel: u32)` is supplied
+    // to `maybe_fuel` (Returns `RuntimeError::OutOfFuel` in case of fuel depletion).
     pub fn add_module(
         &mut self,
         module_name: &str,
         validation_info: &'_ ValidationInfo<'b>,
+        maybe_fuel: Option<u32>,
     ) -> Result<ModuleAddr, RuntimeError> {
-        self.store.add_module(module_name, validation_info, None)
+        self.store
+            .add_module(module_name, validation_info, maybe_fuel)
     }
 
     pub fn get_module_by_name(&self, module_name: &str) -> Option<ModuleAddr> {

--- a/tests/fuel.rs
+++ b/tests/fuel.rs
@@ -241,3 +241,28 @@ fn resumable_drop() {
         RunState::Resumable { .. }
     ));
 }
+
+static FUELED_INITIALIZATION_WAT: &str = r#"(module
+    (func $start
+      (nop)
+    )
+    (start $start)
+)"#;
+
+#[test_log::test]
+fn fueled_initialization() {
+    let wasm_bytes = wat::parse_str(FUELED_INITIALIZATION_WAT).unwrap();
+    let validation_info = &validate(&wasm_bytes).expect("validation falied");
+    let mut runtime_instance = RuntimeInstance::new(());
+    let module = runtime_instance.add_module("module", validation_info, Some(2));
+    assert!(module.is_ok());
+}
+
+#[test_log::test]
+fn fueled_initialization_fail() {
+    let wasm_bytes = wat::parse_str(FUELED_INITIALIZATION_WAT).unwrap();
+    let validation_info = &validate(&wasm_bytes).expect("validation falied");
+    let mut runtime_instance = RuntimeInstance::new(());
+    let module = runtime_instance.add_module("module", validation_info, Some(0));
+    assert!(matches!(module, Err(wasm::RuntimeError::OutOfFuel)));
+}

--- a/tests/function_host.rs
+++ b/tests/function_host.rs
@@ -36,6 +36,7 @@ pub fn host_func_call_within_module() {
         .add_module(
             "importing_mod",
             &validate(&wasm_bytes).expect("validation failed"),
+            None,
         )
         .expect("instantiation failed");
     let function_ref = runtime_instance
@@ -76,6 +77,7 @@ pub fn host_func_call_as_start_func() {
         .add_module(
             "importing_mod",
             &validate(&wasm_bytes).expect("validation failed"),
+            None,
         )
         .expect("instantiation to be successful");
 }
@@ -102,6 +104,7 @@ pub fn host_func_call_within_start_func() {
         .add_module(
             "importing_mod",
             &validate(&wasm_bytes).expect("validation failed"),
+            None,
         )
         .expect("instantiation to be successful");
 }
@@ -144,6 +147,7 @@ pub fn simple_multivariate_host_func_within_module() {
         .add_module(
             "importing_mod",
             &validate(&wasm_bytes).expect("validation failed"),
+            None,
         )
         .expect("instantiation failed");
     let function_ref = runtime_instance
@@ -180,6 +184,7 @@ pub fn simple_multivariate_host_func_with_host_func_wrapper() {
         .add_module(
             "importing_mod",
             &validate(&wasm_bytes).expect("validation failed"),
+            None,
         )
         .expect("instantiation failed");
     let function_ref = runtime_instance
@@ -248,6 +253,7 @@ pub fn weird_multi_typed_host_func() {
         .add_module(
             "importing_mod",
             &validate(&wasm_bytes).expect("validation failed"),
+            None,
         )
         .expect("instantiation failed");
     let function_ref = runtime_instance
@@ -285,6 +291,7 @@ pub fn host_func_runtime_error() {
         .add_module(
             "importing_mod",
             &validate(&wasm_bytes).expect("validation failed"),
+            None,
         )
         .expect("instantiation failed");
     let function_ref = runtime_instance

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -88,7 +88,7 @@ pub fn compile_simple_import() {
     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let _module_base = instance
-        .add_module("base", &validation_info)
+        .add_module("base", &validation_info, None)
         .expect("Successful instantiation");
 
     // assert_eq!((), instance.invoke_typed_named("print_three", ()).unwrap());
@@ -106,7 +106,7 @@ pub fn run_simple_import() {
     let wasm_bytes = wat::parse_str(SIMPLE_IMPORT_BASE).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let module_base = instance
-        .add_module("base", &validation_info)
+        .add_module("base", &validation_info, None)
         .expect("instantiation failed");
 
     let get_three = instance.get_function_by_name("base", "get_three").unwrap();
@@ -127,7 +127,7 @@ pub fn run_call_indirect() {
     let wasm_bytes = wat::parse_str(CALL_INDIRECT_BASE).unwrap();
     let validation_info = validate(&wasm_bytes).expect("validation failed");
     let _module_base = instance
-        .add_module("base", &validation_info)
+        .add_module("base", &validation_info, None)
         .expect("Successful instantiation");
 
     let run = instance.get_function_by_name("base", "run").unwrap();

--- a/tests/specification/run.rs
+++ b/tests/specification/run.rs
@@ -124,7 +124,7 @@ fn validate_instantiate<'a, 'b: 'a>(
     // TODO change hacky hidden name that uses interpreter internals
     let module_name = format!("module_{}", modules.len());
     let module = catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-        interpreter.add_module(module_name.as_str(), &validation_info)
+        interpreter.add_module(module_name.as_str(), &validation_info, None)
     }))
     .map_err(WastError::Panic)??;
 
@@ -670,7 +670,7 @@ fn execute<'a>(
 
             let module_name = format!("module_{}", modules.len());
             let module_addr = catch_unwind_and_suppress_panic_handler(AssertUnwindSafe(|| {
-                interpreter.add_module(module_name.as_str(), &validation_info)
+                interpreter.add_module(module_name.as_str(), &validation_info, None)
             }))
             .map_err(WastError::Panic)??;
             modules.push(module_addr);


### PR DESCRIPTION
Module instantiation in Wasm includes the execution of a start function if specified. This start function might take arbitrarily long to execute. With this commit instantiation takes an optional fuel argument, failing instantiation if fuel is depleted.

There is no mechanism to resume initialization if fuel is depleted, the initialization simply fails. Additionally, the amount of least amount of fuel required to continue execution if execution fails is not returned as there is no way to continue execution anyway, and on a whole retry this required fuel would only pertain to the next instruction that would be executed, which is not very useful.

Related to #42 .

### Pull Request Overview

<!--
This pull request adds/changes/fixes...
-->

### TODO or Help Wanted

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo doc`

### Benchmark Results

<!--
Remove this section if performance is likely unaffected

Put your benchmark results here
-->

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
