### PR TITLE
Allow Access to Linear Memory via `&mut [u8]`

### DIFF
--- a/src/execution/checked/mod.rs
+++ b/src/execution/checked/mod.rs
@@ -493,6 +493,22 @@ impl<'b, T: Config> Store<'b, T> {
             .map_err(|_| RuntimeError::FunctionInvocationSignatureMismatch)?;
         Ok(stored_returns)
     }
+
+    /// This is a safe variant of [`Store::mem_access_mut_slice`].
+    pub fn mem_access_mut_slice<R>(
+        &self,
+        memory: Stored<MemAddr>,
+        accessor: impl FnOnce(&mut [u8]) -> R,
+    ) -> Result<R, RuntimeError> {
+        // 1. try unwrap
+        let memory = memory.try_unwrap_into_bare(self.id)?;
+        // 2. call
+        let returns = self.mem_access_mut_slice_unchecked(memory, accessor);
+        // 3. rewrap
+        // result is generic
+        // 4. return
+        Ok(returns)
+    }
 }
 
 // All functions in this impl block must occur in the same order as they are

--- a/src/execution/store/linear_memory.rs
+++ b/src/execution/store/linear_memory.rs
@@ -459,6 +459,29 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
 
         Ok(())
     }
+
+    /// Allows a given closure to temporarily access the entire memory as a
+    /// `&mut [u8]`.
+    ///
+    /// # Note on locking
+    ///
+    /// This operation exclusively locks the entire linear memory for the
+    /// duration of this function call. To acquire the lock, this function may
+    /// also block until the lock is available.
+    pub fn access_mut_slice<R>(&self, accessor: impl FnOnce(&mut [u8]) -> R) -> R {
+        /// Converts an exclusively borrowed slice of atomic `u8`s to a slice of
+        /// non-atomic `u8`s
+        // TODO when `atomic_from_mut` is stabilized, replace this function with
+        // `Atomic::U8::get_mut_slice`
+        fn atomic_u8_get_mut_slice(slice: &mut [AtomicU8]) -> &mut [u8] {
+            // SAFETY: the mutable reference guarantees unique ownership
+            unsafe { &mut *(slice as *mut [AtomicU8] as *mut [u8]) }
+        }
+
+        let mut write_lock_guard = self.inner_data.write();
+        let non_atomic_slice = atomic_u8_get_mut_slice(&mut write_lock_guard);
+        accessor(non_atomic_slice)
+    }
 }
 
 impl<const PAGE_SIZE: usize> core::fmt::Debug for LinearMemory<PAGE_SIZE> {

--- a/src/execution/store/mod.rs
+++ b/src/execution/store/mod.rs
@@ -1302,6 +1302,20 @@ impl<'b, T: Config> Store<'b, T> {
                 })
             })
     }
+
+    /// Allows a given closure to temporarily access the entire memory as a
+    /// `&mut [u8]`.
+    ///
+    /// # Safety
+    /// The caller has to guarantee that the given [`MemAddr`] came from the
+    /// current [`Store`] object.
+    pub fn mem_access_mut_slice_unchecked<R>(
+        &self,
+        memory: MemAddr,
+        accessor: impl FnOnce(&mut [u8]) -> R,
+    ) -> R {
+        self.memories.get(memory).mem.access_mut_slice(accessor)
+    }
 }
 
 /// A unique identifier for a specific [`Store`]

--- a/tests/memory_as_slice.rs
+++ b/tests/memory_as_slice.rs
@@ -1,0 +1,46 @@
+use std::io::Write;
+
+use wasm::{Limits, MemType, Store};
+
+#[test_log::test]
+fn simple_byte_writes() {
+    let mut store = Store::new(());
+    let mem = store.mem_alloc(MemType {
+        limits: Limits { min: 1, max: None },
+    });
+
+    store
+        .mem_access_mut_slice(mem, |mem_as_slice| {
+            for (n, x) in mem_as_slice.into_iter().enumerate() {
+                *x = u8::try_from(n % 256).expect("this to never be larger than 255");
+            }
+        })
+        .unwrap();
+}
+
+#[test_log::test]
+fn interpret_as_str() {
+    let mut store = Store::new(());
+    let mem = store.mem_alloc(MemType {
+        limits: Limits { min: 1, max: None },
+    });
+
+    const STR_TO_WRITE: &str = "Hello World!";
+
+    // Write a string into the memory
+    store
+        .mem_access_mut_slice(mem, |mut mem_as_slice| {
+            let bytes_written = mem_as_slice.write(STR_TO_WRITE.as_bytes()).unwrap();
+            assert_eq!(bytes_written, 12);
+        })
+        .unwrap();
+
+    // Read the string again and check if it is equal to the original one
+    store
+        .mem_access_mut_slice(mem, |mem_as_slice| {
+            let bytes = &mem_as_slice[0..STR_TO_WRITE.as_bytes().len()];
+            let as_str = std::str::from_utf8(bytes).unwrap();
+            assert_eq!(as_str, STR_TO_WRITE);
+        })
+        .unwrap();
+}


### PR DESCRIPTION
This adds a new function to the `Store` that allows the caller to pass in a `impl FnOnce(&mut [u8]) -> R` through which a linear memory can be accessed as a `&mut [u8]` temporarily.

I was not able to use a `WriteLockGuard` to return the reference to the user, because of the way our `RwSpinLock` is designed.

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Benchmark Results

<!--
Remove this section if performance is likely unaffected

Put your benchmark results here
-->

### Github Issue

Closes https://github.com/DLR-FT/wasm-interpreter/issues/272
Closes https://github.com/DLR-FT/wasm-interpreter/issues/121
