### PR TITLE
Use cargo-nextest for Miri Tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -257,7 +257,7 @@
             #
             #
             # Run this to find unsafe `unsafe`:
-            # cargo miri test
+            # cargo miri nextest run
             #
             #
             # Run this to find unused dependencies:
@@ -274,6 +274,7 @@
                 })
                 cargo-llvm-cov
                 cargo-udeps
+                cargo-nextest
               ];
               env = { inherit (pkgs.cargo-llvm-cov) LLVM_COV LLVM_PROFDATA; };
             };


### PR DESCRIPTION
`cargo miri test` runs all tests on a single thread. On the other hand, nextest supports multi-threaded testing like this: `cargo miri nextest run`

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
