### PR TITLE
rewrite URLs to W3C spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Multi-memory proposal, GC proposal
 ## Resources
 
 - `A fast in-place interpreter` by Ben L. Titzer: https://arxiv.org/abs/2205.01183
-- WebAssembly spec: https://webassembly.github.io/spec/core/index.html
+- WebAssembly spec: https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#types%E2%91%A6
 - WebAssembly Opcode Table: https://pengowray.github.io/wasm-ops/
 - Compiler/Interpreter Know-How Gist Compilation: https://gist.github.com/o11c/6b08643335388bbab0228db763f99219
 - Mozilla Developer Network WebAssembly Homepage: https://developer.mozilla.org/en-US/docs/WebAssembly

--- a/src/core/indices.rs
+++ b/src/core/indices.rs
@@ -1,9 +1,9 @@
 // /// This macro defines index types. Currently (2024-06-10) all indices are [`u32`].
-// /// See <https://webassembly.github.io/spec/core/binary/modules.html#indices> for more information.
+// /// See <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#indices%E2%91%A2> for more information.
 // macro_rules! def_idx_types {
 //     ($($name:ident),*) => {
 //         $(
-//             /// <https://webassembly.github.io/spec/core/binary/modules.html#indices>
+//             /// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#indices%E2%91%A2>
 //             pub type $name = usize;
 //         )*
 //     };

--- a/src/core/sidetable.rs
+++ b/src/core/sidetable.rs
@@ -23,7 +23,7 @@
 //! # Reference
 //!
 //! - Core / Syntax / Instructions / Control Instructions, WASM Spec,
-//!   <https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions>
+//!   <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#control-instructions%E2%91%A0>
 //! - "A fast in-place interpreter for WebAssembly", Ben L. Titzer,
 //!   <https://arxiv.org/abs/2205.01183>
 

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -2322,7 +2322,7 @@ pub(super) fn run<T: Config>(
                 trace!("Instruction: ref.is_null [{}] -> [{}]", rref, res);
                 stack.push_value::<T>(Value::I32(res))?;
             }
-            // https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-ref-mathsf-ref-func-x
+            // https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-refmathsfreffuncx%E2%91%A0
             REF_FUNC => {
                 decrement_fuel!(T::get_flat_cost(REF_FUNC));
                 let func_idx = wasm.read_var_u32().unwrap_validated() as FuncIdx;
@@ -2476,7 +2476,7 @@ pub(super) fn run<T: Config>(
                         trace!("Instruction: i64.trunc_sat_f64_u [{v1}] -> [{res}]");
                         stack.push_value::<T>(res.into())?;
                     }
-                    // See https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-init-x
+                    // See https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-memorymathsfmemoryinitx%E2%91%A0
                     // Copy a region from a data segment into memory
                     MEMORY_INIT => {
                         //  mappings:
@@ -2522,7 +2522,7 @@ pub(super) fn run<T: Config>(
                         let data_idx = wasm.read_var_u32().unwrap_validated() as DataIdx;
                         data_drop(&store.modules, &mut store.data, current_module, data_idx)?;
                     }
-                    // See https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-copy
+                    // See https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-memorymathsfmemorycopy%E2%91%A0
                     MEMORY_COPY => {
                         //  mappings:
                         //      n => number of bytes to copy
@@ -2573,7 +2573,7 @@ pub(super) fn run<T: Config>(
                             .copy(d as MemIdx, &src_mem.mem, s as MemIdx, n as MemIdx)?;
                         trace!("Instruction: memory.copy");
                     }
-                    // See https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-fill
+                    // See https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-memorymathsfmemoryfill%E2%91%A0
                     MEMORY_FILL => {
                         //  mappings:
                         //      n => number of bytes to update
@@ -2616,8 +2616,9 @@ pub(super) fn run<T: Config>(
 
                         trace!("Instruction: memory.fill");
                     }
-                    // https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-init-x-y
-                    // https://webassembly.github.io/spec/core/binary/instructions.html#table-instructions
+                    // https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-tablemathsftableinitxy%E2%91%A0
+
+                    // TODO https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#table-instructions%E2%91%A6
                     // in binary format it seems that elemidx is first ???????
                     // this is ONLY for passive elements
                     TABLE_INIT => {
@@ -2665,7 +2666,7 @@ pub(super) fn run<T: Config>(
                             elem_idx,
                         )?;
                     }
-                    // https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-copy-x-y
+                    // https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-tablemathsftablecopyxy%E2%91%A0
                     TABLE_COPY => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(TABLE_COPY));
                         let table_x_idx = wasm.read_var_u32().unwrap_validated() as usize;
@@ -3428,14 +3429,14 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::V128(data))?;
                     }
 
-                    // vvunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvunop>
+                    // vvunop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-valtypemathsfv128mathsfhrefsyntax-vvunopmathitvvunop%E2%91%A0
                     V128_NOT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_NOT));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         stack.push_value::<T>(Value::V128(data.map(|byte| !byte)))?;
                     }
 
-                    // vvbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvbinop>
+                    // vvbinop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-valtypemathsfv128mathsfhrefsyntax-vvbinopmathitvvbinop%E2%91%A0
                     V128_AND => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_AND));
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3465,7 +3466,7 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::V128(result))?;
                     }
 
-                    // vvternop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvternop>
+                    // vvternop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-valtypemathsfv128mathsfhrefsyntax-vvternopmathitvvternop%E2%91%A0
                     V128_BITSELECT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_BITSELECT));
                         let data3: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3476,7 +3477,7 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::V128(result))?;
                     }
 
-                    // vvtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvtestop>
+                    // vvtestop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-valtypemathsfv128mathsfhrefsyntax-instr-vecmathsfany_true
                     V128_ANY_TRUE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_ANY_TRUE));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -3675,7 +3676,7 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
                     }
 
-                    // Group vunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vunop>
+                    // Group vunop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-valtypemathsfv128mathsfhrefsyntax-vvunopmathitvvunop%E2%91%A0
                     // viunop
                     I8X16_ABS => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_ABS));
@@ -3841,7 +3842,7 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
-                    // Group vbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vbinop>
+                    // Group vbinop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instructions%E2%91%A0
                     // vibinop
                     I8X16_ADD => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_ADD));
@@ -4358,7 +4359,7 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
-                    // Group vrelop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vrelop>
+                    // Group vrelop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instructions%E2%91%A0
                     // virelop
                     I8X16_EQ => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_EQ));
@@ -4941,7 +4942,7 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::V128(from_lanes(result)))?;
                     }
 
-                    // Group vtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vtestop>
+                    // Group vtestop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instructions%E2%91%A0
                     // vitestop
                     I8X16_ALL_TRUE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_ALL_TRUE));
@@ -4972,7 +4973,7 @@ pub(super) fn run<T: Config>(
                         stack.push_value::<T>(Value::I32(all_true as u32))?;
                     }
 
-                    // Group vcvtop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vcvtop>
+                    // Group vcvtop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instructions%E2%91%A0
                     I16X8_EXTEND_HIGH_I8X16_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTEND_HIGH_I8X16_S));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
@@ -5613,7 +5614,7 @@ fn calculate_mem_address(memarg: &MemArg, relative_address: u32) -> Result<usize
         // The spec states that this should be a 33 bit integer, e.g. it is not legal to wrap if the
         // sum of offset and relative_address exceeds u32::MAX. To emulate this behavior, we use a
         // checked addition.
-        // See: https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
+        // See: https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instructions%E2%91%A0
         .checked_add(relative_address)
         .ok_or(TrapError::MemoryOrDataAccessOutOfBounds)?
         .try_into()

--- a/src/execution/store/linear_memory.rs
+++ b/src/execution/store/linear_memory.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Implementation of the linear memory suitable for concurrent access
 ///
 /// Implements the base for the instructions described in
-/// <https://webassembly.github.io/spec/core/exec/instructions.html#memory-instructions>.
+/// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instructions%E2%91%A4>.
 ///
 /// This linear memory implementation internally relies on a [`Vec<AtomicU8>`]. Thus, the atomic unit
 /// of information for it is a byte (`u8`). All access to the linear memory internally occur through
@@ -97,7 +97,7 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
     /// Size of a page in the linear memory, measured in bytes
     ///
     /// The WASM specification demands a page size of 64 KiB, that is `65536` bytes:
-    /// <https://webassembly.github.io/spec/core/exec/runtime.html?highlight=page#memory-instances>
+    /// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instances%E2%91%A0>
     const PAGE_SIZE: usize = PAGE_SIZE;
 
     /// Create a new, empty [`LinearMemory`]
@@ -239,11 +239,9 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
     }
 
     /// Implementation of the behavior described in
-    /// <https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-fill>.
+    /// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-memorymathsfmemoryfill%E2%91%A0>.
     /// Note, that the WASM spec defines the behavior by recursion, while our implementation uses
     /// the memset like [`core::ptr::write_bytes`].
-    ///
-    /// <https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-fill>
     pub fn fill(&self, index: MemIdx, data_byte: u8, count: MemIdx) -> Result<(), RuntimeError> {
         let lock_guard = self.inner_data.read();
 
@@ -292,7 +290,7 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
     /// - Copies the `count` bytes starting from `source_index`, overwriting the `count` bytes
     ///   starting from `destination_index`
     ///
-    /// <https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-copy>
+    /// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-memorymathsfmemorycopy%E2%91%A0>
     pub fn copy(
         &self,
         destination_index: MemIdx,
@@ -387,7 +385,7 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
     // Rationale behind having `source_index` and `count` when the callsite could also just create a
     // subslice for `source_data`? Have all the index error checks in one place.
     //
-    // <https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-init-x>
+    // <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#-hrefsyntax-instr-memorymathsfmemoryinitx%E2%91%A0>
     pub fn init(
         &self,
         destination_index: MemIdx,

--- a/src/execution/store/mod.rs
+++ b/src/execution/store/mod.rs
@@ -46,7 +46,7 @@ pub(crate) mod linear_memory;
 /// consists of the runtime representation of all instances of functions, tables, memories, and
 /// globals, element segments, and data segments that have been allocated during the life time of
 /// the abstract machine.
-/// <https://webassembly.github.io/spec/core/exec/runtime.html#store>
+/// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#store%E2%91%A0>
 pub struct Store<'b, T: Config> {
     pub(crate) functions: AddrVec<FuncAddr, FuncInst<T>>,
     pub(crate) tables: AddrVec<TableAddr, TableInst>,
@@ -157,7 +157,7 @@ impl<'b, T: Config> Store<'b, T> {
         let module_addr = self.modules.insert(module_inst);
 
         // TODO rewrite this part
-        // <https://webassembly.github.io/spec/core/exec/modules.html#functions>
+        // <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#functions%E2%91%A6>
         let func_addrs: Vec<FuncAddr> = validation_info
             .functions
             .iter()
@@ -220,7 +220,7 @@ impl<'b, T: Config> Store<'b, T> {
         }
 
         // instantiation: step 11 - module allocation (except function allocation - which was made in step 5)
-        // https://webassembly.github.io/spec/core/exec/modules.html#alloc-module
+        // https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#modules%E2%91%A6
 
         // allocation: begin
 
@@ -481,7 +481,7 @@ impl<'b, T: Config> Store<'b, T> {
     /// Therefore, all "invalid" host functions (e.g. those which return incorrect return values)
     /// can cause the interpreter to panic or behave unexpectedly.
     ///
-    /// See: <https://webassembly.github.io/spec/core/exec/modules.html#host-functions>
+    /// See: <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#host-functions%E2%91%A2>
     /// See: WebAssembly Specification 2.0 - 7.1.7 - func_alloc
     ///
     /// # Safety
@@ -888,7 +888,7 @@ impl<'b, T: Config> Store<'b, T> {
         Ok(())
     }
 
-    /// roughly matches <https://webassembly.github.io/spec/core/exec/modules.html#functions> with the addition of sidetable pointer to the input signature
+    /// roughly matches <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#functions%E2%91%A6> with the addition of sidetable pointer to the input signature
     ///
     /// # Safety
     /// The caller has to guarantee that the given [`ModuleAddr`] came from the
@@ -924,7 +924,7 @@ impl<'b, T: Config> Store<'b, T> {
         self.functions.insert(func_inst)
     }
 
-    /// <https://webassembly.github.io/spec/core/exec/modules.html#tables>
+    /// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#tables%E2%91%A6>
     ///
     /// # Safety
     /// The caller has to guarantee that any [`FuncAddr`] or
@@ -939,7 +939,7 @@ impl<'b, T: Config> Store<'b, T> {
         self.tables.insert(table_inst)
     }
 
-    /// <https://webassembly.github.io/spec/core/exec/modules.html#memories>
+    /// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memories%E2%91%A6>
     fn alloc_mem(&mut self, mem_type: MemType) -> MemAddr {
         let mem_inst = MemInst {
             ty: mem_type,
@@ -951,7 +951,7 @@ impl<'b, T: Config> Store<'b, T> {
         self.memories.insert(mem_inst)
     }
 
-    /// <https://webassembly.github.io/spec/core/exec/modules.html#globals>
+    /// <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#globals%E2%91%A6>
     ///
     /// # Safety
     /// The caller has to guarantee that any [`FuncAddr`] or

--- a/src/execution/value.rs
+++ b/src/execution/value.rs
@@ -303,7 +303,7 @@ impl F64 {
 
 /// A value at runtime. This is essentially a duplicate of [ValType] just with additional values.
 ///
-/// See <https://webassembly.github.io/spec/core/exec/runtime.html#values>
+/// See <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#values%E2%91%A2>
 // TODO implement missing variants
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Value {

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -13,7 +13,7 @@ use crate::RuntimeError;
 /// 2. Labels
 /// 3. Activations
 ///
-/// See <https://webassembly.github.io/spec/core/exec/runtime.html#stack>
+/// See <https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#stack%E2%91%A0>
 #[derive(Default, Debug)]
 pub(crate) struct Stack {
     /// WASM values on the stack, i.e. the actual data that instructions operate on
@@ -200,7 +200,7 @@ impl Stack {
     }
 }
 
-/// The [WASM spec](https://webassembly.github.io/spec/core/exec/runtime.html#stack) calls this `Activations`, however it refers to the call frames of functions.
+/// The [WASM spec](https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#stack%E2%91%A0) calls this `Activations`, however it refers to the call frames of functions.
 #[derive(Debug)]
 pub(crate) struct CallFrame {
     /// Store address of the function that called this [`CallFrame`]'s function

--- a/src/validation/code.rs
+++ b/src/validation/code.rs
@@ -223,7 +223,7 @@ fn read_instructions(
                     stps_to_backpatch: Vec::new(),
                 };
                 // The types are explicitly popped and pushed in
-                // https://webassembly.github.io/spec/core/appendix/algorithm.html
+                // https://www.w3.org/TR/wasm-core/#a3-validation-algorithm
                 // therefore types on the stack might change.
                 stack.assert_push_ctrl(label_info, block_ty, true)?;
             }
@@ -234,7 +234,7 @@ fn read_instructions(
                     stp: sidetable.len(),
                 };
                 // The types are explicitly popped and pushed in
-                // https://webassembly.github.io/spec/core/appendix/algorithm.html
+                // https://www.w3.org/TR/wasm-core/#a3-validation-algorithm
                 // therefore types on the stack might change.
                 stack.assert_push_ctrl(label_info, block_ty, true)?;
             }
@@ -256,7 +256,7 @@ fn read_instructions(
                     stps_to_backpatch: Vec::new(),
                 };
                 // The types are explicitly popped and pushed in
-                // https://webassembly.github.io/spec/core/appendix/algorithm.html
+                // https://www.w3.org/TR/wasm-core/#a3-validation-algorithm
                 // therefore types on the stack might change.
                 stack.assert_push_ctrl(label_info, block_ty, true)?;
             }
@@ -294,7 +294,7 @@ fn read_instructions(
                         stack.push_valtype(*valtype);
                     }
                     // The types are explicitly popped and pushed in
-                    // https://webassembly.github.io/spec/core/appendix/algorithm.html
+                    // https://www.w3.org/TR/wasm-core/#a3-validation-algorithm
                     // therefore types on the stack might change.
                     stack.assert_push_ctrl(label_info, block_ty, true)?;
                 } else {
@@ -312,7 +312,7 @@ fn read_instructions(
                 let label_idx = wasm.read_var_u32()? as LabelIdx;
                 stack.assert_pop_val_type(ValType::NumType(NumType::I32))?;
                 // The types are explicitly popped and pushed in
-                // https://webassembly.github.io/spec/core/appendix/algorithm.html
+                // https://www.w3.org/TR/wasm-core/#a3-validation-algorithm
                 // therefore types on the stack might change.
                 validate_branch_and_generate_sidetable_entry(
                     wasm, label_idx, stack, sidetable, true,
@@ -364,7 +364,7 @@ fn read_instructions(
             }
             END => {
                 // The types are explicitly popped and pushed in
-                // https://webassembly.github.io/spec/core/appendix/algorithm.html
+                // https://www.w3.org/TR/wasm-core/#a3-validation-algorithm
                 // therefore types on the stack might change.
                 let (label_info, block_ty) = stack.assert_pop_ctrl(true)?;
                 let stp_here = sidetable.len();
@@ -1109,7 +1109,7 @@ fn read_instructions(
                 }
 
                 // check whether func_idx is in C.refs
-                // https://webassembly.github.io/spec/core/valid/conventions.html#context
+                // https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#contexts%E2%91%A0
                 if !validation_context_refs.contains(&func_idx) {
                     return Err(ValidationError::ReferencingAnUnreferencedFunction(func_idx));
                 }
@@ -1584,20 +1584,20 @@ fn read_instructions(
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // vvunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvunop>
+                    // vvunop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vvunop
                     V128_NOT => {
                         stack.assert_pop_val_type(ValType::VecType)?;
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // vvbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvbinop>
+                    // vvbinop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vvbinop
                     V128_AND | V128_ANDNOT | V128_OR | V128_XOR => {
                         stack.assert_pop_val_type(ValType::VecType)?;
                         stack.assert_pop_val_type(ValType::VecType)?;
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // vvternop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvternop>
+                    // vvternop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vvternop
                     V128_BITSELECT => {
                         stack.assert_pop_val_type(ValType::VecType)?;
                         stack.assert_pop_val_type(ValType::VecType)?;
@@ -1605,7 +1605,7 @@ fn read_instructions(
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // vvtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvtestop>
+                    // vvtestop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vvtestop
                     V128_ANY_TRUE => {
                         stack.assert_pop_val_type(ValType::VecType)?;
                         stack.push_valtype(ValType::NumType(NumType::I32));
@@ -1751,7 +1751,7 @@ fn read_instructions(
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // Group vunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vunop>
+                    // Group vunop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vvunop
                     // viunop
                     I8X16_ABS | I16X8_ABS | I32X4_ABS | I64X2_ABS
                     | I8X16_NEG | I16X8_NEG | I32X4_NEG | I64X2_NEG
@@ -1770,7 +1770,7 @@ fn read_instructions(
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // Group vbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vbinop>
+                    // Group vbinop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vvbinop
                     // vibinop
                     I8X16_ADD | I16X8_ADD | I32X4_ADD | I64X2_ADD
                     | I8X16_SUB | I16X8_SUB | I32X4_SUB | I64X2_SUB
@@ -1803,7 +1803,7 @@ fn read_instructions(
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // Group vrelop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vrelop>
+                    // Group vrelop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vrelop
                     // virelop
                     I8X16_EQ | I16X8_EQ | I32X4_EQ | I64X2_EQ
                     | I8X16_NE | I16X8_NE | I32X4_NE | I64X2_NE
@@ -1837,7 +1837,7 @@ fn read_instructions(
                         stack.push_valtype(ValType::VecType);
                     }
 
-                    // Group vtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vtestop>
+                    // Group vtestop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vvtestop
                     // vitestop
                     I8X16_ALL_TRUE | I16X8_ALL_TRUE | I32X4_ALL_TRUE | I64X2_ALL_TRUE
                     => {
@@ -1845,7 +1845,7 @@ fn read_instructions(
                         stack.push_valtype(ValType::NumType(NumType::I32));
                     }
 
-                    // Group vcvtop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vcvtop>
+                    // Group vcvtop https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#syntax-vcvtop
                     I16X8_EXTEND_HIGH_I8X16_S | I16X8_EXTEND_HIGH_I8X16_U | I16X8_EXTEND_LOW_I8X16_S | I16X8_EXTEND_LOW_I8X16_U
                     | I32X4_EXTEND_HIGH_I16X8_S | I32X4_EXTEND_HIGH_I16X8_U | I32X4_EXTEND_LOW_I16X8_S | I32X4_EXTEND_LOW_I16X8_U
                     | I64X2_EXTEND_HIGH_I32X4_S | I64X2_EXTEND_HIGH_I32X4_U | I64X2_EXTEND_LOW_I32X4_S | I64X2_EXTEND_LOW_I32X4_U

--- a/src/validation/data.rs
+++ b/src/validation/data.rs
@@ -107,7 +107,7 @@ pub(super) fn validate_data_section(
                 // this hasn't been yet implemented in wasm
                 // as per docs:
 
-                // https://webassembly.github.io/spec/core/binary/modules.html#data-section
+                // https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#data-section%E2%91%A0
                 // The initial integer can be interpreted as a bitfield. Bit 0 indicates a passive segment, bit 1 indicates the presence of an explicit memory index for an active segment.
                 // In the current version of WebAssembly, at most one memory may be defined or imported in a single module, so all valid active data segments have a memory value of 0
             }

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -124,14 +124,14 @@ fn get_imports_length(imports: &Vec<Import>) -> ImportsLength {
 pub fn validate(wasm: &[u8]) -> Result<ValidationInfo<'_>, ValidationError> {
     let mut wasm = WasmReader::new(wasm);
 
-    // represents C.refs in https://webassembly.github.io/spec/core/valid/conventions.html#context
+    // represents C.refs in https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#contexts%E2%91%A0
     // A func.ref instruction is onlv valid if it has an immediate that is a member of C.refs.
     // this list holds all the func_idx's occurring in the module, except in its functions or start function.
     // I make an exception here by not including func_idx's occuring within data segments in C.refs as well, so that single pass validation is possible.
     // If there is a func_idx within the data segment, this would ultimately mean that data segment cannot be validated,
     // therefore this hack is acceptable.
-    // https://webassembly.github.io/spec/core/valid/modules.html#data-segments
-    // https://webassembly.github.io/spec/core/valid/modules.html#valid-module
+    // https://www.w3.org/TR/wasm-core/#data-segments%E2%91%A2
+    // https://www.w3.org/TR/wasm-core/#modules%E2%91%A3
 
     let mut validation_context_refs: BTreeSet<FuncIdx> = BTreeSet::new();
 
@@ -329,7 +329,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo<'_>, ValidationError> {
     let start = handle_section(&mut wasm, &mut header, SectionTy::Start, |wasm, _| {
         let func_idx = wasm.read_var_u32().map(|idx| idx as FuncIdx)?;
         // start function signature must be [] -> []
-        // https://webassembly.github.io/spec/core/valid/modules.html#start-function
+        // https://www.w3.org/TR/wasm-core/#start-function%E2%91%A2
         let type_idx = *all_functions
             .get(func_idx)
             .ok_or(ValidationError::InvalidFuncIdx(func_idx))?;
@@ -365,7 +365,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo<'_>, ValidationError> {
 
     while (skip_section(&mut wasm, &mut header)?).is_some() {}
 
-    // https://webassembly.github.io/spec/core/binary/modules.html#data-count-section
+    // https://www.w3.org/TR/wasm-core/#data-count-section%E2%91%A0
     // As per the official documentation:
     //
     // The data count section is used to simplify single-pass validation. Since the data section occurs after the code section, the `memory.init` and `data.drop` and instructions would not be able to check whether the data segment index is valid until the data section is read. The data count section occurs before the code section, so a single-pass validator can use this count instead of deferring validation.
@@ -416,7 +416,7 @@ pub fn validate(wasm: &[u8]) -> Result<ValidationInfo<'_>, ValidationError> {
     })?
     .unwrap_or_default();
 
-    // https://webassembly.github.io/spec/core/binary/modules.html#data-count-section
+    // https://www.w3.org/TR/wasm-core/#data-count-section%E2%91%A0
     if let (Some(data_count), data_len) = (data_count, data_section.len()) {
         if data_count as usize != data_len {
             return Err(ValidationError::DataCountAndDataSectionsLengthAreDifferent);

--- a/src/validation/read_constant_expression.rs
+++ b/src/validation/read_constant_expression.rs
@@ -17,7 +17,7 @@ use super::validation_stack::ValidationStack;
 /// and nothing more.
 ///
 /// Valid constant instructions are:
-/// - Core: <https://webassembly.github.io/spec/core/valid/instructions.html#valid-constant>
+/// - Core: <https://www.w3.org/TR/wasm-core/#expressions%E2%91%A2>
 /// - Extended Proposal: <https://webassembly.github.io/extended-const/core/valid/instructions.html#valid-constant>
 ///
 /// # The Wonders of `global.get`
@@ -88,7 +88,7 @@ pub fn read_constant_expression(
     wasm: &mut WasmReader,
     stack: &mut ValidationStack,
     // The globals slice should contain ONLY imported globals IF AND ONLY IF we are calling `read_constant_expression` for local globals instantiation
-    // As per https://webassembly.github.io/spec/core/valid/modules.html (bottom of the page):
+    // As per https://www.w3.org/TR/wasm-core/#modules%E2%91%A3 (bottom of the page):
     //
     //  Globals, however, are not recursive and not accessible within constant expressions when they are defined locally. The effect of defining the limited context C'
     //   for validating certain definitions is that they can only access functions and imported globals and nothing else.

--- a/src/validation/validation_stack.rs
+++ b/src/validation/validation_stack.rs
@@ -397,7 +397,7 @@ impl ValidationStack {
     }
 }
 
-/// corresponds to `opdtype` <https://webassembly.github.io/spec/core/valid/instructions.html#instructions>
+/// corresponds to `opdtype` <https://www.w3.org/TR/wasm-core/#instructions%E2%91%A2>
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ValidationStackEntry {
     Val(ValType),
@@ -405,7 +405,7 @@ pub enum ValidationStackEntry {
 }
 
 impl ValidationStackEntry {
-    /// corresponds to whether `(self, other)` is a member of "matches" (<=) relation defined in <https://webassembly.github.io/spec/core/valid/instructions.html#instructions>
+    /// corresponds to whether `(self, other)` is a member of "matches" (<=) relation defined in <https://www.w3.org/TR/wasm-core/#instructions%E2%91%A2>
     fn unifies_to(&self, other: &ValidationStackEntry) -> bool {
         match self {
             ValidationStackEntry::Bottom => true,


### PR DESCRIPTION
### Pull Request Overview

In a lot of the places in our code we use URLs to refer to various parts of the spec. Unfortunately the URLs are most often not permalinks, and thus the contents behind them changes, unbeknownst to us.

We need to address two issues here:

1. Use permalinks to the Wasm spec
2. Use clear references

### TODO or Help Wanted

My first thought was that just using the W3C spec is fine. However, inspecting the URLs a bit closer (i.e. https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#globals%E2%91%A6 ) there is an issue: when multiple chapters have the same title, their corresponding anchor just gets append a number (as unicode displaying a digit in a circle, for example `⑦`). Likely this means that if in an early section yet another subsection with the title `globals` is inserted, all anchors pointing to `global` subsections following it are shifted by one. No bueno.

We need a better way to refer to the spec, which in the best case does not break when we upgrade our spec target (i.e. from Wasm 2.0 to Wasm 3.0).

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Github Issue

<!--
This pull request closes <GITHUB_ISSUE>
-->
