### PR TITLE
Add Embedder API for Accessing Imports/Exports of a Module

### DIFF
--- a/src/execution/linker.rs
+++ b/src/execution/linker.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    borrow::ToOwned,
     collections::btree_map::{BTreeMap, Entry},
     string::String,
     vec::Vec,
@@ -138,10 +139,9 @@ impl Linker {
         validation_info: &ValidationInfo,
     ) -> Result<Vec<ExternVal>, RuntimeError> {
         validation_info
-            .imports
-            .iter()
-            .map(|import| {
-                self.get_unchecked(import.module_name.clone(), import.name.clone())
+            .imports()
+            .map(|(module_name, name, _desc)| {
+                self.get_unchecked(module_name.to_owned(), name.to_owned())
                     .ok_or(RuntimeError::UnableToResolveExternLookup)
             })
             .collect()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@ extern crate log_wrapper;
 
 pub use core::error::ValidationError;
 pub use core::reader::types::{
-    export::ExportDesc, global::GlobalType, Limits, MemType, NumType, RefType, TableType, ValType,
+    export::ExportDesc, global::GlobalType, ExternType, FuncType, Limits, MemType, NumType,
+    RefType, ResultType, TableType, ValType,
 };
 pub use core::rw_spinlock;
 pub use execution::error::{RuntimeError, TrapError};

--- a/tests/module_imports_exports.rs
+++ b/tests/module_imports_exports.rs
@@ -1,0 +1,103 @@
+use wasm::{validate, ExternType, FuncType, GlobalType, NumType, ResultType, ValType};
+
+#[test_log::test]
+fn empty_module() {
+    const EMPTY_MODULE: &str = r#"
+        (module)
+    "#;
+    let wasm_bytes = wat::parse_str(EMPTY_MODULE).unwrap();
+
+    let validation_info = validate(&wasm_bytes).unwrap();
+
+    assert_eq!(validation_info.imports().len(), 0);
+    assert_eq!(validation_info.exports().len(), 0);
+}
+
+#[test_log::test]
+fn imports() {
+    const MODULE_WITH_IMPORTS: &str = r#"
+        (module
+            (import "foo" "baz" (func))
+            (import "bar" "bat" (global (mut i64)))
+        )
+    "#;
+
+    let wasm_bytes = wat::parse_str(MODULE_WITH_IMPORTS).unwrap();
+
+    let validation_info = validate(&wasm_bytes).unwrap();
+
+    let imports: Vec<(&str, &str, ExternType)> = validation_info.imports().collect();
+
+    assert_eq!(
+        &imports,
+        &[
+            (
+                "foo",
+                "baz",
+                ExternType::Func(FuncType {
+                    params: ResultType {
+                        valtypes: Vec::new()
+                    },
+                    returns: ResultType {
+                        valtypes: Vec::new()
+                    },
+                })
+            ),
+            (
+                "bar",
+                "bat",
+                ExternType::Global(GlobalType {
+                    ty: ValType::NumType(NumType::I64),
+                    is_mut: true,
+                }),
+            )
+        ]
+    );
+
+    assert_eq!(validation_info.exports().len(), 0);
+}
+
+#[test_log::test]
+fn exports() {
+    const MODULE_WITH_EXPORTED_DEFINITIONS: &str = r#"
+        (module
+            (func $my_func (export "foo") (param i32) (result i64)
+                local.get 0
+                i64.extend_i32_u
+            )
+            (global $my_global (export "bar") (mut i32)
+                i32.const 123
+            )
+        )
+    "#;
+
+    let wasm_bytes = wat::parse_str(MODULE_WITH_EXPORTED_DEFINITIONS).unwrap();
+
+    let validation_info = validate(&wasm_bytes).unwrap();
+
+    let exports: Vec<(&str, ExternType)> = validation_info.exports().collect();
+
+    assert_eq!(
+        &exports,
+        &[
+            (
+                "foo",
+                ExternType::Func(FuncType {
+                    params: ResultType {
+                        valtypes: vec![ValType::NumType(NumType::I32)]
+                    },
+                    returns: ResultType {
+                        valtypes: vec![ValType::NumType(NumType::I64)],
+                    }
+                }),
+            ),
+            (
+                "bar",
+                ExternType::Global(GlobalType {
+                    ty: ValType::NumType(NumType::I32),
+                    is_mut: true
+                })
+            )
+        ]
+    )
+}


### PR DESCRIPTION
This PR implements the missing two Embedder API functions `module_imports` and `module_exports`.

These functions are called on a `ValidationInfo`, and return that module's imports and exports, respectively.

This change also makes our linker fully modular, without it requiring direct field access to `ValidationInfo` linke before.Thus, it should be possible to move the linker to a separate crate now. What do we think about this?

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
