### PR TITLE
Fix Bug Where the PC is Reset to an Unknown Location When Out Of Fuel in Fill/Init Instructions

### DIFF
--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -1236,7 +1236,7 @@ pub(super) fn run<T: Config>(
                     } else {
                         stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                         resumable.current_func_addr = current_func_addr;
-                        resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                        resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                         resumable.stp = stp;
                         return Ok(InterpreterLoopOutcome::OutOfFuel {
                             required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),
@@ -2740,7 +2740,7 @@ pub(super) fn run<T: Config>(
                             } else {
                                 stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
-                                resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                                resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
                                 return Ok(InterpreterLoopOutcome::OutOfFuel {
                                     required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),
@@ -2833,7 +2833,7 @@ pub(super) fn run<T: Config>(
                             } else {
                                 stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
-                                resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                                resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
                                 return Ok(InterpreterLoopOutcome::OutOfFuel {
                                     required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),
@@ -2895,7 +2895,7 @@ pub(super) fn run<T: Config>(
                             } else {
                                 stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
-                                resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                                resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
                                 return Ok(InterpreterLoopOutcome::OutOfFuel {
                                     required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),
@@ -2937,7 +2937,7 @@ pub(super) fn run<T: Config>(
                             } else {
                                 stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
-                                resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                                resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
                                 return Ok(InterpreterLoopOutcome::OutOfFuel {
                                     required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),
@@ -3044,7 +3044,7 @@ pub(super) fn run<T: Config>(
                             } else {
                                 stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
-                                resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                                resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
                                 return Ok(InterpreterLoopOutcome::OutOfFuel {
                                     required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),
@@ -3139,7 +3139,7 @@ pub(super) fn run<T: Config>(
                             } else {
                                 stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
-                                resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                                resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
                                 return Ok(InterpreterLoopOutcome::OutOfFuel {
                                     required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),
@@ -3216,7 +3216,7 @@ pub(super) fn run<T: Config>(
                             } else {
                                 stack.push_value::<T>(Value::I32(len)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
-                                resumable.pc = wasm.pc - prev_pc; // the instruction was fetched already, we roll this back
+                                resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
                                 return Ok(InterpreterLoopOutcome::OutOfFuel {
                                     required_fuel: NonZeroU64::new(cost - *fuel).expect("the last check guarantees that the current fuel is smaller than cost"),

--- a/tests/memory_fill.rs
+++ b/tests/memory_fill.rs
@@ -17,7 +17,7 @@
 
 // use core::slice::SlicePattern;
 
-use checked::Store;
+use checked::{Store, StoredRunState};
 use wasm::validate;
 
 #[test_log::test]
@@ -66,4 +66,55 @@ fn memory_fill() {
 #[test_log::test]
 fn memory_fill_with_control_flow() {
     todo!()
+}
+
+#[test_log::test]
+fn fill_with_fuel() {
+    let w = r#"
+    (module
+        (memory (export "mem") 1)
+        (func (export "fill")
+            (memory.fill (i32.const 0) (i32.const 2777) (i32.const 100))
+        )
+    )
+  "#;
+    let wasm_bytes = wat::parse_str(w).unwrap();
+    let validation_info = validate(&wasm_bytes).unwrap();
+    let mut store = Store::new(());
+    let module = store
+        .module_instantiate(&validation_info, Vec::new(), None)
+        .unwrap()
+        .module_addr;
+
+    let fill = store
+        .instance_export(module, "fill")
+        .unwrap()
+        .as_func()
+        .unwrap();
+    let mem = store
+        .instance_export(module, "mem")
+        .unwrap()
+        .as_mem()
+        .expect("memory");
+
+    let mut run_state = store.invoke(fill, Vec::new(), Some(1)).unwrap();
+    loop {
+        match run_state {
+            StoredRunState::Finished { .. } => break,
+            StoredRunState::Resumable { mut resumable, .. } => {
+                *resumable.fuel_mut().as_mut().unwrap() += 1;
+                run_state = store.resume_wasm(resumable).unwrap();
+            }
+            StoredRunState::HostCalled { .. } => unreachable!("no host calls exist"),
+        }
+    }
+
+    let expected = [vec![217u8; 100], vec![0u8; 5]].concat();
+    for (idx, expected_byte) in expected.into_iter().enumerate() {
+        let mem_byte: u8 = store.mem_read(mem, idx as u32).unwrap();
+        assert_eq!(
+            mem_byte.to_ascii_lowercase(),
+            expected_byte.to_ascii_lowercase()
+        );
+    }
 }


### PR DESCRIPTION
This also adds a single test case for the `memory.fill` instruction specifically.

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`
