### PR TITLE
Make The ValueStack Contain a Special Base Call Frame

### DIFF
--- a/src/execution/const_interpreter_loop.rs
+++ b/src/execution/const_interpreter_loop.rs
@@ -1,10 +1,16 @@
+use alloc::vec::Vec;
+
 use crate::{
     addrs::ModuleAddr,
     assert_validated::UnwrapValidatedExt,
     config::Config,
     core::{
         indices::GlobalIdx,
-        reader::{span::Span, WasmReader},
+        reader::{
+            span::Span,
+            types::{FuncType, ResultType},
+            WasmReader,
+        },
     },
     unreachable_validated,
     value::{self, Ref},
@@ -137,7 +143,18 @@ pub(crate) fn run_const_span<T: Config>(
 
     wasm.move_start_to(*span).unwrap_validated();
 
-    let mut stack = Stack::new();
+    let mut stack = Stack::new::<T>(
+        Vec::new(),
+        &FuncType {
+            params: ResultType {
+                valtypes: Vec::new(),
+            },
+            returns: ResultType {
+                valtypes: Vec::new(),
+            },
+        },
+        &[],
+    )?;
     run_const(&mut wasm, &mut stack, module, store)?;
 
     Ok(stack.peek_value())

--- a/src/execution/interop.rs
+++ b/src/execution/interop.rs
@@ -273,7 +273,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::addrs::FuncAddr;
+    use crate::addrs::{Addr, FuncAddr};
     use crate::value::{ExternAddr, Value, ValueTypeMismatchError};
     use alloc::vec::Vec;
 
@@ -373,15 +373,15 @@ mod tests {
 
     #[test]
     fn roundtrip_single_ref_func() {
-        const RUST_VALUE: RefFunc = RefFunc(Some(FuncAddr::INVALID));
-        let wasm_value: Value = RUST_VALUE.into();
+        let rust_value: RefFunc = RefFunc(Some(FuncAddr::new_unchecked(0)));
+        let wasm_value: Value = rust_value.into();
         assert_eq!(wasm_value.try_into(), err::<u32>());
         assert_eq!(wasm_value.try_into(), err::<i32>());
         assert_eq!(wasm_value.try_into(), err::<u64>());
         assert_eq!(wasm_value.try_into(), err::<i64>());
         assert_eq!(wasm_value.try_into(), err::<f32>());
         assert_eq!(wasm_value.try_into(), err::<f64>());
-        assert_eq!(wasm_value.try_into(), ok(RUST_VALUE));
+        assert_eq!(wasm_value.try_into(), ok(rust_value));
         assert_eq!(wasm_value.try_into(), err::<RefExtern>());
     }
 
@@ -453,10 +453,10 @@ mod tests {
 
     #[test]
     fn roundtrip_list2() {
-        const RUST_VALUES: (f32, RefFunc) = (3.0, RefFunc(Some(FuncAddr::INVALID)));
-        let wasm_values: Vec<Value> = RUST_VALUES.into_values();
+        let rust_values: (f32, RefFunc) = (3.0, RefFunc(Some(FuncAddr::new_unchecked(0))));
+        let wasm_values: Vec<Value> = rust_values.into_values();
         let roundtrip_rust_values = InteropValueList::try_from_values(wasm_values.into_iter());
-        assert_eq!(roundtrip_rust_values, Ok(RUST_VALUES));
+        assert_eq!(roundtrip_rust_values, Ok(rust_values));
     }
 
     #[test]

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -115,15 +115,14 @@ pub(super) fn run<T: Config>(
                     continue;
                 }
 
-                let (maybe_return_func_addr, maybe_return_address, maybe_return_stp) =
-                    stack.pop_call_frame();
-
-                // We finished this entire invocation if there is no call frame left. If there are
-                // one or more call frames, we need to continue from where the callee was called
-                // from.
-                if stack.call_frame_count() == 0 {
+                let Some((maybe_return_func_addr, maybe_return_address, maybe_return_stp)) =
+                    stack.pop_call_frame()
+                else {
+                    // We finished this entire invocation if this was the base call frame.
                     break;
-                }
+                };
+                // If there are one or more call frames, we need to continue
+                // from where the callee was called from.
 
                 trace!("end of function reached, returning to previous call frame");
                 current_func_addr = maybe_return_func_addr;

--- a/src/execution/resumable.rs
+++ b/src/execution/resumable.rs
@@ -90,7 +90,13 @@ pub enum RunState {
 
 #[cfg(test)]
 mod test {
-    use crate::{addrs::FuncAddr, value_stack::Stack};
+    use alloc::vec::Vec;
+
+    use crate::{
+        addrs::{Addr, FuncAddr},
+        core::reader::types::{FuncType, ResultType},
+        value_stack::Stack,
+    };
 
     use super::{Dormitory, Resumable};
 
@@ -99,11 +105,25 @@ mod test {
     fn dormitory_constructor() {
         let dorm = Dormitory::new();
 
+        let empty_stack = Stack::new::<()>(
+            Vec::new(),
+            &FuncType {
+                params: ResultType {
+                    valtypes: Vec::new(),
+                },
+                returns: ResultType {
+                    valtypes: Vec::new(),
+                },
+            },
+            &[],
+        )
+        .unwrap();
+
         let resumable = Resumable {
-            stack: Stack::new(),
+            stack: empty_stack,
             pc: 11,
             stp: 13,
-            current_func_addr: FuncAddr::INVALID,
+            current_func_addr: FuncAddr::new_unchecked(0),
             maybe_fuel: None,
         };
 

--- a/src/execution/store/addrs.rs
+++ b/src/execution/store/addrs.rs
@@ -113,11 +113,6 @@ impl<A: Addr, Inst> AddrVec<A, Inst> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FuncAddr(usize);
 
-impl FuncAddr {
-    // This is unfortunately needed as a default value for the base `CallFrame` in every call stack.
-    pub(crate) const INVALID: Self = FuncAddr(usize::MAX);
-}
-
 impl core::fmt::Display for FuncAddr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "function address {}", self.0)

--- a/src/execution/store/mod.rs
+++ b/src/execution/store/mod.rs
@@ -1075,14 +1075,10 @@ impl<'b, T: Config> Store<'b, T> {
                     }
                     FuncInst::WasmFunc(wasm_func_inst) => {
                         // Prepare a new stack with the locals for the entry function
-                        let mut stack = Stack::new_with_values(params);
-
-                        stack.push_call_frame::<T>(
-                            FuncAddr::INVALID, // TODO using a default value like this is dangerous
+                        let stack = Stack::new::<T>(
+                            params,
                             &wasm_func_inst.function_type,
                             &wasm_func_inst.locals,
-                            usize::MAX,
-                            usize::MAX,
                         )?;
 
                         let mut resumable = Resumable {


### PR DESCRIPTION
Previously, the `value_stack::Stack` data structure did not guarantee that there was always a single `CallFrame` present.

However, there should always be at least one `CallFrame`. Let's call this the _base call frame_.

This base call frame contains less information than normal call frames. For example, it does not store a `return_func_addr`, `return_addr` or `return_stp`. That's why we had to use invalid default values for these in the past (`FuncAddr(usize::MAX)` & `usize::MAX`).

However, these default values are very dangerous, especially so with the upcoming usage of unsafe code in execution.

Therefore, this PR changes the value stack to handle this edge case of there always being at least one call frame with partially-initialized fields.

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

