### PR TITLE
feat: replace Vec by Box for value stack

### DIFF
--- a/crates/benchmark/benches/general_purpose.rs
+++ b/crates/benchmark/benches/general_purpose.rs
@@ -17,6 +17,8 @@ macro_rules! bench_wasm {
         arg_type = $arg_type:ty;
         return_type = $return_type:ty;
         inputs = $inputs:expr;
+        value_stack_size = $value_stack_size:expr;
+        call_stack_size = $call_stack_size:expr;
     } => {
         bench_wasm!{
             name = $name;
@@ -30,6 +32,8 @@ macro_rules! bench_wasm {
             arg_type = $arg_type;
             return_type = $return_type;
             inputs = $inputs;
+            value_stack_size = $value_stack_size;
+            call_stack_size = $call_stack_size;
         }
     };
 
@@ -41,6 +45,8 @@ macro_rules! bench_wasm {
         arg_type = $arg_type:ty;
         return_type = $return_type:ty;
         inputs = $inputs:expr;
+        value_stack_size = $value_stack_size:expr;
+        call_stack_size = $call_stack_size:expr;
     } => {
 
         fn $name(c: &mut Criterion) {
@@ -49,7 +55,12 @@ macro_rules! bench_wasm {
 
             // Our interpreter
             let our_validation_info = validate(&wasm_bytes).unwrap();
-            let mut store = Store::new(());
+            struct UserData;
+            impl wasm::config::Config for UserData {
+                const MAX_VALUE_STACK_SIZE: usize = $value_stack_size;
+                const MAX_CALL_STACK_SIZE: usize = $call_stack_size;
+            }
+            let mut store = Store::new(UserData);
             // SAFETY: Only one store is used. Therefore, this must always be
             // the correct one.
             let module = unsafe { store.module_instantiate(&our_validation_info, Vec::new(), None) }.unwrap().module_addr;
@@ -166,6 +177,8 @@ bench_wasm! {
     arg_type = i32;
     return_type = i32;
     inputs = (0..=9).map(|p| 1 << p);
+    value_stack_size = 0x800;
+    call_stack_size = 0x400;
 }
 
 bench_wasm! {
@@ -205,6 +218,8 @@ bench_wasm! {
     arg_type = i32;
     return_type = i32;
     inputs = (0..=20).map(|p| 1 << p);
+    value_stack_size = 8;
+    call_stack_size = 2;
 }
 
 criterion_group! {

--- a/flake.nix
+++ b/flake.nix
@@ -182,7 +182,7 @@
                       "''${COMMON_BENCH_CMD[@]}" --save-baseline benchmark-current.baseline
 
                       # delete old current dev branch benchmark results
-                      find "$GIT_WORKTREE_PATH/target/" -type d -name 'benchmark-current.baseline' -delete
+                      find "$GIT_WORKTREE_PATH/target/" -type d -name 'benchmark-current.baseline' -exec rm --recursive -- {} \;
 
                       # copy results from current to main worktree target/ dir
                       find target/ -type d -name 'benchmark-current.baseline' -exec cp --recursive --no-target-directory -- {} "$GIT_WORKTREE_PATH/"{} \;

--- a/src/core/fixed_capacity_vec.rs
+++ b/src/core/fixed_capacity_vec.rs
@@ -129,7 +129,10 @@ impl<T> FixedCapacityVec<T> {
     pub fn pop(&mut self) -> Result<T, EmptyContainerError> {
         self.len = self.len.checked_sub(1).ok_or(EmptyContainerError)?;
 
-        let value = self.elements.get(self.len).ok_or(EmptyContainerError)?;
+        let value = self
+            .elements
+            .get(self.len)
+            .expect("than len is never larger than the length of elements");
 
         Ok(
             // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
@@ -161,7 +164,10 @@ impl<T> FixedCapacityVec<T> {
     pub fn peek(&self) -> Result<&T, EmptyContainerError> {
         let idx = self.len.checked_sub(1).ok_or(EmptyContainerError)?;
 
-        let value = self.elements.get(idx).ok_or(EmptyContainerError)?;
+        let value = self
+            .elements
+            .get(idx)
+            .expect("than len is never larger than the length of elements");
 
         Ok(
             // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
@@ -174,11 +180,12 @@ impl<T> FixedCapacityVec<T> {
     #[inline(always)]
     pub fn get(&self, idx: usize) -> Option<&T> {
         if idx < self.len {
-            self.elements.get(idx).map(|e|
-            // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
-            // number of initialized values starting from `self.element`'s beginning. The pervious
-            // if condition in term checks that idx is Smaller than 
-            unsafe{ e.assume_init_ref() })
+            self.elements.get(idx).map(|e| {
+                // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
+                // number of initialized values starting from `self.element`'s beginning. The pervious
+                // if condition in term checks that idx is Smaller than
+                unsafe { e.assume_init_ref() }
+            })
         } else {
             None
         }
@@ -188,11 +195,10 @@ impl<T> FixedCapacityVec<T> {
     #[inline(always)]
     pub fn get_mut(&mut self, idx: usize) -> Option<&mut T> {
         if idx < self.len {
-            self.elements.get_mut(idx).map(|e|
+            self.elements.get_mut(idx).map(|e| {
                 // SAFETY: per the previous if statement, the index points into the range of
                 // initialized stack members.
-                unsafe{
-                    e.assume_init_mut()
+                unsafe { e.assume_init_mut() }
             })
         } else {
             None
@@ -211,9 +217,7 @@ impl<T: Clone> FixedCapacityVec<T> {
         for e in values {
             // SAFETY: this is safe, as the previous if statement verifies that there is enough
             // space for all elements from `values` in `stack`
-            unsafe {
-                self.push_unchecked(e.clone());
-            }
+            unsafe { self.push_unchecked(e.clone()) };
         }
 
         Ok(())

--- a/src/core/fixed_capacity_vec.rs
+++ b/src/core/fixed_capacity_vec.rs
@@ -1,0 +1,327 @@
+use core::mem::MaybeUninit;
+
+use alloc::boxed::Box;
+
+/// The operation would remove more elements than currently present or tries to access an element
+/// when none are present
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct EmptyContainerError;
+
+/// The operation would add elements past the maximum capacity
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FullContainerError;
+
+impl From<FullContainerError> for crate::RuntimeError {
+    fn from(_: FullContainerError) -> Self {
+        Self::StackExhaustion
+    }
+}
+
+// TODO consider adding a generic ContainerError enum?
+
+pub struct FixedCapacityVec<T> {
+    /// A contiguous, non-reallocating, heap allocated vector. Behaves like a subset of
+    /// [`alloc::vec::Vec`], cleansed of any operation that reallocates. Backed by via boxed
+    /// slice containing elements of type `MaybeUninit<T>`. The maximum size (pendant to
+    /// [`alloc::vec::Vec::capacity`]) is determined at creation and remains unchanged over the
+    /// lifetime of [`Self`]. Nonetheless a variable amount of `T` can be kept within [`Self`], just
+    /// never more than the maximum size passed to the constructor.
+    ///
+    /// This can be used as a stack, in which case the first element (forming the bottom of the
+    /// stack) is at index 0, and new elements grow towards [`Self`]'s end. The last element
+    /// (`self.stack[self.stack.len() - 1]` is the topmost possible entry.
+    elements: Box<[MaybeUninit<T>]>,
+
+    /// Number of elements in [`Self`]. Also an index, pointing always to the first unused slot in
+    /// [`Self::elements`].
+    // Developer notes:
+    // - It is UB to access `self.elements[self.len]` or any other index larger than `self.len`.
+    // - If `self.stack_height == 0`, then there are no elements.
+    // - The guaranteed to be initialized range of [`Self::stack`] always is `self.stack[..self.stack_height]`.
+    len: usize,
+}
+
+impl<T> FixedCapacityVec<T> {
+    /// Construct new [`Self`], holding up to `capacity` elements of type `T`
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            elements: Box::new_uninit_slice(capacity),
+            len: 0,
+        }
+    }
+
+    /// Check if the [`Self`] is empty
+    #[inline(always)]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Check if the [`Self`] is full
+    #[inline(always)]
+    pub const fn is_full(&self) -> bool {
+        self.len == self.elements.len()
+    }
+
+    /// Get the [`Self`] is height.
+    #[inline(always)]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Get the maximum number of elements that fit into [`Self`].
+    #[inline(always)]
+    pub const fn capacity(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Push a value to the end of [`Self`]
+    ///
+    /// # Safety
+    ///
+    /// - Causes UB if [`Self`] is already full.
+    /// - Causes UB if [`Self`] has a capacity equal to `usize::MAX`
+    #[inline(always)]
+    pub unsafe fn push_unchecked(&mut self, value: T) {
+        debug_assert!(!self.is_full());
+        debug_assert!(self.capacity() < usize::MAX);
+
+        // SAFETY: This must never be called when `Self` is full
+        unsafe { *self.elements.get_unchecked_mut(self.len) = MaybeUninit::new(value) };
+
+        // SAFETY: This must never be called when `self.capacity()` is `usize::MAX`
+        self.len = unsafe { self.len.unchecked_add(1) };
+    }
+
+    /// Push a value to the end of [`Self`]
+    pub fn push(&mut self, value: T) -> Result<(), FullContainerError> {
+        // check if insertion will overflow `self.len`
+        let new_len = self.len.checked_add(1).ok_or(FullContainerError)?;
+
+        *self.elements.get_mut(self.len).ok_or(FullContainerError)? = MaybeUninit::new(value);
+
+        // only "commit" the `new_len` if the insertion actually succeeded
+        self.len = new_len;
+
+        Ok(())
+    }
+
+    /// Pop a value from [`Self`]'s top/tail
+    ///
+    /// # Safety
+    ///
+    /// Causes UB if the stack is empty.
+    #[inline(always)]
+    pub unsafe fn pop_unchecked(&mut self) -> T {
+        debug_assert!(!self.is_empty());
+
+        // SAFETY: This must never be called when `self` is empty. If the stack is indeed not
+        // empty, then both the unchecked subtraction is guaranteed not to underflow.
+        self.len = unsafe { self.len.unchecked_sub(1) };
+
+        // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the number
+        // of initialized values starting from `self.element`'s beginning. As we require `self.len`
+        // not to be zero before calling this function, it is now at zero and thus a valid index to
+        // an initialized element.
+        unsafe { self.elements.get_unchecked(self.len).assume_init_read() }
+    }
+
+    /// Pop a value from [`Self`]'s top/tail
+    pub fn pop(&mut self) -> Result<T, EmptyContainerError> {
+        self.len = self.len.checked_sub(1).ok_or(EmptyContainerError)?;
+
+        let value = self.elements.get(self.len).ok_or(EmptyContainerError)?;
+
+        Ok(
+            // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
+            // number of initialized values starting from `self.element`'s beginning.
+            unsafe { value.assume_init_read() },
+        )
+    }
+
+    /// Peek at the topmost/last value from [`Self`]
+    ///
+    /// # Safety
+    ///
+    /// Causes UB if the stack is empty.
+    #[inline(always)]
+    pub unsafe fn peek_unchecked(&self) -> &T {
+        debug_assert!(!self.is_empty());
+
+        // SAFETY: This must never be called when the `self` is empty. If the stack is indeed not
+        // empty, then both the unchecked subtraction can not underflow, and the element at that
+        // index will be already initialized.
+        unsafe {
+            self.elements
+                .get_unchecked(self.len.unchecked_sub(1))
+                .assume_init_ref()
+        }
+    }
+
+    /// Peek at the topmost/last value from [`Self`]
+    pub fn peek(&self) -> Result<&T, EmptyContainerError> {
+        let idx = self.len.checked_sub(1).ok_or(EmptyContainerError)?;
+
+        let value = self.elements.get(idx).ok_or(EmptyContainerError)?;
+
+        Ok(
+            // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
+            // number of initialized values starting from `self.element`'s beginning.
+            unsafe { value.assume_init_ref() },
+        )
+    }
+
+    /// Get a shared ref to the nth element in [`Self`]
+    #[inline(always)]
+    pub fn get(&self, idx: usize) -> Option<&T> {
+        if idx < self.len {
+            self.elements.get(idx).map(|e|
+            // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
+            // number of initialized values starting from `self.element`'s beginning. The pervious
+            // if condition in term checks that idx is Smaller than 
+            unsafe{ e.assume_init_ref() })
+        } else {
+            None
+        }
+    }
+
+    /// Get a mut ref to the nth element in [`Self`]
+    #[inline(always)]
+    pub fn get_mut(&mut self, idx: usize) -> Option<&mut T> {
+        if idx < self.len {
+            self.elements.get_mut(idx).map(|e|
+                // SAFETY: per the previous if statement, the index points into the range of
+                // initialized stack members.
+                unsafe{
+                    e.assume_init_mut()
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: Clone> FixedCapacityVec<T> {
+    /// Push from a slice into [`Self`], appending after the last/topmost element
+    pub fn push_from_slice(&mut self, values: &[T]) -> Result<(), FullContainerError> {
+        // verify `values` fits into the new self
+        if values.len() > (self.elements.len() - self.len) {
+            return Err(FullContainerError);
+        }
+
+        for e in values {
+            // SAFETY: this is safe, as the previous if statement verifies that there is enough
+            // space for all elements from `values` in `stack`
+            unsafe {
+                self.push_unchecked(e.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Pop `n` elements from [`Self`] into a slice. The topmost/last element of [`Self`] will
+    /// become the slice's last element.
+    pub fn pop_into_slice(
+        &mut self,
+        n: usize,
+    ) -> Result<impl core::ops::Deref<Target = [T]> + '_, EmptyContainerError> {
+        // verify at least `n` elements are still one the stack
+        if n > self.elements.len() {
+            return Err(EmptyContainerError);
+        }
+
+        let old_len = self.len();
+
+        // SAFETY: the previous if statement ensure that `n` is smaller than or equal to
+        // `self.elements.len()`, hence this subtraction is guaranteed to not underflow
+        self.len = unsafe { self.len.unchecked_sub(n) };
+
+        // SAFETY: the prior if statement checks that `stack_height - n` wont underflow. And the
+        // rest of the module ensures that stack_height never gets bigger than `self.stack.len()`.
+        // Thus the index range is always in-bounds.
+        Ok(SliceDropGuard(unsafe {
+            self.elements.get_unchecked_mut(self.len..old_len)
+        }))
+    }
+}
+
+pub struct SliceDropGuard<'a, T>(&'a mut [MaybeUninit<T>]);
+
+impl<'a, T> core::ops::Deref for SliceDropGuard<'a, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The rest of the module ensures that stack_height never gets bigger than
+        // `self.stack.len()`. Thus the index range is always in-bounds.
+        unsafe { slice_assume_init(self.0) }
+    }
+}
+
+impl<'a, T> Drop for SliceDropGuard<'a, T> {
+    fn drop(&mut self) {
+        for e in &mut *self.0 {
+            // SAFETY: The rest of the module ensures that stack_height never gets bigger than
+            // `self.stack.len()`. Thus the index range is always in-bounds.
+            unsafe { e.assume_init_drop() };
+        }
+    }
+}
+
+impl<T: Copy> FixedCapacityVec<T> {
+    /// Remove `remove_count` values from [`Self`], keeping the topmost `keep_count` values
+    ///
+    /// From the [`Self`], remove `remove_count` elements, by sliding down the `keep_count` last/topmost
+    /// values `remove_count` positions forward/towards the bottom.
+    ///
+    /// **Effects**
+    ///
+    /// - after the operation, [`Self`] will contain `remove_count` fewer elements
+    /// - `keep_count` topmost elements will be identical before and after the operation
+    /// - all elements below the `remove_count + keep_count` topmost stack entry remain
+    pub fn remove_in_between(&mut self, remove_count: usize, keep_count: usize) {
+        // TODO make unchecked version, remove overflowing arithmetic in safe version
+        let len = self.len();
+        self.elements
+            .copy_within(len - keep_count..len, len - keep_count - remove_count);
+        self.len -= remove_count;
+    }
+}
+
+impl<T: core::fmt::Debug> core::fmt::Debug for FixedCapacityVec<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // SAFETY: per the guarantees of push/pop/etc., `0..self.stack_height` is always a range to
+        // initalized values.
+        let stack_elements_slice = unsafe { slice_assume_init(&self.elements[..self.len]) };
+
+        f.debug_struct("Stack")
+            .field("stack", &stack_elements_slice)
+            .field("stack_height", &self.len)
+            .finish()
+    }
+}
+
+impl<T> Drop for FixedCapacityVec<T> {
+    fn drop(&mut self) {
+        // SAFETY: self is guaranteed to have at least `self.len` elements, because `sel.len` can
+        // not grow past `self.elements.len` (aka `self.capacity()`).
+        for e in unsafe { self.elements.get_unchecked_mut(0..self.len) } {
+            // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
+            // number of initialized values starting from `self.element`'s beginning.
+            unsafe { e.assume_init_drop() }
+        }
+    }
+}
+
+// TODO use assume_init_ref, once we get the MSRV to 1.93.0
+/// # Safety
+///
+/// Use this to assume a range of a slice to be initialized. This is provided starting with Rust
+/// 1.93.0.
+#[inline(always)]
+unsafe fn slice_assume_init<T>(slice: &[MaybeUninit<T>]) -> &[T] {
+    // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
+    // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
+    // The pointer obtained is valid since it refers to memory owned by `slice` which is a
+    // reference and thus guaranteed to be valid for reads.
+    unsafe { &*(slice as *const _ as *const [T]) }
+}

--- a/src/core/fixed_capacity_vec.rs
+++ b/src/core/fixed_capacity_vec.rs
@@ -129,16 +129,13 @@ impl<T> FixedCapacityVec<T> {
     pub fn pop(&mut self) -> Result<T, EmptyContainerError> {
         self.len = self.len.checked_sub(1).ok_or(EmptyContainerError)?;
 
-        let value = self
-            .elements
-            .get(self.len)
-            .expect("than len is never larger than the length of elements");
+        // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the number
+        // of initialized values starting from `self.element`'s beginning. As we require `self.len`
+        // not to be zero before calling this function, it is now at zero and thus a valid index to
+        // an initialized element.
+        let value = unsafe { self.elements.get_unchecked(self.len).assume_init_read() };
 
-        Ok(
-            // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
-            // number of initialized values starting from `self.element`'s beginning.
-            unsafe { value.assume_init_read() },
-        )
+        Ok(value)
     }
 
     /// Peek at the topmost/last value from [`Self`]
@@ -164,16 +161,13 @@ impl<T> FixedCapacityVec<T> {
     pub fn peek(&self) -> Result<&T, EmptyContainerError> {
         let idx = self.len.checked_sub(1).ok_or(EmptyContainerError)?;
 
-        let value = self
-            .elements
-            .get(idx)
-            .expect("than len is never larger than the length of elements");
+        // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the number
+        // of initialized values starting from `self.element`'s beginning. As we require `self.len`
+        // not to be zero before calling this function, it is now at zero and thus a valid index to
+        // an initialized element.
+        let value = unsafe { self.elements.get_unchecked(idx).assume_init_ref() };
 
-        Ok(
-            // SAFETY: This is guaranteed to be initialized, as `self.len` accurately tracks the
-            // number of initialized values starting from `self.element`'s beginning.
-            unsafe { value.assume_init_ref() },
-        )
+        Ok(value)
     }
 
     /// Get a shared ref to the nth element in [`Self`]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,4 +4,5 @@ pub mod indices;
 pub mod reader;
 pub mod rw_spinlock;
 pub mod sidetable;
+pub mod stack;
 pub mod utils;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,8 +1,8 @@
 pub mod error;
 
+pub mod fixed_capacity_vec;
 pub mod indices;
 pub mod reader;
 pub mod rw_spinlock;
 pub mod sidetable;
-pub mod stack;
 pub mod utils;

--- a/src/execution/const_interpreter_loop.rs
+++ b/src/execution/const_interpreter_loop.rs
@@ -70,32 +70,32 @@ pub(crate) unsafe fn run_const<T: Config>(
                     "Constant instruction: global.get [{global_idx}] -> [{:?}]",
                     global
                 );
-                stack.push_value::<T>(global.value)?;
+                stack.push_value(global.value)?;
             }
             I32_CONST => {
                 let constant = wasm.read_var_i32().unwrap_validated();
                 trace!("Constant instruction: i32.const [] -> [{constant}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             F32_CONST => {
                 let constant = value::F32::from_bits(wasm.read_f32().unwrap_validated());
                 trace!("Constanting instruction: f32.const [] -> [{constant}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             F64_CONST => {
                 let constant = value::F64::from_bits(wasm.read_f64().unwrap_validated());
                 trace!("Constanting instruction: f64.const [] -> [{constant}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             I64_CONST => {
                 let constant = wasm.read_var_i64().unwrap_validated();
                 trace!("Constant instruction: i64.const [] -> [{constant}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             REF_NULL => {
                 let reftype = RefType::read(wasm).unwrap_validated();
 
-                stack.push_value::<T>(Value::Ref(Ref::Null(reftype)))?;
+                stack.push_value(Value::Ref(Ref::Null(reftype)))?;
                 trace!("Instruction: ref.null '{:?}' -> [{:?}]", reftype, reftype);
             }
             REF_FUNC => {
@@ -105,7 +105,7 @@ pub(crate) unsafe fn run_const<T: Config>(
                 // SAFETY: Validation guarantees the function index to be valid
                 // in the current module.
                 let func_addr = unsafe { store.modules.get(module).func_addrs.get(func_idx) };
-                stack.push_value::<T>(Value::Ref(Ref::Func(*func_addr)))?;
+                stack.push_value(Value::Ref(Ref::Func(*func_addr)))?;
             }
 
             FD_EXTENSIONS => {
@@ -118,7 +118,7 @@ pub(crate) unsafe fn run_const<T: Config>(
                             *byte_ref = wasm.read_u8().unwrap_validated();
                         }
 
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
                     0x00..=0x0B | 0x0D.. => unreachable_validated!(),
                 }

--- a/src/execution/interpreter_loop.rs
+++ b/src/execution/interpreter_loop.rs
@@ -315,11 +315,9 @@ pub(super) fn run<T: Config>(
 
                 match func_to_call_inst {
                     FuncInst::HostFunc(host_func_to_call_inst) => {
-                        let params = stack
-                            .pop_tail_iter(
-                                host_func_to_call_inst.function_type.params.valtypes.len(),
-                            )
-                            .collect();
+                        let params = stack.pop_tail_iter(
+                            host_func_to_call_inst.function_type.params.valtypes.len(),
+                        );
 
                         resumable.current_func_addr = current_func_addr;
                         resumable.pc = wasm.pc;
@@ -423,11 +421,9 @@ pub(super) fn run<T: Config>(
 
                 match func_to_call_inst {
                     FuncInst::HostFunc(host_func_to_call_inst) => {
-                        let params = stack
-                            .pop_tail_iter(
-                                host_func_to_call_inst.function_type.params.valtypes.len(),
-                            )
-                            .collect();
+                        let params = stack.pop_tail_iter(
+                            host_func_to_call_inst.function_type.params.valtypes.len(),
+                        );
 
                         resumable.current_func_addr = current_func_addr;
                         resumable.pc = wasm.pc;
@@ -480,9 +476,9 @@ pub(super) fn run<T: Config>(
                 let val2 = stack.pop_value();
                 let val1 = stack.pop_value();
                 if test_val != 0 {
-                    stack.push_value::<T>(val1)?;
+                    stack.push_value(val1)?;
                 } else {
-                    stack.push_value::<T>(val2)?;
+                    stack.push_value(val2)?;
                 }
                 trace!("Instruction: SELECT");
             }
@@ -493,9 +489,9 @@ pub(super) fn run<T: Config>(
                 let val2 = stack.pop_value();
                 let val1 = stack.pop_value();
                 if test_val != 0 {
-                    stack.push_value::<T>(val1)?;
+                    stack.push_value(val1)?;
                 } else {
-                    stack.push_value::<T>(val2)?;
+                    stack.push_value(val2)?;
                 }
                 trace!("Instruction: SELECT_T");
             }
@@ -505,7 +501,7 @@ pub(super) fn run<T: Config>(
                 // next.
                 let local_idx = unsafe { LocalIdx::read_unchecked(wasm) };
                 let value = *stack.get_local(local_idx);
-                stack.push_value::<T>(value)?;
+                stack.push_value(value)?;
                 trace!("Instruction: local.get {} [] -> [t]", local_idx);
             }
             LOCAL_SET => {
@@ -544,7 +540,7 @@ pub(super) fn run<T: Config>(
                 // store. Therefore, it is valid in the current store.
                 let global = unsafe { store.globals.get(global_addr) };
 
-                stack.push_value::<T>(global.value)?;
+                stack.push_value(global.value)?;
 
                 trace!(
                     "Instruction: global.get '{}' [<GLOBAL>] -> [{:?}]",
@@ -597,7 +593,7 @@ pub(super) fn run<T: Config>(
                     .get(i.cast_unsigned().into_usize())
                     .ok_or(TrapError::TableOrElementAccessOutOfBounds)?;
 
-                stack.push_value::<T>((*val).into())?;
+                stack.push_value((*val).into())?;
                 trace!(
                     "Instruction: table.get '{}' [{}] -> [{}]",
                     table_idx,
@@ -660,7 +656,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem_inst.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I32(data))?;
+                stack.push_value(Value::I32(data))?;
                 trace!("Instruction: i32.load [{relative_address}] -> [{data}]");
             }
             I64_LOAD => {
@@ -683,7 +679,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I64(data))?;
+                stack.push_value(Value::I64(data))?;
                 trace!("Instruction: i64.load [{relative_address}] -> [{data}]");
             }
             F32_LOAD => {
@@ -706,7 +702,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::F32(data))?;
+                stack.push_value(Value::F32(data))?;
                 trace!("Instruction: f32.load [{relative_address}] -> [{data}]");
             }
             F64_LOAD => {
@@ -729,7 +725,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::F64(data))?;
+                stack.push_value(Value::F64(data))?;
                 trace!("Instruction: f64.load [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_S => {
@@ -752,7 +748,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i8 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I32(data as u32))?;
+                stack.push_value(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load8_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD8_U => {
@@ -775,7 +771,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u8 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I32(data as u32))?;
+                stack.push_value(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load8_u [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_S => {
@@ -798,7 +794,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i16 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I32(data as u32))?;
+                stack.push_value(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load16_s [{relative_address}] -> [{data}]");
             }
             I32_LOAD16_U => {
@@ -821,7 +817,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u16 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I32(data as u32))?;
+                stack.push_value(Value::I32(data as u32))?;
                 trace!("Instruction: i32.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_S => {
@@ -844,7 +840,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i8 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I64(data as u64))?;
+                stack.push_value(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load8_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD8_U => {
@@ -867,7 +863,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u8 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I64(data as u64))?;
+                stack.push_value(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load8_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_S => {
@@ -890,7 +886,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i16 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I64(data as u64))?;
+                stack.push_value(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load16_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD16_U => {
@@ -913,7 +909,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u16 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I64(data as u64))?;
+                stack.push_value(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load16_u [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_S => {
@@ -936,7 +932,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: i32 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I64(data as u64))?;
+                stack.push_value(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load32_s [{relative_address}] -> [{data}]");
             }
             I64_LOAD32_U => {
@@ -959,7 +955,7 @@ pub(super) fn run<T: Config>(
                 let idx = calculate_mem_address(&memarg, relative_address)?;
                 let data: u32 = mem.mem.load(idx)?;
 
-                stack.push_value::<T>(Value::I64(data as u64))?;
+                stack.push_value(Value::I64(data as u64))?;
                 trace!("Instruction: i64.load32_u [{relative_address}] -> [{data}]");
             }
             I32_STORE => {
@@ -1205,7 +1201,7 @@ pub(super) fn run<T: Config>(
                 // store. Therefore, it is valid in the current store.
                 let mem = unsafe { store.memories.get(mem_addr) };
                 let size = mem.size() as u32;
-                stack.push_value::<T>(Value::I32(size))?;
+                stack.push_value(Value::I32(size))?;
                 trace!("Instruction: memory.size [] -> [{}]", size);
             }
             MEMORY_GROW => {
@@ -1234,7 +1230,7 @@ pub(super) fn run<T: Config>(
                     if *fuel >= cost {
                         *fuel -= cost;
                     } else {
-                        stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                        stack.push_value(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                         resumable.current_func_addr = current_func_addr;
                         resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                         resumable.stp = stp;
@@ -1251,20 +1247,20 @@ pub(super) fn run<T: Config>(
                     Ok(_) => sz,
                     Err(_) => u32::MAX,
                 };
-                stack.push_value::<T>(Value::I32(pushed_value))?;
+                stack.push_value(Value::I32(pushed_value))?;
                 trace!("Instruction: memory.grow [{}] -> [{}]", n, pushed_value);
             }
             I32_CONST => {
                 decrement_fuel!(T::get_flat_cost(I32_CONST));
                 let constant = wasm.read_var_i32().unwrap_validated();
                 trace!("Instruction: i32.const [] -> [{constant}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             F32_CONST => {
                 decrement_fuel!(T::get_flat_cost(F32_CONST));
                 let constant = F32::from_bits(wasm.read_f32().unwrap_validated());
                 trace!("Instruction: f32.const [] -> [{constant:.7}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             I32_EQZ => {
                 decrement_fuel!(T::get_flat_cost(I32_EQZ));
@@ -1273,7 +1269,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == 0 { 1 } else { 0 };
 
                 trace!("Instruction: i32.eqz [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_EQ => {
                 decrement_fuel!(T::get_flat_cost(I32_EQ));
@@ -1283,7 +1279,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_NE => {
                 decrement_fuel!(T::get_flat_cost(I32_NE));
@@ -1293,7 +1289,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_LT_S => {
                 decrement_fuel!(T::get_flat_cost(I32_LT_S));
@@ -1303,7 +1299,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.lt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I32_LT_U => {
@@ -1314,7 +1310,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) < (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.lt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_GT_S => {
                 decrement_fuel!(T::get_flat_cost(I32_GT_S));
@@ -1324,7 +1320,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.gt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_GT_U => {
                 decrement_fuel!(T::get_flat_cost(I32_GT_U));
@@ -1334,7 +1330,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) > (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.gt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_LE_S => {
                 decrement_fuel!(T::get_flat_cost(I32_LE_S));
@@ -1344,7 +1340,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.le_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_LE_U => {
                 decrement_fuel!(T::get_flat_cost(I32_LE_U));
@@ -1354,7 +1350,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) <= (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.le_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_GE_S => {
                 decrement_fuel!(T::get_flat_cost(I32_GE_S));
@@ -1364,7 +1360,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i32.ge_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_GE_U => {
                 decrement_fuel!(T::get_flat_cost(I32_GE_U));
@@ -1374,7 +1370,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u32) >= (v2 as u32) { 1 } else { 0 };
 
                 trace!("Instruction: i32.ge_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_EQZ => {
                 decrement_fuel!(T::get_flat_cost(I64_EQZ));
@@ -1383,7 +1379,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == 0 { 1 } else { 0 };
 
                 trace!("Instruction: i64.eqz [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_EQ => {
                 decrement_fuel!(T::get_flat_cost(I64_EQ));
@@ -1393,7 +1389,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_NE => {
                 decrement_fuel!(T::get_flat_cost(I64_NE));
@@ -1403,7 +1399,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_LT_S => {
                 decrement_fuel!(T::get_flat_cost(I64_LT_S));
@@ -1413,7 +1409,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.lt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I64_LT_U => {
@@ -1424,7 +1420,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) < (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.lt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_GT_S => {
                 decrement_fuel!(T::get_flat_cost(I64_GT_S));
@@ -1434,7 +1430,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.gt_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_GT_U => {
                 decrement_fuel!(T::get_flat_cost(I64_GT_U));
@@ -1444,7 +1440,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) > (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.gt_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_LE_S => {
                 decrement_fuel!(T::get_flat_cost(I64_LE_S));
@@ -1454,7 +1450,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.le_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_LE_U => {
                 decrement_fuel!(T::get_flat_cost(I64_LE_U));
@@ -1464,7 +1460,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) <= (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.le_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_GE_S => {
                 decrement_fuel!(T::get_flat_cost(I64_GE_S));
@@ -1474,7 +1470,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: i64.ge_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_GE_U => {
                 decrement_fuel!(T::get_flat_cost(I64_GE_U));
@@ -1484,7 +1480,7 @@ pub(super) fn run<T: Config>(
                 let res = if (v1 as u64) >= (v2 as u64) { 1 } else { 0 };
 
                 trace!("Instruction: i64.ge_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_EQ => {
                 decrement_fuel!(T::get_flat_cost(F32_EQ));
@@ -1494,7 +1490,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_NE => {
                 decrement_fuel!(T::get_flat_cost(F32_NE));
@@ -1504,7 +1500,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_LT => {
                 decrement_fuel!(T::get_flat_cost(F32_LT));
@@ -1514,7 +1510,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.lt [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_GT => {
                 decrement_fuel!(T::get_flat_cost(F32_GT));
@@ -1524,7 +1520,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.gt [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_LE => {
                 decrement_fuel!(T::get_flat_cost(F32_LE));
@@ -1534,7 +1530,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.le [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_GE => {
                 decrement_fuel!(T::get_flat_cost(F32_GE));
@@ -1544,7 +1540,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f32.ge [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             F64_EQ => {
@@ -1555,7 +1551,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 == v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.eq [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_NE => {
                 decrement_fuel!(T::get_flat_cost(F64_NE));
@@ -1565,7 +1561,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 != v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.ne [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_LT => {
                 decrement_fuel!(T::get_flat_cost(F64_LT));
@@ -1575,7 +1571,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 < v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.lt [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_GT => {
                 decrement_fuel!(T::get_flat_cost(F64_GT));
@@ -1585,7 +1581,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 > v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.gt [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_LE => {
                 decrement_fuel!(T::get_flat_cost(F64_LE));
@@ -1595,7 +1591,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 <= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.le [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_GE => {
                 decrement_fuel!(T::get_flat_cost(F64_GE));
@@ -1605,7 +1601,7 @@ pub(super) fn run<T: Config>(
                 let res = if v1 >= v2 { 1 } else { 0 };
 
                 trace!("Instruction: f64.ge [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I32_CLZ => {
@@ -1614,7 +1610,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.leading_zeros() as i32;
 
                 trace!("Instruction: i32.clz [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_CTZ => {
                 decrement_fuel!(T::get_flat_cost(I32_CTZ));
@@ -1622,7 +1618,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.trailing_zeros() as i32;
 
                 trace!("Instruction: i32.ctz [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_POPCNT => {
                 decrement_fuel!(T::get_flat_cost(I32_POPCNT));
@@ -1630,19 +1626,19 @@ pub(super) fn run<T: Config>(
                 let res = v1.count_ones() as i32;
 
                 trace!("Instruction: i32.popcnt [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_CONST => {
                 decrement_fuel!(T::get_flat_cost(I64_CONST));
                 let constant = wasm.read_var_i64().unwrap_validated();
                 trace!("Instruction: i64.const [] -> [{constant}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             F64_CONST => {
                 decrement_fuel!(T::get_flat_cost(F64_CONST));
                 let constant = F64::from_bits(wasm.read_f64().unwrap_validated());
                 trace!("Instruction: f64.const [] -> [{constant}]");
-                stack.push_value::<T>(constant.into())?;
+                stack.push_value(constant.into())?;
             }
             I32_ADD => {
                 decrement_fuel!(T::get_flat_cost(I32_ADD));
@@ -1651,7 +1647,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_add(v2);
 
                 trace!("Instruction: i32.add [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_SUB => {
                 decrement_fuel!(T::get_flat_cost(I32_SUB));
@@ -1660,7 +1656,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_sub(v2);
 
                 trace!("Instruction: i32.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_MUL => {
                 decrement_fuel!(T::get_flat_cost(I32_MUL));
@@ -1669,7 +1665,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_mul(v2);
 
                 trace!("Instruction: i32.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_DIV_S => {
                 decrement_fuel!(T::get_flat_cost(I32_DIV_S));
@@ -1686,7 +1682,7 @@ pub(super) fn run<T: Config>(
                 let res = divisor / dividend;
 
                 trace!("Instruction: i32.div_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_DIV_U => {
                 decrement_fuel!(T::get_flat_cost(I32_DIV_U));
@@ -1703,7 +1699,7 @@ pub(super) fn run<T: Config>(
                 let res = (divisor / dividend) as i32;
 
                 trace!("Instruction: i32.div_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_REM_S => {
                 decrement_fuel!(T::get_flat_cost(I32_REM_S));
@@ -1718,7 +1714,7 @@ pub(super) fn run<T: Config>(
                 let res = res.unwrap_or_default();
 
                 trace!("Instruction: i32.rem_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_CLZ => {
                 decrement_fuel!(T::get_flat_cost(I64_CLZ));
@@ -1726,7 +1722,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.leading_zeros() as i64;
 
                 trace!("Instruction: i64.clz [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_CTZ => {
                 decrement_fuel!(T::get_flat_cost(I64_CTZ));
@@ -1734,7 +1730,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.trailing_zeros() as i64;
 
                 trace!("Instruction: i64.ctz [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_POPCNT => {
                 decrement_fuel!(T::get_flat_cost(I64_POPCNT));
@@ -1742,7 +1738,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.count_ones() as i64;
 
                 trace!("Instruction: i64.popcnt [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_ADD => {
                 decrement_fuel!(T::get_flat_cost(I64_ADD));
@@ -1751,7 +1747,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_add(v2);
 
                 trace!("Instruction: i64.add [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_SUB => {
                 decrement_fuel!(T::get_flat_cost(I64_SUB));
@@ -1760,7 +1756,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_sub(v2);
 
                 trace!("Instruction: i64.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_MUL => {
                 decrement_fuel!(T::get_flat_cost(I64_MUL));
@@ -1769,7 +1765,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_mul(v2);
 
                 trace!("Instruction: i64.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_DIV_S => {
                 decrement_fuel!(T::get_flat_cost(I64_DIV_S));
@@ -1786,7 +1782,7 @@ pub(super) fn run<T: Config>(
                 let res = divisor / dividend;
 
                 trace!("Instruction: i64.div_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_DIV_U => {
                 decrement_fuel!(T::get_flat_cost(I64_DIV_U));
@@ -1803,7 +1799,7 @@ pub(super) fn run<T: Config>(
                 let res = (divisor / dividend) as i64;
 
                 trace!("Instruction: i64.div_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_REM_S => {
                 decrement_fuel!(T::get_flat_cost(I64_REM_S));
@@ -1818,7 +1814,7 @@ pub(super) fn run<T: Config>(
                 let res = res.unwrap_or_default();
 
                 trace!("Instruction: i64.rem_s [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_REM_U => {
                 decrement_fuel!(T::get_flat_cost(I64_REM_U));
@@ -1835,7 +1831,7 @@ pub(super) fn run<T: Config>(
                 let res = (divisor % dividend) as i64;
 
                 trace!("Instruction: i64.rem_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_AND => {
                 decrement_fuel!(T::get_flat_cost(I64_AND));
@@ -1845,7 +1841,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 & v2;
 
                 trace!("Instruction: i64.and [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_OR => {
                 decrement_fuel!(T::get_flat_cost(I64_OR));
@@ -1855,7 +1851,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 | v2;
 
                 trace!("Instruction: i64.or [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_XOR => {
                 decrement_fuel!(T::get_flat_cost(I64_XOR));
@@ -1865,7 +1861,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 ^ v2;
 
                 trace!("Instruction: i64.xor [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_SHL => {
                 decrement_fuel!(T::get_flat_cost(I64_SHL));
@@ -1875,7 +1871,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_shl((v2 & 63) as u32);
 
                 trace!("Instruction: i64.shl [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_SHR_S => {
                 decrement_fuel!(T::get_flat_cost(I64_SHR_S));
@@ -1885,7 +1881,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.wrapping_shr((v2 & 63) as u32);
 
                 trace!("Instruction: i64.shr_s [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_SHR_U => {
                 decrement_fuel!(T::get_flat_cost(I64_SHR_U));
@@ -1895,7 +1891,7 @@ pub(super) fn run<T: Config>(
                 let res = (v1 as u64).wrapping_shr((v2 & 63) as u32);
 
                 trace!("Instruction: i64.shr_u [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_ROTL => {
                 decrement_fuel!(T::get_flat_cost(I64_ROTL));
@@ -1905,7 +1901,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.rotate_left((v2 & 63) as u32);
 
                 trace!("Instruction: i64.rotl [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_ROTR => {
                 decrement_fuel!(T::get_flat_cost(I64_ROTR));
@@ -1915,7 +1911,7 @@ pub(super) fn run<T: Config>(
                 let res = v1.rotate_right((v2 & 63) as u32);
 
                 trace!("Instruction: i64.rotr [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_REM_U => {
                 decrement_fuel!(T::get_flat_cost(I32_REM_U));
@@ -1933,7 +1929,7 @@ pub(super) fn run<T: Config>(
                 let res = res.unwrap_or_default() as i32;
 
                 trace!("Instruction: i32.rem_u [{divisor} {dividend}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_AND => {
                 decrement_fuel!(T::get_flat_cost(I32_AND));
@@ -1942,7 +1938,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 & v2;
 
                 trace!("Instruction: i32.and [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_OR => {
                 decrement_fuel!(T::get_flat_cost(I32_OR));
@@ -1951,7 +1947,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 | v2;
 
                 trace!("Instruction: i32.or [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_XOR => {
                 decrement_fuel!(T::get_flat_cost(I32_XOR));
@@ -1960,7 +1956,7 @@ pub(super) fn run<T: Config>(
                 let res = v1 ^ v2;
 
                 trace!("Instruction: i32.xor [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_SHL => {
                 decrement_fuel!(T::get_flat_cost(I32_SHL));
@@ -1969,7 +1965,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.wrapping_shl(v1 as u32);
 
                 trace!("Instruction: i32.shl [{v2} {v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_SHR_S => {
                 decrement_fuel!(T::get_flat_cost(I32_SHR_S));
@@ -1979,7 +1975,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.wrapping_shr(v1 as u32);
 
                 trace!("Instruction: i32.shr_s [{v2} {v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_SHR_U => {
                 decrement_fuel!(T::get_flat_cost(I32_SHR_U));
@@ -1989,7 +1985,7 @@ pub(super) fn run<T: Config>(
                 let res = (v2 as u32).wrapping_shr(v1 as u32) as i32;
 
                 trace!("Instruction: i32.shr_u [{v2} {v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_ROTL => {
                 decrement_fuel!(T::get_flat_cost(I32_ROTL));
@@ -1999,7 +1995,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.rotate_left(v1 as u32);
 
                 trace!("Instruction: i32.rotl [{v2} {v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_ROTR => {
                 decrement_fuel!(T::get_flat_cost(I32_ROTR));
@@ -2009,7 +2005,7 @@ pub(super) fn run<T: Config>(
                 let res = v2.rotate_right(v1 as u32);
 
                 trace!("Instruction: i32.rotr [{v2} {v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             F32_ABS => {
@@ -2018,7 +2014,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.abs();
 
                 trace!("Instruction: f32.abs [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_NEG => {
                 decrement_fuel!(T::get_flat_cost(F32_NEG));
@@ -2026,7 +2022,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.neg();
 
                 trace!("Instruction: f32.neg [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_CEIL => {
                 decrement_fuel!(T::get_flat_cost(F32_CEIL));
@@ -2034,7 +2030,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.ceil();
 
                 trace!("Instruction: f32.ceil [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_FLOOR => {
                 decrement_fuel!(T::get_flat_cost(F32_FLOOR));
@@ -2042,7 +2038,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.floor();
 
                 trace!("Instruction: f32.floor [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_TRUNC => {
                 decrement_fuel!(T::get_flat_cost(F32_TRUNC));
@@ -2050,7 +2046,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.trunc();
 
                 trace!("Instruction: f32.trunc [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_NEAREST => {
                 decrement_fuel!(T::get_flat_cost(F32_NEAREST));
@@ -2058,7 +2054,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.nearest();
 
                 trace!("Instruction: f32.nearest [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_SQRT => {
                 decrement_fuel!(T::get_flat_cost(F32_SQRT));
@@ -2066,7 +2062,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.sqrt();
 
                 trace!("Instruction: f32.sqrt [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_ADD => {
                 decrement_fuel!(T::get_flat_cost(F32_ADD));
@@ -2075,7 +2071,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 + v2;
 
                 trace!("Instruction: f32.add [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_SUB => {
                 decrement_fuel!(T::get_flat_cost(F32_SUB));
@@ -2084,7 +2080,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 - v2;
 
                 trace!("Instruction: f32.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_MUL => {
                 decrement_fuel!(T::get_flat_cost(F32_MUL));
@@ -2093,7 +2089,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 * v2;
 
                 trace!("Instruction: f32.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_DIV => {
                 decrement_fuel!(T::get_flat_cost(F32_DIV));
@@ -2102,7 +2098,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1 / v2;
 
                 trace!("Instruction: f32.div [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_MIN => {
                 decrement_fuel!(T::get_flat_cost(F32_MIN));
@@ -2111,7 +2107,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.min(v2);
 
                 trace!("Instruction: f32.min [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_MAX => {
                 decrement_fuel!(T::get_flat_cost(F32_MAX));
@@ -2120,7 +2116,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.max(v2);
 
                 trace!("Instruction: f32.max [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_COPYSIGN => {
                 decrement_fuel!(T::get_flat_cost(F32_COPYSIGN));
@@ -2129,7 +2125,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v1.copysign(v2);
 
                 trace!("Instruction: f32.copysign [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             F64_ABS => {
@@ -2138,7 +2134,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.abs();
 
                 trace!("Instruction: f64.abs [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_NEG => {
                 decrement_fuel!(T::get_flat_cost(F64_NEG));
@@ -2146,7 +2142,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.neg();
 
                 trace!("Instruction: f64.neg [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_CEIL => {
                 decrement_fuel!(T::get_flat_cost(F64_CEIL));
@@ -2154,7 +2150,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.ceil();
 
                 trace!("Instruction: f64.ceil [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_FLOOR => {
                 decrement_fuel!(T::get_flat_cost(F64_FLOOR));
@@ -2162,7 +2158,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.floor();
 
                 trace!("Instruction: f64.floor [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_TRUNC => {
                 decrement_fuel!(T::get_flat_cost(F64_TRUNC));
@@ -2170,7 +2166,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.trunc();
 
                 trace!("Instruction: f64.trunc [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_NEAREST => {
                 decrement_fuel!(T::get_flat_cost(F64_NEAREST));
@@ -2178,7 +2174,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.nearest();
 
                 trace!("Instruction: f64.nearest [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_SQRT => {
                 decrement_fuel!(T::get_flat_cost(F64_SQRT));
@@ -2186,7 +2182,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.sqrt();
 
                 trace!("Instruction: f64.sqrt [{v1}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_ADD => {
                 decrement_fuel!(T::get_flat_cost(F64_ADD));
@@ -2195,7 +2191,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 + v2;
 
                 trace!("Instruction: f64.add [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_SUB => {
                 decrement_fuel!(T::get_flat_cost(F64_SUB));
@@ -2204,7 +2200,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 - v2;
 
                 trace!("Instruction: f64.sub [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_MUL => {
                 decrement_fuel!(T::get_flat_cost(F64_MUL));
@@ -2213,7 +2209,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 * v2;
 
                 trace!("Instruction: f64.mul [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_DIV => {
                 decrement_fuel!(T::get_flat_cost(F64_DIV));
@@ -2222,7 +2218,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1 / v2;
 
                 trace!("Instruction: f64.div [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_MIN => {
                 decrement_fuel!(T::get_flat_cost(F64_MIN));
@@ -2231,7 +2227,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.min(v2);
 
                 trace!("Instruction: f64.min [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_MAX => {
                 decrement_fuel!(T::get_flat_cost(F64_MAX));
@@ -2240,7 +2236,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.max(v2);
 
                 trace!("Instruction: f64.max [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_COPYSIGN => {
                 decrement_fuel!(T::get_flat_cost(F64_COPYSIGN));
@@ -2249,7 +2245,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v1.copysign(v2);
 
                 trace!("Instruction: f64.copysign [{v1} {v2}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_WRAP_I64 => {
                 decrement_fuel!(T::get_flat_cost(I32_WRAP_I64));
@@ -2257,7 +2253,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v as i32;
 
                 trace!("Instruction: i32.wrap_i64 [{v}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_TRUNC_F32_S => {
                 decrement_fuel!(T::get_flat_cost(I32_TRUNC_F32_S));
@@ -2275,7 +2271,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_i32();
 
                 trace!("Instruction: i32.trunc_f32_s [{v:.7}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_TRUNC_F32_U => {
                 decrement_fuel!(T::get_flat_cost(I32_TRUNC_F32_U));
@@ -2293,7 +2289,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_u32() as i32;
 
                 trace!("Instruction: i32.trunc_f32_u [{v:.7}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I32_TRUNC_F64_S => {
@@ -2312,7 +2308,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_i32();
 
                 trace!("Instruction: i32.trunc_f64_s [{v:.7}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_TRUNC_F64_U => {
                 decrement_fuel!(T::get_flat_cost(I32_TRUNC_F64_U));
@@ -2330,7 +2326,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.as_u32() as i32;
 
                 trace!("Instruction: i32.trunc_f32_u [{v:.7}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I64_EXTEND_I32_S => {
@@ -2340,7 +2336,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v as i64;
 
                 trace!("Instruction: i64.extend_i32_s [{v}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I64_EXTEND_I32_U => {
@@ -2350,7 +2346,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v as u32 as i64;
 
                 trace!("Instruction: i64.extend_i32_u [{v}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I64_TRUNC_F32_S => {
@@ -2370,7 +2366,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_i64();
 
                 trace!("Instruction: i64.trunc_f32_s [{v:.7}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_TRUNC_F32_U => {
                 decrement_fuel!(T::get_flat_cost(I64_TRUNC_F32_U));
@@ -2388,7 +2384,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_u64() as i64;
 
                 trace!("Instruction: i64.trunc_f32_u [{v:.7}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
 
             I64_TRUNC_F64_S => {
@@ -2408,7 +2404,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_i64();
 
                 trace!("Instruction: i64.trunc_f64_s [{v:.17}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_TRUNC_F64_U => {
                 decrement_fuel!(T::get_flat_cost(I64_TRUNC_F64_U));
@@ -2426,7 +2422,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.as_u64() as i64;
 
                 trace!("Instruction: i64.trunc_f64_u [{v:.17}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_CONVERT_I32_S => {
                 decrement_fuel!(T::get_flat_cost(F32_CONVERT_I32_S));
@@ -2434,7 +2430,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = value::F32(v as f32);
 
                 trace!("Instruction: f32.convert_i32_s [{v}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_CONVERT_I32_U => {
                 decrement_fuel!(T::get_flat_cost(F32_CONVERT_I32_U));
@@ -2442,7 +2438,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = value::F32(v as u32 as f32);
 
                 trace!("Instruction: f32.convert_i32_u [{v}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_CONVERT_I64_S => {
                 decrement_fuel!(T::get_flat_cost(F32_CONVERT_I64_S));
@@ -2450,7 +2446,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = value::F32(v as f32);
 
                 trace!("Instruction: f32.convert_i64_s [{v}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_CONVERT_I64_U => {
                 decrement_fuel!(T::get_flat_cost(F32_CONVERT_I64_U));
@@ -2458,7 +2454,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = value::F32(v as u64 as f32);
 
                 trace!("Instruction: f32.convert_i64_u [{v}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_DEMOTE_F64 => {
                 decrement_fuel!(T::get_flat_cost(F32_DEMOTE_F64));
@@ -2466,7 +2462,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = v.as_f32();
 
                 trace!("Instruction: f32.demote_f64 [{v:.17}] -> [{res:.7}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_CONVERT_I32_S => {
                 decrement_fuel!(T::get_flat_cost(F64_CONVERT_I32_S));
@@ -2474,7 +2470,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = value::F64(v as f64);
 
                 trace!("Instruction: f64.convert_i32_s [{v}] -> [{res:.17}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_CONVERT_I32_U => {
                 decrement_fuel!(T::get_flat_cost(F64_CONVERT_I32_U));
@@ -2482,7 +2478,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = value::F64(v as u32 as f64);
 
                 trace!("Instruction: f64.convert_i32_u [{v}] -> [{res:.17}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_CONVERT_I64_S => {
                 decrement_fuel!(T::get_flat_cost(F64_CONVERT_I64_S));
@@ -2490,7 +2486,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = value::F64(v as f64);
 
                 trace!("Instruction: f64.convert_i64_s [{v}] -> [{res:.17}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_CONVERT_I64_U => {
                 decrement_fuel!(T::get_flat_cost(F64_CONVERT_I64_U));
@@ -2498,7 +2494,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = value::F64(v as u64 as f64);
 
                 trace!("Instruction: f64.convert_i64_u [{v}] -> [{res:.17}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_PROMOTE_F32 => {
                 decrement_fuel!(T::get_flat_cost(F64_PROMOTE_F32));
@@ -2506,7 +2502,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = v.as_f64();
 
                 trace!("Instruction: f64.promote_f32 [{v:.7}] -> [{res:.17}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I32_REINTERPRET_F32 => {
                 decrement_fuel!(T::get_flat_cost(I32_REINTERPRET_F32));
@@ -2514,7 +2510,7 @@ pub(super) fn run<T: Config>(
                 let res: i32 = v.reinterpret_as_i32();
 
                 trace!("Instruction: i32.reinterpret_f32 [{v:.7}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             I64_REINTERPRET_F64 => {
                 decrement_fuel!(T::get_flat_cost(I64_REINTERPRET_F64));
@@ -2522,7 +2518,7 @@ pub(super) fn run<T: Config>(
                 let res: i64 = v.reinterpret_as_i64();
 
                 trace!("Instruction: i64.reinterpret_f64 [{v:.17}] -> [{res}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F32_REINTERPRET_I32 => {
                 decrement_fuel!(T::get_flat_cost(F32_REINTERPRET_I32));
@@ -2530,7 +2526,7 @@ pub(super) fn run<T: Config>(
                 let res: value::F32 = value::F32::from_bits(v1 as u32);
 
                 trace!("Instruction: f32.reinterpret_i32 [{v1}] -> [{res:.7}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             F64_REINTERPRET_I64 => {
                 decrement_fuel!(T::get_flat_cost(F64_REINTERPRET_I64));
@@ -2538,13 +2534,13 @@ pub(super) fn run<T: Config>(
                 let res: value::F64 = value::F64::from_bits(v1 as u64);
 
                 trace!("Instruction: f64.reinterpret_i64 [{v1}] -> [{res:.17}]");
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
             }
             REF_NULL => {
                 decrement_fuel!(T::get_flat_cost(REF_NULL));
                 let reftype = RefType::read(wasm).unwrap_validated();
 
-                stack.push_value::<T>(Value::Ref(Ref::Null(reftype)))?;
+                stack.push_value(Value::Ref(Ref::Null(reftype)))?;
                 trace!("Instruction: ref.null '{:?}' -> [{:?}]", reftype, reftype);
             }
             REF_IS_NULL => {
@@ -2554,7 +2550,7 @@ pub(super) fn run<T: Config>(
 
                 let res = if is_null { 1 } else { 0 };
                 trace!("Instruction: ref.is_null [{}] -> [{}]", rref, res);
-                stack.push_value::<T>(Value::I32(res))?;
+                stack.push_value(Value::I32(res))?;
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-ref-mathsf-ref-func-x
             REF_FUNC => {
@@ -2571,7 +2567,7 @@ pub(super) fn run<T: Config>(
                 // SAFETY: Validation guarantees the function index to be valid
                 // in the current module.
                 let func_addr = unsafe { current_module.func_addrs.get(func_idx) };
-                stack.push_value::<T>(Value::Ref(Ref::Func(*func_addr)))?;
+                stack.push_value(Value::Ref(Ref::Func(*func_addr)))?;
             }
             FC_EXTENSIONS => {
                 // Should we call instruction hook here as well? Multibyte instruction
@@ -2595,7 +2591,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f32_s [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     I32_TRUNC_SAT_F32_U => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(I32_TRUNC_SAT_F32_U));
@@ -2611,7 +2607,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f32_u [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     I32_TRUNC_SAT_F64_S => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(I32_TRUNC_SAT_F64_S));
@@ -2629,7 +2625,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f64_s [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     I32_TRUNC_SAT_F64_U => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(I32_TRUNC_SAT_F64_U));
@@ -2645,7 +2641,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i32.trunc_sat_f64_u [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     I64_TRUNC_SAT_F32_S => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(I64_TRUNC_SAT_F32_S));
@@ -2663,7 +2659,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f32_s [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     I64_TRUNC_SAT_F32_U => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(I64_TRUNC_SAT_F32_U));
@@ -2679,7 +2675,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f32_u [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     I64_TRUNC_SAT_F64_S => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(I64_TRUNC_SAT_F64_S));
@@ -2697,7 +2693,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f64_s [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     I64_TRUNC_SAT_F64_U => {
                         decrement_fuel!(T::get_fc_extension_flat_cost(I64_TRUNC_SAT_F64_U));
@@ -2713,7 +2709,7 @@ pub(super) fn run<T: Config>(
                         };
 
                         trace!("Instruction: i64.trunc_sat_f64_u [{v1}] -> [{res}]");
-                        stack.push_value::<T>(res.into())?;
+                        stack.push_value(res.into())?;
                     }
                     // See https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-memory-mathsf-memory-init-x
                     // Copy a region from a data segment into memory
@@ -2738,7 +2734,7 @@ pub(super) fn run<T: Config>(
                             if *fuel >= cost {
                                 *fuel -= cost;
                             } else {
-                                stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                                stack.push_value(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
                                 resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
@@ -2831,7 +2827,7 @@ pub(super) fn run<T: Config>(
                             if *fuel >= cost {
                                 *fuel -= cost;
                             } else {
-                                stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                                stack.push_value(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
                                 resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
@@ -2893,7 +2889,7 @@ pub(super) fn run<T: Config>(
                             if *fuel >= cost {
                                 *fuel -= cost;
                             } else {
-                                stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                                stack.push_value(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
                                 resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
@@ -2935,7 +2931,7 @@ pub(super) fn run<T: Config>(
                             if *fuel >= cost {
                                 *fuel -= cost;
                             } else {
-                                stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                                stack.push_value(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
                                 resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
@@ -3042,7 +3038,7 @@ pub(super) fn run<T: Config>(
                             if *fuel >= cost {
                                 *fuel -= cost;
                             } else {
-                                stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                                stack.push_value(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
                                 resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
@@ -3137,7 +3133,7 @@ pub(super) fn run<T: Config>(
                             if *fuel >= cost {
                                 *fuel -= cost;
                             } else {
-                                stack.push_value::<T>(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                                stack.push_value(Value::I32(n)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
                                 resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
@@ -3154,10 +3150,10 @@ pub(super) fn run<T: Config>(
                         // if the grow operation fails, err := Value::I32(2^32-1) is pushed to the stack per spec
                         match tab.grow(n, val) {
                             Ok(_) => {
-                                stack.push_value::<T>(Value::I32(sz))?;
+                                stack.push_value(Value::I32(sz))?;
                             }
                             Err(_) => {
-                                stack.push_value::<T>(Value::I32(u32::MAX))?;
+                                stack.push_value(Value::I32(u32::MAX))?;
                             }
                         }
                     }
@@ -3183,7 +3179,7 @@ pub(super) fn run<T: Config>(
 
                         let sz = tab.elem.len() as u32;
 
-                        stack.push_value::<T>(Value::I32(sz))?;
+                        stack.push_value(Value::I32(sz))?;
 
                         trace!("Instruction: table.size '{}' [] -> [{}]", table_idx, sz);
                     }
@@ -3214,7 +3210,7 @@ pub(super) fn run<T: Config>(
                             if *fuel >= cost {
                                 *fuel -= cost;
                             } else {
-                                stack.push_value::<T>(Value::I32(len)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
+                                stack.push_value(Value::I32(len)).unwrap_validated(); // we are pushing back what was just popped, this can't panic.
                                 resumable.current_func_addr = current_func_addr;
                                 resumable.pc = prev_pc; // the instruction was fetched already, we roll this back
                                 resumable.stp = stp;
@@ -3259,7 +3255,7 @@ pub(super) fn run<T: Config>(
 
                 let res = if v | 0x7F != 0x7F { v | 0xFFFFFF00 } else { v };
 
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
 
                 trace!("Instruction i32.extend8_s [{}] -> [{}]", v, res);
             }
@@ -3278,7 +3274,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
 
                 trace!("Instruction i32.extend16_s [{}] -> [{}]", v, res);
             }
@@ -3297,7 +3293,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
 
                 trace!("Instruction i64.extend8_s [{}] -> [{}]", v, res);
             }
@@ -3316,7 +3312,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
 
                 trace!("Instruction i64.extend16_s [{}] -> [{}]", v, res);
             }
@@ -3335,7 +3331,7 @@ pub(super) fn run<T: Config>(
                     v
                 };
 
-                stack.push_value::<T>(res.into())?;
+                stack.push_value(res.into())?;
 
                 trace!("Instruction i64.extend32_s [{}] -> [{}]", v, res);
             }
@@ -3366,7 +3362,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let data: u128 = memory.mem.load(idx)?;
-                        stack.push_value::<T>(data.to_le_bytes().into())?;
+                        stack.push_value(data.to_le_bytes().into())?;
                     }
                     V128_STORE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_STORE));
@@ -3422,7 +3418,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as i16);
 
-                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD8X8_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD8X8_U));
@@ -3453,7 +3449,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as u16);
 
-                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD16X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD16X4_S));
@@ -3484,7 +3480,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as i32);
 
-                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD16X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD16X4_U));
@@ -3515,7 +3511,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as u32);
 
-                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD32X2_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD32X2_S));
@@ -3546,7 +3542,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as i64);
 
-                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
                     }
                     V128_LOAD32X2_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD32X2_U));
@@ -3577,7 +3573,7 @@ pub(super) fn run<T: Config>(
 
                         let extended_lanes = half_lanes.map(|lane| lane as u64);
 
-                        stack.push_value::<T>(Value::V128(from_lanes(extended_lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(extended_lanes)))?;
                     }
 
                     // v128.loadN_splat
@@ -3601,7 +3597,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<1, u8>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes([lane; 16])))?;
+                        stack.push_value(Value::V128(from_lanes([lane; 16])))?;
                     }
                     V128_LOAD16_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD16_SPLAT));
@@ -3623,7 +3619,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<2, u16>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes([lane; 8])))?;
+                        stack.push_value(Value::V128(from_lanes([lane; 8])))?;
                     }
                     V128_LOAD32_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD32_SPLAT));
@@ -3645,7 +3641,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<4, u32>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes([lane; 4])))?;
+                        stack.push_value(Value::V128(from_lanes([lane; 4])))?;
                     }
                     V128_LOAD64_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD64_SPLAT));
@@ -3667,7 +3663,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let lane = memory.mem.load::<8, u64>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes([lane; 2])))?;
+                        stack.push_value(Value::V128(from_lanes([lane; 2])))?;
                     }
 
                     // v128.loadN_zero
@@ -3693,7 +3689,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let data = memory.mem.load::<4, u32>(idx)? as u128;
-                        stack.push_value::<T>(Value::V128(data.to_le_bytes()))?;
+                        stack.push_value(Value::V128(data.to_le_bytes()))?;
                     }
                     V128_LOAD64_ZERO => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD64_ZERO));
@@ -3716,7 +3712,7 @@ pub(super) fn run<T: Config>(
                         let idx = calculate_mem_address(&memarg, relative_address)?;
 
                         let data = memory.mem.load::<8, u64>(idx)? as u128;
-                        stack.push_value::<T>(Value::V128(data.to_le_bytes()))?;
+                        stack.push_value(Value::V128(data.to_le_bytes()))?;
                     }
 
                     // v128.loadN_lane
@@ -3743,7 +3739,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u8; 16] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<1, u8>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
 
                     V128_LOAD16_LANE => {
@@ -3769,7 +3765,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u16; 8] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<2, u16>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
                     V128_LOAD32_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD32_LANE));
@@ -3794,7 +3790,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u32; 4] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<4, u32>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
                     V128_LOAD64_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_LOAD64_LANE));
@@ -3819,7 +3815,7 @@ pub(super) fn run<T: Config>(
                         let mut lanes: [u64; 2] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() =
                             memory.mem.load::<8, u64>(idx)?;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
 
                     // v128.storeN_lane
@@ -3931,14 +3927,14 @@ pub(super) fn run<T: Config>(
                             *byte_ref = wasm.read_u8().unwrap_validated();
                         }
 
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
 
                     // vvunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvunop>
                     V128_NOT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_NOT));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
-                        stack.push_value::<T>(Value::V128(data.map(|byte| !byte)))?;
+                        stack.push_value(Value::V128(data.map(|byte| !byte)))?;
                     }
 
                     // vvbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvbinop>
@@ -3947,28 +3943,28 @@ pub(super) fn run<T: Config>(
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] & data2[i]);
-                        stack.push_value::<T>(Value::V128(result))?;
+                        stack.push_value(Value::V128(result))?;
                     }
                     V128_ANDNOT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_ANDNOT));
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] & !data2[i]);
-                        stack.push_value::<T>(Value::V128(result))?;
+                        stack.push_value(Value::V128(result))?;
                     }
                     V128_OR => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_OR));
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] | data2[i]);
-                        stack.push_value::<T>(Value::V128(result))?;
+                        stack.push_value(Value::V128(result))?;
                     }
                     V128_XOR => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_XOR));
                         let data2: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result = array::from_fn(|i| data1[i] ^ data2[i]);
-                        stack.push_value::<T>(Value::V128(result))?;
+                        stack.push_value(Value::V128(result))?;
                     }
 
                     // vvternop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvternop>
@@ -3979,7 +3975,7 @@ pub(super) fn run<T: Config>(
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result =
                             array::from_fn(|i| (data1[i] & data3[i]) | (data2[i] & !data3[i]));
-                        stack.push_value::<T>(Value::V128(result))?;
+                        stack.push_value(Value::V128(result))?;
                     }
 
                     // vvtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vvtestop>
@@ -3987,7 +3983,7 @@ pub(super) fn run<T: Config>(
                         decrement_fuel!(T::get_fd_extension_flat_cost(V128_ANY_TRUE));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let any_true = data.into_iter().any(|byte| byte > 0);
-                        stack.push_value::<T>(Value::I32(any_true as u32))?;
+                        stack.push_value(Value::I32(any_true as u32))?;
                     }
 
                     I8X16_SWIZZLE => {
@@ -3996,7 +3992,7 @@ pub(super) fn run<T: Config>(
                         let data1: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let result =
                             array::from_fn(|i| *data1.get(usize::from(data2[i])).unwrap_or(&0));
-                        stack.push_value::<T>(Value::V128(result))?;
+                        stack.push_value(Value::V128(result))?;
                     }
 
                     I8X16_SHUFFLE => {
@@ -4014,7 +4010,7 @@ pub(super) fn run<T: Config>(
                                 .unwrap_validated()
                         });
 
-                        stack.push_value::<T>(Value::V128(result))?;
+                        stack.push_value(Value::V128(result))?;
                     }
 
                     // shape.splat
@@ -4023,38 +4019,38 @@ pub(super) fn run<T: Config>(
                         let value: u32 = stack.pop_value().try_into().unwrap_validated();
                         let lane = value as u8;
                         let data = from_lanes([lane; 16]);
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
                     I16X8_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_SPLAT));
                         let value: u32 = stack.pop_value().try_into().unwrap_validated();
                         let lane = value as u16;
                         let data = from_lanes([lane; 8]);
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
                     I32X4_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_SPLAT));
                         let lane: u32 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 4]);
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
                     I64X2_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_SPLAT));
                         let lane: u64 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 2]);
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
                     F32X4_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_SPLAT));
                         let lane: F32 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 4]);
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
                     F64X2_SPLAT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_SPLAT));
                         let lane: F64 = stack.pop_value().try_into().unwrap_validated();
                         let data = from_lanes([lane; 2]);
-                        stack.push_value::<T>(Value::V128(data))?;
+                        stack.push_value(Value::V128(data))?;
                     }
 
                     // shape.extract_lane
@@ -4064,7 +4060,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::I32(lane as u32))?;
+                        stack.push_value(Value::I32(lane as u32))?;
                     }
                     I8X16_EXTRACT_LANE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_EXTRACT_LANE_U));
@@ -4072,7 +4068,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::I32(lane as u32))?;
+                        stack.push_value(Value::I32(lane as u32))?;
                     }
                     I16X8_EXTRACT_LANE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTRACT_LANE_S));
@@ -4080,7 +4076,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::I32(lane as u32))?;
+                        stack.push_value(Value::I32(lane as u32))?;
                     }
                     I16X8_EXTRACT_LANE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTRACT_LANE_U));
@@ -4088,7 +4084,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::I32(lane as u32))?;
+                        stack.push_value(Value::I32(lane as u32))?;
                     }
                     I32X4_EXTRACT_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTRACT_LANE));
@@ -4096,7 +4092,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::I32(lane))?;
+                        stack.push_value(Value::I32(lane))?;
                     }
                     I64X2_EXTRACT_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTRACT_LANE));
@@ -4104,7 +4100,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::I64(lane))?;
+                        stack.push_value(Value::I64(lane))?;
                     }
                     F32X4_EXTRACT_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_EXTRACT_LANE));
@@ -4112,7 +4108,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::F32(lane))?;
+                        stack.push_value(Value::F32(lane))?;
                     }
                     F64X2_EXTRACT_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_EXTRACT_LANE));
@@ -4120,7 +4116,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let lane = *lanes.get(lane_idx).unwrap_validated();
-                        stack.push_value::<T>(Value::F64(lane))?;
+                        stack.push_value(Value::F64(lane))?;
                     }
 
                     // shape.replace_lane
@@ -4132,7 +4128,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u8; 16] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
                     I16X8_REPLACE_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_REPLACE_LANE));
@@ -4142,7 +4138,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u16; 8] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
                     I32X4_REPLACE_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_REPLACE_LANE));
@@ -4151,7 +4147,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u32; 4] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
                     I64X2_REPLACE_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_REPLACE_LANE));
@@ -4160,7 +4156,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [u64; 2] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
                     F32X4_REPLACE_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_REPLACE_LANE));
@@ -4169,7 +4165,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [F32; 4] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
                     F64X2_REPLACE_LANE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_REPLACE_LANE));
@@ -4178,7 +4174,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let mut lanes: [F64; 2] = to_lanes(data);
                         *lanes.get_mut(lane_idx).unwrap_validated() = new_lane;
-                        stack.push_value::<T>(Value::V128(from_lanes(lanes)))?;
+                        stack.push_value(Value::V128(from_lanes(lanes)))?;
                     }
 
                     // Group vunop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vunop>
@@ -4188,56 +4184,56 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let result: [i8; 16] = lanes.map(i8::wrapping_abs);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ABS => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_ABS));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let result: [i16; 8] = lanes.map(i16::wrapping_abs);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_ABS => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_ABS));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [i32; 4] = lanes.map(i32::wrapping_abs);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_ABS => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_ABS));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i64; 2] = to_lanes(data);
                         let result: [i64; 2] = lanes.map(i64::wrapping_abs);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_NEG => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_NEG));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let result: [i8; 16] = lanes.map(i8::wrapping_neg);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NEG => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_NEG));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let result: [i16; 8] = lanes.map(i16::wrapping_neg);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_NEG => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_NEG));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [i32; 4] = lanes.map(i32::wrapping_neg);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_NEG => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_NEG));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i64; 2] = to_lanes(data);
                         let result: [i64; 2] = lanes.map(i64::wrapping_neg);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     // vfunop
                     F32X4_ABS => {
@@ -4245,98 +4241,98 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.abs());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_ABS => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_ABS));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.abs());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_NEG => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_NEG));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_NEG => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_NEG));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_SQRT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_SQRT));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.sqrt());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_SQRT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_SQRT));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.sqrt());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_CEIL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_CEIL));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.ceil());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_CEIL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_CEIL));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.ceil());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_FLOOR => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_FLOOR));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.floor());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_FLOOR => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_FLOOR));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.floor());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_TRUNC => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_TRUNC));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.trunc());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_TRUNC => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_TRUNC));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.trunc());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_NEAREST => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_NEAREST));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| lane.nearest());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_NEAREST => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_NEAREST));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [F64; 2] = to_lanes(data);
                         let result: [F64; 2] = lanes.map(|lane| lane.nearest());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     // others
                     I8X16_POPCNT => {
@@ -4344,7 +4340,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let result: [u8; 16] = lanes.map(|lane| lane.count_ones() as u8);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vbinop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vbinop>
@@ -4357,7 +4353,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ADD => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_ADD));
@@ -4367,7 +4363,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_ADD => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_ADD));
@@ -4377,7 +4373,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_ADD => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_ADD));
@@ -4387,7 +4383,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [u64; 2] =
                             array::from_fn(|i| lanes1[i].wrapping_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SUB => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_SUB));
@@ -4397,7 +4393,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SUB => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_SUB));
@@ -4407,7 +4403,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SUB => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_SUB));
@@ -4417,7 +4413,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SUB => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_SUB));
@@ -4427,7 +4423,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [u64; 2] =
                             array::from_fn(|i| lanes1[i].wrapping_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     // vfbinop
                     F32X4_ADD => {
@@ -4437,7 +4433,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_ADD => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_ADD));
@@ -4446,7 +4442,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_SUB => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_SUB));
@@ -4455,7 +4451,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_SUB => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_SUB));
@@ -4464,7 +4460,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_MUL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_MUL));
@@ -4473,7 +4469,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].mul(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_MUL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_MUL));
@@ -4482,7 +4478,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].mul(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_DIV => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_DIV));
@@ -4491,7 +4487,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].div(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_DIV => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_DIV));
@@ -4500,7 +4496,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].div(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_MIN => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_MIN));
@@ -4509,7 +4505,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_MIN => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_MIN));
@@ -4518,7 +4514,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_MAX => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_MAX));
@@ -4527,7 +4523,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F32; 4] = to_lanes(data2);
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [F32; 4] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_MAX => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_MAX));
@@ -4536,7 +4532,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [F64; 2] = to_lanes(data2);
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [F64; 2] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_PMIN => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_PMIN));
@@ -4553,7 +4549,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_PMIN => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_PMIN));
@@ -4570,7 +4566,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_PMAX => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_PMAX));
@@ -4587,7 +4583,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_PMAX => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_PMAX));
@@ -4604,7 +4600,7 @@ pub(super) fn run<T: Config>(
                                 v1
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     // viminmaxop
                     I8X16_MIN_S => {
@@ -4614,7 +4610,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i8; 16] = to_lanes(data2);
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MIN_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_MIN_S));
@@ -4623,7 +4619,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i16; 8] = to_lanes(data2);
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MIN_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_MIN_S));
@@ -4632,7 +4628,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i32; 4] = to_lanes(data2);
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_MIN_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_MIN_U));
@@ -4641,7 +4637,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u8; 16] = to_lanes(data2);
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MIN_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_MIN_U));
@@ -4650,7 +4646,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u16; 8] = to_lanes(data2);
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MIN_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_MIN_U));
@@ -4659,7 +4655,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u32; 4] = to_lanes(data2);
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] = array::from_fn(|i| lanes1[i].min(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_MAX_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_MAX_S));
@@ -4668,7 +4664,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i8; 16] = to_lanes(data2);
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MAX_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_MAX_S));
@@ -4677,7 +4673,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i16; 8] = to_lanes(data2);
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MAX_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_MAX_S));
@@ -4686,7 +4682,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [i32; 4] = to_lanes(data2);
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_MAX_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_MAX_U));
@@ -4695,7 +4691,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u8; 16] = to_lanes(data2);
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_MAX_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_MAX_U));
@@ -4704,7 +4700,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u16; 8] = to_lanes(data2);
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MAX_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_MAX_U));
@@ -4713,7 +4709,7 @@ pub(super) fn run<T: Config>(
                         let lanes2: [u32; 4] = to_lanes(data2);
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] = array::from_fn(|i| lanes1[i].max(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     // visatbinop
@@ -4725,7 +4721,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ADD_SAT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_ADD_SAT_S));
@@ -4735,7 +4731,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_ADD_SAT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_ADD_SAT_U));
@@ -4745,7 +4741,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_ADD_SAT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_ADD_SAT_U));
@@ -4755,7 +4751,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_add(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SUB_SAT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_SUB_SAT_S));
@@ -4765,7 +4761,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SUB_SAT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_SUB_SAT_S));
@@ -4775,7 +4771,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SUB_SAT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_SUB_SAT_U));
@@ -4785,7 +4781,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [u8; 16] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SUB_SAT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_SUB_SAT_U));
@@ -4795,7 +4791,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].saturating_sub(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     // others
                     I16X8_MUL => {
@@ -4806,7 +4802,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [u16; 8] =
                             array::from_fn(|i| lanes1[i].wrapping_mul(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_MUL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_MUL));
@@ -4816,7 +4812,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [u32; 4] =
                             array::from_fn(|i| lanes1[i].wrapping_mul(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_MUL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_MUL));
@@ -4826,7 +4822,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [u64; 2] =
                             array::from_fn(|i| lanes1[i].wrapping_mul(lanes2[i]));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_AVGR_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_AVGR_U));
@@ -4837,7 +4833,7 @@ pub(super) fn run<T: Config>(
                         let result: [u8; 16] = array::from_fn(|i| {
                             (lanes1[i] as u16 + lanes2[i] as u16).div_ceil(2) as u8
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_AVGR_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_AVGR_U));
@@ -4848,7 +4844,7 @@ pub(super) fn run<T: Config>(
                         let result: [u16; 8] = array::from_fn(|i| {
                             (lanes1[i] as u32 + lanes2[i] as u32).div_ceil(2) as u16
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_Q15MULRSAT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_Q15MULRSAT_S));
@@ -4861,7 +4857,7 @@ pub(super) fn run<T: Config>(
                                 .clamp(i16::MIN as i64, i16::MAX as i64)
                                 as i16
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vrelop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vrelop>
@@ -4874,7 +4870,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EQ => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EQ));
@@ -4884,7 +4880,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EQ => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EQ));
@@ -4894,7 +4890,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EQ => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EQ));
@@ -4904,7 +4900,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_NE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_NE));
@@ -4914,7 +4910,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_NE));
@@ -4924,7 +4920,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_NE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_NE));
@@ -4934,7 +4930,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_NE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_NE));
@@ -4944,7 +4940,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_LT_S));
@@ -4954,7 +4950,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_LT_S));
@@ -4964,7 +4960,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_LT_S));
@@ -4974,7 +4970,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_LT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_LT_S));
@@ -4984,7 +4980,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_LT_U));
@@ -4994,7 +4990,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_LT_U));
@@ -5004,7 +5000,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_LT_U));
@@ -5014,7 +5010,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_GT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_GT_S));
@@ -5024,7 +5020,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_GT_S));
@@ -5034,7 +5030,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_GT_S));
@@ -5044,7 +5040,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_GT_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_GT_S));
@@ -5054,7 +5050,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_GT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_GT_U));
@@ -5064,7 +5060,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_GT_U));
@@ -5074,7 +5070,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GT_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_GT_U));
@@ -5084,7 +5080,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_LE_S));
@@ -5094,7 +5090,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_LE_S));
@@ -5104,7 +5100,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_LE_S));
@@ -5114,7 +5110,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_LE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_LE_S));
@@ -5124,7 +5120,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_LE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_LE_U));
@@ -5134,7 +5130,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_LE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_LE_U));
@@ -5144,7 +5140,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_LE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_LE_U));
@@ -5154,7 +5150,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     I8X16_GE_S => {
@@ -5165,7 +5161,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_GE_S));
@@ -5175,7 +5171,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_GE_S));
@@ -5185,7 +5181,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_GE_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_GE_S));
@@ -5195,7 +5191,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [i64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_GE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_GE_U));
@@ -5205,7 +5201,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u8; 16] = to_lanes(data1);
                         let result: [i8; 16] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i8).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_GE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_GE_U));
@@ -5215,7 +5211,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u16; 8] = to_lanes(data1);
                         let result: [i16; 8] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i16).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_GE_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_GE_U));
@@ -5225,7 +5221,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [u32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     // vfrelop
                     F32X4_EQ => {
@@ -5236,7 +5232,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_EQ => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_EQ));
@@ -5246,7 +5242,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] == lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_NE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_NE));
@@ -5256,7 +5252,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_NE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_NE));
@@ -5266,7 +5262,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] != lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_LT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_LT));
@@ -5276,7 +5272,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_LT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_LT));
@@ -5286,7 +5282,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] < lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_GT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_GT));
@@ -5296,7 +5292,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_GT => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_GT));
@@ -5306,7 +5302,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] > lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_LE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_LE));
@@ -5316,7 +5312,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_LE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_LE));
@@ -5326,7 +5322,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] <= lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_GE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_GE));
@@ -5336,7 +5332,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F32; 4] = to_lanes(data1);
                         let result: [i32; 4] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i32).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_GE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_GE));
@@ -5346,7 +5342,7 @@ pub(super) fn run<T: Config>(
                         let lanes1: [F64; 2] = to_lanes(data1);
                         let result: [i64; 2] =
                             array::from_fn(|i| ((lanes1[i] >= lanes2[i]) as i64).neg());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vishiftop
@@ -5356,7 +5352,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let result: [u8; 16] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SHL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_SHL));
@@ -5364,7 +5360,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let result: [u16; 8] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SHL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_SHL));
@@ -5372,7 +5368,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let result: [u32; 4] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SHL => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_SHL));
@@ -5380,7 +5376,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let result: [u64; 2] = lanes.map(|lane| lane.wrapping_shl(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SHR_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_SHR_S));
@@ -5388,7 +5384,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i8; 16] = to_lanes(data);
                         let result: [i8; 16] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_SHR_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_SHR_U));
@@ -5396,7 +5392,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let result: [u8; 16] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SHR_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_SHR_S));
@@ -5404,7 +5400,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i16; 8] = to_lanes(data);
                         let result: [i16; 8] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_SHR_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_SHR_U));
@@ -5412,7 +5408,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let result: [u16; 8] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SHR_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_SHR_S));
@@ -5420,7 +5416,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [i32; 4] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_SHR_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_SHR_U));
@@ -5428,7 +5424,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let result: [u32; 4] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SHR_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_SHR_S));
@@ -5436,7 +5432,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i64; 2] = to_lanes(data);
                         let result: [i64; 2] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_SHR_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_SHR_U));
@@ -5444,7 +5440,7 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let result: [u64; 2] = lanes.map(|lane| lane.wrapping_shr(shift));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     // Group vtestop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vtestop>
@@ -5454,28 +5450,28 @@ pub(super) fn run<T: Config>(
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u8; 16] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value::<T>(Value::I32(all_true as u32))?;
+                        stack.push_value(Value::I32(all_true as u32))?;
                     }
                     I16X8_ALL_TRUE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_ALL_TRUE));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u16; 8] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value::<T>(Value::I32(all_true as u32))?;
+                        stack.push_value(Value::I32(all_true as u32))?;
                     }
                     I32X4_ALL_TRUE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_ALL_TRUE));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value::<T>(Value::I32(all_true as u32))?;
+                        stack.push_value(Value::I32(all_true as u32))?;
                     }
                     I64X2_ALL_TRUE => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_ALL_TRUE));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u64; 2] = to_lanes(data);
                         let all_true = lanes.into_iter().all(|lane| lane != 0);
-                        stack.push_value::<T>(Value::I32(all_true as u32))?;
+                        stack.push_value(Value::I32(all_true as u32))?;
                     }
 
                     // Group vcvtop <https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-vcvtop>
@@ -5485,7 +5481,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [i8; 16] = to_lanes(data);
                         let high_lanes: [i8; 8] = lanes[8..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as i16);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EXTEND_HIGH_I8X16_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTEND_HIGH_I8X16_U));
@@ -5493,7 +5489,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [u8; 16] = to_lanes(data);
                         let high_lanes: [u8; 8] = lanes[8..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as u16);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EXTEND_LOW_I8X16_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTEND_LOW_I8X16_S));
@@ -5501,7 +5497,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [i8; 16] = to_lanes(data);
                         let low_lanes: [i8; 8] = lanes[..8].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as i16);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_EXTEND_LOW_I8X16_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTEND_LOW_I8X16_U));
@@ -5509,7 +5505,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [u8; 16] = to_lanes(data);
                         let low_lanes: [u8; 8] = lanes[..8].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as u16);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_HIGH_I16X8_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTEND_HIGH_I16X8_S));
@@ -5517,7 +5513,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [i16; 8] = to_lanes(data);
                         let high_lanes: [i16; 4] = lanes[4..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as i32);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_HIGH_I16X8_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTEND_HIGH_I16X8_U));
@@ -5525,7 +5521,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [u16; 8] = to_lanes(data);
                         let high_lanes: [u16; 4] = lanes[4..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as u32);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_LOW_I16X8_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTEND_LOW_I16X8_S));
@@ -5533,7 +5529,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [i16; 8] = to_lanes(data);
                         let low_lanes: [i16; 4] = lanes[..4].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as i32);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_EXTEND_LOW_I16X8_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTEND_LOW_I16X8_U));
@@ -5541,7 +5537,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [u16; 8] = to_lanes(data);
                         let low_lanes: [u16; 4] = lanes[..4].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as u32);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_HIGH_I32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTEND_HIGH_I32X4_S));
@@ -5549,7 +5545,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [i32; 4] = to_lanes(data);
                         let high_lanes: [i32; 2] = lanes[2..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as i64);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_HIGH_I32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTEND_HIGH_I32X4_U));
@@ -5557,7 +5553,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [u32; 4] = to_lanes(data);
                         let high_lanes: [u32; 2] = lanes[2..].try_into().unwrap();
                         let result = high_lanes.map(|lane| lane as u64);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_LOW_I32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTEND_LOW_I32X4_S));
@@ -5565,7 +5561,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [i32; 4] = to_lanes(data);
                         let low_lanes: [i32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as i64);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I64X2_EXTEND_LOW_I32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTEND_LOW_I32X4_U));
@@ -5573,7 +5569,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [u32; 4] = to_lanes(data);
                         let low_lanes: [u32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| lane as u64);
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_TRUNC_SAT_F32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_TRUNC_SAT_F32X4_S));
@@ -5590,7 +5586,7 @@ pub(super) fn run<T: Config>(
                                 lane.as_i32()
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_TRUNC_SAT_F32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_TRUNC_SAT_F32X4_U));
@@ -5605,7 +5601,7 @@ pub(super) fn run<T: Config>(
                                 lane.as_u32()
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I32X4_TRUNC_SAT_F64X2_S_ZERO => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(
@@ -5624,9 +5620,7 @@ pub(super) fn run<T: Config>(
                                 lane.as_i32()
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes([
-                            result[0], result[1], 0, 0,
-                        ])))?;
+                        stack.push_value(Value::V128(from_lanes([result[0], result[1], 0, 0])))?;
                     }
                     I32X4_TRUNC_SAT_F64X2_U_ZERO => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(
@@ -5643,23 +5637,21 @@ pub(super) fn run<T: Config>(
                                 lane.as_u32()
                             }
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes([
-                            result[0], result[1], 0, 0,
-                        ])))?;
+                        stack.push_value(Value::V128(from_lanes([result[0], result[1], 0, 0])))?;
                     }
                     F32X4_CONVERT_I32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_CONVERT_I32X4_S));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [i32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| F32(lane as f32));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_CONVERT_I32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_CONVERT_I32X4_U));
                         let data: [u8; 16] = stack.pop_value().try_into().unwrap_validated();
                         let lanes: [u32; 4] = to_lanes(data);
                         let result: [F32; 4] = lanes.map(|lane| F32(lane as f32));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_CONVERT_LOW_I32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_CONVERT_LOW_I32X4_S));
@@ -5667,7 +5659,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [i32; 4] = to_lanes(data);
                         let low_lanes: [i32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| F64(lane as f64));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_CONVERT_LOW_I32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_CONVERT_LOW_I32X4_U));
@@ -5675,7 +5667,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [u32; 4] = to_lanes(data);
                         let low_lanes: [u32; 2] = lanes[..2].try_into().unwrap();
                         let result = low_lanes.map(|lane| F64(lane as f64));
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F32X4_DEMOTE_F64X2_ZERO => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F32X4_DEMOTE_F64X2_ZERO));
@@ -5683,7 +5675,7 @@ pub(super) fn run<T: Config>(
                         let lanes = to_lanes::<8, 2, F64>(data);
                         let half_lanes = lanes.map(|lane| lane.as_f32());
                         let result = [half_lanes[0], half_lanes[1], F32(0.0), F32(0.0)];
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     F64X2_PROMOTE_LOW_F32X4 => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(F64X2_PROMOTE_LOW_F32X4));
@@ -5691,7 +5683,7 @@ pub(super) fn run<T: Config>(
                         let lanes: [F32; 4] = to_lanes(data);
                         let half_lanes: [F32; 2] = lanes[..2].try_into().unwrap();
                         let result = half_lanes.map(|lane| lane.as_f64());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     // ishape.narrow_ishape_sx
@@ -5707,7 +5699,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(i8::MIN as i16, i8::MAX as i16) as i8);
                         let result: [i8; 16] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I8X16_NARROW_I16X8_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I8X16_NARROW_I16X8_U));
@@ -5721,7 +5713,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(u8::MIN as i16, u8::MAX as i16) as u8);
                         let result: [u8; 16] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NARROW_I32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_NARROW_I32X4_S));
@@ -5735,7 +5727,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(i16::MIN as i32, i16::MAX as i32) as i16);
                         let result: [i16; 8] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
                     I16X8_NARROW_I32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_NARROW_I32X4_U));
@@ -5749,7 +5741,7 @@ pub(super) fn run<T: Config>(
                             .map(|lane| lane.clamp(u16::MIN as i32, u16::MAX as i32) as u16);
                         let result: [u16; 8] =
                             array::from_fn(|_| concatenated_narrowed_lanes.next().unwrap());
-                        stack.push_value::<T>(Value::V128(from_lanes(result)))?;
+                        stack.push_value(Value::V128(from_lanes(result)))?;
                     }
 
                     // ishape.bitmask
@@ -5762,7 +5754,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value::<T>(Value::I32(bitmask))?;
+                        stack.push_value(Value::I32(bitmask))?;
                     }
                     I16X8_BITMASK => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_BITMASK));
@@ -5773,7 +5765,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value::<T>(Value::I32(bitmask))?;
+                        stack.push_value(Value::I32(bitmask))?;
                     }
                     I32X4_BITMASK => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_BITMASK));
@@ -5784,7 +5776,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value::<T>(Value::I32(bitmask))?;
+                        stack.push_value(Value::I32(bitmask))?;
                     }
                     I64X2_BITMASK => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_BITMASK));
@@ -5795,7 +5787,7 @@ pub(super) fn run<T: Config>(
                             .into_iter()
                             .enumerate()
                             .fold(0u32, |acc, (i, bit)| acc | ((bit as u32) << i));
-                        stack.push_value::<T>(Value::I32(bitmask))?;
+                        stack.push_value(Value::I32(bitmask))?;
                     }
 
                     // ishape.dot_ishape_s
@@ -5815,7 +5807,7 @@ pub(super) fn run<T: Config>(
                             let v2 = multiplied[2 * i + 1];
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(added)))?;
+                        stack.push_value(Value::V128(from_lanes(added)))?;
                     }
 
                     // ishape.extmul_half_ishape_sx
@@ -5832,7 +5824,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I16X8_EXTMUL_HIGH_I8X16_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTMUL_HIGH_I8X16_U));
@@ -5847,7 +5839,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I16X8_EXTMUL_LOW_I8X16_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTMUL_LOW_I8X16_S));
@@ -5862,7 +5854,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I16X8_EXTMUL_LOW_I8X16_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I16X8_EXTMUL_LOW_I8X16_U));
@@ -5877,7 +5869,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u16;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_HIGH_I16X8_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTMUL_HIGH_I16X8_S));
@@ -5892,7 +5884,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_HIGH_I16X8_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTMUL_HIGH_I16X8_U));
@@ -5907,7 +5899,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_LOW_I16X8_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTMUL_LOW_I16X8_S));
@@ -5922,7 +5914,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I32X4_EXTMUL_LOW_I16X8_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I32X4_EXTMUL_LOW_I16X8_U));
@@ -5937,7 +5929,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u32;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_HIGH_I32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTMUL_HIGH_I32X4_S));
@@ -5952,7 +5944,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_HIGH_I32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTMUL_HIGH_I32X4_U));
@@ -5967,7 +5959,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_LOW_I32X4_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTMUL_LOW_I32X4_S));
@@ -5982,7 +5974,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as i64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
                     I64X2_EXTMUL_LOW_I32X4_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(I64X2_EXTMUL_LOW_I32X4_U));
@@ -5997,7 +5989,7 @@ pub(super) fn run<T: Config>(
                             let v2 = high_lanes2[i] as u64;
                             v1.wrapping_mul(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(multiplied)))?;
+                        stack.push_value(Value::V128(from_lanes(multiplied)))?;
                     }
 
                     // ishape.extadd_pairwise_ishape_sx
@@ -6012,7 +6004,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as i16;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
                     }
                     I16X8_EXTADD_PAIRWISE_I8X16_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(
@@ -6025,7 +6017,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as u16;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
                     }
                     I32X4_EXTADD_PAIRWISE_I16X8_S => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(
@@ -6038,7 +6030,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as i32;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
                     }
                     I32X4_EXTADD_PAIRWISE_I16X8_U => {
                         decrement_fuel!(T::get_fd_extension_flat_cost(
@@ -6051,7 +6043,7 @@ pub(super) fn run<T: Config>(
                             let v2 = lanes[2 * i + 1] as u32;
                             v1.wrapping_add(v2)
                         });
-                        stack.push_value::<T>(Value::V128(from_lanes(added_pairwise)))?;
+                        stack.push_value(Value::V128(from_lanes(added_pairwise)))?;
                     }
 
                     // Unimplemented or invalid instructions

--- a/src/execution/store/mod.rs
+++ b/src/execution/store/mod.rs
@@ -1413,7 +1413,7 @@ impl<'b, T: Config> Store<'b, T> {
 
         if let Some(mut wasm_resumable) = host_resumable.inner_resumable {
             for return_value in host_call_return_values {
-                wasm_resumable.stack.push_value::<T>(return_value)?;
+                wasm_resumable.stack.push_value(return_value)?;
             }
 
             Ok(RunState::Resumable {

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -1,6 +1,7 @@
 use core::mem::MaybeUninit;
 
-use alloc::vec::{Drain, Vec};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use crate::addrs::FuncAddr;
 use crate::config::Config;
@@ -20,7 +21,13 @@ use crate::RuntimeError;
 #[derive(Debug)]
 pub(crate) struct Stack {
     /// WASM values on the stack, i.e. the actual data that instructions operate on
-    values: Vec<Value>,
+    values: Box<[Value]>,
+
+    /// Stack pointer aka an index into [`Self::values`], pointing to the element above the current top
+    ///
+    /// - If this is 0, than the stack is empty. You must not pop the stack.
+    /// - If this is equal to `self.values.len()`, then the stack is full. You must not push.
+    stack_height: usize,
 
     /// Call frames
     ///
@@ -30,12 +37,19 @@ pub(crate) struct Stack {
 
 impl Stack {
     pub fn new<T: Config>(
-        params_to_base_call_frame: Vec<Value>,
+        mut params_to_base_call_frame: Vec<Value>,
         base_call_frame_func_ty: &FuncType,
         base_call_frame_remaining_locals: &[ValType],
     ) -> Result<Self, RuntimeError> {
+        // retain the length of the `params_to_base_call_frame` as index to the first free stack entry
+        let stack_pointer_idx = params_to_base_call_frame.len();
+
+        // realloc Vec to correct size
+        params_to_base_call_frame.resize(T::MAX_VALUE_STACK_SIZE, Value::I32(0));
+
         let mut stack = Self {
-            values: params_to_base_call_frame,
+            values: params_to_base_call_frame.into_boxed_slice(),
+            stack_height: stack_pointer_idx,
             frames: Vec::new(),
         };
 
@@ -47,21 +61,27 @@ impl Stack {
         }
 
         debug_assert!(
-            stack.values.len() >= base_call_frame_func_ty.params.valtypes.len(),
+            stack.stack_height >= base_call_frame_func_ty.params.valtypes.len(),
             "when pushing a new call frame, at least as many values need to be on the stack as required by the new call frames's function"
         );
 
         // the topmost `param_count` values are transferred into/consumed by this new call frame
         let param_count = base_call_frame_func_ty.params.valtypes.len();
-        let call_frame_base_idx = stack.values.len() - param_count;
+        let call_frame_base_idx = stack.stack_height - param_count;
+
+        // verify that enough space is on the stack to push the remaining locals
+        if base_call_frame_remaining_locals.len() + stack.stack_height >= stack.values.len() {
+            return Err(RuntimeError::StackExhaustion);
+        }
 
         // after the params, put the additional locals
         for local in base_call_frame_remaining_locals {
-            stack.values.push(Value::default_from_ty(*local));
+            // SAFETY: the previous if checks that sufficient space is one the stack
+            unsafe { stack.push_value_unchecked(Value::default_from_ty(*local)) };
         }
 
         // now that the locals are all populated, the actual stack section of this call frame begins
-        let value_stack_base_idx = stack.values.len();
+        let value_stack_base_idx = stack.stack_height;
 
         stack.frames.push(CallFrame {
             return_func_addr: MaybeUninit::uninit(),
@@ -76,10 +96,21 @@ impl Stack {
     }
 
     pub(super) fn into_values(self) -> Vec<Value> {
-        self.values
+        let Self {
+            values: value_stack,
+            stack_height: stack_pointer_idx,
+            ..
+        } = self;
+
+        // convert the existing heap allocation into a vector, but shorten it
+        let mut values = Vec::from(value_stack);
+        values.truncate(stack_pointer_idx);
+
+        values
     }
 
     /// Pop a value from the value stack
+    #[inline(always)]
     pub fn pop_value(&mut self) -> Value {
         // If there is at least one call frame, we shall not pop values past the current
         // call frame. However, there is one legitimate reason to pop when there is **no** current
@@ -87,32 +118,67 @@ impl Stack {
         // this interpreter invocation.
         debug_assert!(
             if !self.frames.is_empty() {
-                self.values.len() > self.current_call_frame().value_stack_base_idx
+                self.stack_height > self.current_call_frame().value_stack_base_idx
             } else {
                 true
             },
             "can not pop values past the current call frame"
         );
 
-        self.values.pop().unwrap_validated()
+        debug_assert!(self.stack_height > 0, "pop results in stack underflow");
+
+        // SAFETY: this is not safe if the stack is empty
+        unsafe { self.pop_value_unchecked() }
+    }
+
+    /// Pop a [`Value`] from the value stack
+    ///
+    /// # Safety
+    ///
+    /// This will underflow the stack and cause undefined behavior, if the stack is empty. To
+    /// check, before pushing, assure that the [`Self::stack_height`] is greater than 0.
+    #[inline(always)]
+    unsafe fn pop_value_unchecked(&mut self) -> Value {
+        // stack_pointer_idx always points to the first unused entry above the stack's topmost value
+        self.stack_height -= 1;
+        // *self.values.get(self.stack_height).unwrap_validated()
+        unsafe { *self.values.get_unchecked(self.stack_height) }
     }
 
     /// Returns a cloned copy of the top value on the stack, or `None` if the stack is empty
     pub fn peek_value(&self) -> Option<Value> {
-        self.values.last().copied()
+        match self.stack_height {
+            0 => None,
+            i => Some(*self.values.get(i - 1).unwrap_validated()),
+        }
     }
 
-    /// Push a value to the value stack
-    pub fn push_value<C: Config>(&mut self, value: Value) -> Result<(), RuntimeError> {
+    /// Push a value to the value stack after veryfing that this will not overflow the stack
+    pub fn push_value(&mut self, value: Value) -> Result<(), RuntimeError> {
         // check for value stack exhaustion
-        if self.values.len() > C::MAX_VALUE_STACK_SIZE {
+        if self.stack_height >= self.values.len() {
             return Err(RuntimeError::StackExhaustion);
         }
 
-        // push the value
-        self.values.push(value);
+        // SAFETY: The prior if statement verifies that the stack is not yet exhausted
+        unsafe { self.push_value_unchecked(value) };
 
         Ok(())
+    }
+
+    /// Push a [`Value`] to the value stack
+    ///
+    /// # Safety
+    ///
+    /// This will overflow the stack and cause undefined behavior, if the stack is already full. To
+    /// check, before pushing, assure that the [`Self::stack_height`] is smaller than the maximum
+    /// allowed stack size.
+    #[inline(always)]
+    unsafe fn push_value_unchecked(&mut self, value: Value) {
+        debug_assert!(self.stack_height < self.values.len());
+
+        *self.values.get_mut(self.stack_height).unwrap_validated() = value;
+        self.stack_height += 1;
     }
 
     /// Returns a shared reference to a specific local by its index in the current call frame.
@@ -152,12 +218,12 @@ impl Stack {
             ..
         } = self.frames.pop().unwrap_validated();
 
-        let remove_count = self.values.len() - call_frame_base_idx - return_value_count;
+        let remove_count = self.stack_height - call_frame_base_idx - return_value_count;
 
         self.remove_in_between(remove_count, return_value_count);
 
         debug_assert_eq!(
-            self.values.len(),
+            self.stack_height,
             call_frame_base_idx + return_value_count,
             "after a function call finished, the stack must have exactly as many values as it had before calling the function plus the number of function return values"
         );
@@ -196,21 +262,27 @@ impl Stack {
         }
 
         debug_assert!(
-            self.values.len() >= func_ty.params.valtypes.len(),
+            self.stack_height>= func_ty.params.valtypes.len(),
             "when pushing a new call frame, at least as many values need to be on the stack as required by the new call frames's function"
         );
 
         // the topmost `param_count` values are transferred into/consumed by this new call frame
         let param_count = func_ty.params.valtypes.len();
-        let call_frame_base_idx = self.values.len() - param_count;
+        let call_frame_base_idx = self.stack_height - param_count;
+
+        // verify that enough space is on the stack to push the remaining locals
+        if remaining_locals.len() + self.stack_height >= self.values.len() {
+            return Err(RuntimeError::StackExhaustion);
+        }
 
         // after the params, put the additional locals
         for local in remaining_locals {
-            self.values.push(Value::default_from_ty(*local));
+            // SAFETY: the previous if checks that sufficient space is one the stack
+            unsafe { self.push_value_unchecked(Value::default_from_ty(*local)) };
         }
 
         // now that the locals are all populated, the actual stack section of this call frame begins
-        let value_stack_base_idx = self.values.len();
+        let value_stack_base_idx = self.stack_height;
 
         self.frames.push(CallFrame {
             return_func_addr: MaybeUninit::new(return_func_addr),
@@ -234,9 +306,16 @@ impl Stack {
     ///
     /// Note that this is providing the values in reverse order compared to popping `n` values
     /// (which would yield the element closest to the **top** of the value stack first).
-    pub fn pop_tail_iter(&mut self, n: usize) -> Drain<'_, Value> {
-        let start = self.values.len() - n;
-        self.values.drain(start..)
+    pub fn pop_tail_iter(&mut self, n: usize) -> Vec<Value> {
+        let start = self.stack_height - n;
+        // TODO optimize and reconsider
+        let mut tail = Vec::with_capacity(n);
+        tail.extend_from_slice(self.values.get(start..self.stack_height).unwrap_validated());
+
+        debug_assert_eq!(tail.len(), n);
+
+        self.stack_height -= n;
+        tail
     }
 
     /// Remove `remove_count` values from the stack, keeping the topmost `keep_count` values
@@ -250,10 +329,10 @@ impl Stack {
     /// - `keep_count` topmost elements will be identical before and after the operation
     /// - all elements below the `remove_count + keep_count` topmost stack entry remain
     pub fn remove_in_between(&mut self, remove_count: usize, keep_count: usize) {
-        let len = self.values.len();
+        let len = self.stack_height;
         self.values
-            .copy_within(len - keep_count.., len - keep_count - remove_count);
-        self.values.truncate(len - remove_count);
+            .copy_within(len - keep_count..len, len - keep_count - remove_count);
+        self.stack_height -= remove_count;
     }
 }
 

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -1,10 +1,10 @@
 use core::mem::MaybeUninit;
 
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use crate::addrs::FuncAddr;
 use crate::config::Config;
+use crate::core::fixed_capacity_vec::FixedCapacityVec;
 use crate::core::indices::LocalIdx;
 use crate::core::reader::types::{FuncType, ValType};
 use crate::core::utils::ToUsizeExt;
@@ -21,56 +21,38 @@ use crate::RuntimeError;
 #[derive(Debug)]
 pub(crate) struct Stack {
     /// WASM values on the stack, i.e. the actual data that instructions operate on
-    values: Box<[Value]>,
-
-    /// Stack pointer aka an index into [`Self::values`], pointing to the element above the current top
-    ///
-    /// - If this is 0, than the stack is empty. You must not pop the stack.
-    /// - If this is equal to `self.values.len()`, then the stack is full. You must not push.
-    stack_height: usize,
+    values: FixedCapacityVec<Value>,
 
     /// Call frames
     ///
     /// Each time a function is called, a new frame is pushed, whenever a function returns, a frame is popped
-    frames: Vec<CallFrame>,
+    frames: FixedCapacityVec<CallFrame>,
 }
 
 impl Stack {
     pub fn new<T: Config>(
-        mut params_to_base_call_frame: Vec<Value>,
+        params_to_base_call_frame: Vec<Value>,
         base_call_frame_func_ty: &FuncType,
         base_call_frame_remaining_locals: &[ValType],
     ) -> Result<Self, RuntimeError> {
-        // retain the length of the `params_to_base_call_frame` as index to the first free stack entry
-        let stack_pointer_idx = params_to_base_call_frame.len();
-
-        // realloc Vec to correct size
-        params_to_base_call_frame.resize(T::MAX_VALUE_STACK_SIZE, Value::I32(0));
-
         let mut stack = Self {
-            values: params_to_base_call_frame.into_boxed_slice(),
-            stack_height: stack_pointer_idx,
-            frames: Vec::new(),
+            values: FixedCapacityVec::with_capacity(T::MAX_VALUE_STACK_SIZE),
+            frames: FixedCapacityVec::with_capacity(T::MAX_CALL_STACK_SIZE),
         };
 
-        // The following is a copy of `Stack::push_call_frame` except that it
-        // only partially initializes the call frame's fields.
-
-        if stack.call_frame_count() > T::MAX_CALL_STACK_SIZE {
-            return Err(RuntimeError::StackExhaustion);
-        }
+        stack.values.push_from_slice(&params_to_base_call_frame)?;
 
         debug_assert!(
-            stack.stack_height >= base_call_frame_func_ty.params.valtypes.len(),
+            stack.values.len() >= base_call_frame_func_ty.params.valtypes.len(),
             "when pushing a new call frame, at least as many values need to be on the stack as required by the new call frames's function"
         );
 
         // the topmost `param_count` values are transferred into/consumed by this new call frame
         let param_count = base_call_frame_func_ty.params.valtypes.len();
-        let call_frame_base_idx = stack.stack_height - param_count;
+        let call_frame_base_idx = stack.values.len() - param_count;
 
         // verify that enough space is on the stack to push the remaining locals
-        if base_call_frame_remaining_locals.len() + stack.stack_height >= stack.values.len() {
+        if base_call_frame_remaining_locals.len() + stack.values.len() >= stack.values.capacity() {
             return Err(RuntimeError::StackExhaustion);
         }
 
@@ -81,7 +63,7 @@ impl Stack {
         }
 
         // now that the locals are all populated, the actual stack section of this call frame begins
-        let value_stack_base_idx = stack.stack_height;
+        let value_stack_base_idx = stack.values.len();
 
         stack.frames.push(CallFrame {
             return_func_addr: MaybeUninit::uninit(),
@@ -90,23 +72,16 @@ impl Stack {
             call_frame_base_idx,
             return_value_count: base_call_frame_func_ty.returns.valtypes.len(),
             return_stp: MaybeUninit::uninit(),
-        });
+        })?;
 
         Ok(stack)
     }
 
-    pub(super) fn into_values(self) -> Vec<Value> {
-        let Self {
-            values: value_stack,
-            stack_height: stack_pointer_idx,
-            ..
-        } = self;
-
-        // convert the existing heap allocation into a vector, but shorten it
-        let mut values = Vec::from(value_stack);
-        values.truncate(stack_pointer_idx);
-
-        values
+    pub(super) fn into_values(mut self) -> Vec<Value> {
+        self.values
+            .pop_into_slice(self.values.len())
+            .unwrap_validated()
+            .to_vec()
     }
 
     /// Pop a value from the value stack
@@ -118,16 +93,17 @@ impl Stack {
         // this interpreter invocation.
         debug_assert!(
             if !self.frames.is_empty() {
-                self.stack_height > self.current_call_frame().value_stack_base_idx
+                self.values.len() > self.current_call_frame().value_stack_base_idx
             } else {
                 true
             },
             "can not pop values past the current call frame"
         );
 
-        debug_assert!(self.stack_height > 0, "pop results in stack underflow");
+        debug_assert!(!self.values.is_empty(), "pop results in stack underflow");
 
-        // SAFETY: this is not safe if the stack is empty
+        // SAFETY: this is safe only if there is at least one `Value` on the stack, which must
+        // belong to the current `CallFrame`.
         unsafe { self.pop_value_unchecked() }
     }
 
@@ -136,27 +112,22 @@ impl Stack {
     /// # Safety
     ///
     /// This will underflow the stack and cause undefined behavior, if the stack is empty. To
-    /// check, before pushing, assure that the [`Self::stack_height`] is greater than 0.
+    /// check, before pushing, assure that [`Self::values`] is not empty.
     #[inline(always)]
     unsafe fn pop_value_unchecked(&mut self) -> Value {
-        // stack_pointer_idx always points to the first unused entry above the stack's topmost value
-        self.stack_height -= 1;
-        // *self.values.get(self.stack_height).unwrap_validated()
-        unsafe { *self.values.get_unchecked(self.stack_height) }
+        // SAFETY: safe only if stack contains at least one element
+        unsafe { self.values.pop_unchecked() }
     }
 
     /// Returns a cloned copy of the top value on the stack, or `None` if the stack is empty
     pub fn peek_value(&self) -> Option<Value> {
-        match self.stack_height {
-            0 => None,
-            i => Some(*self.values.get(i - 1).unwrap_validated()),
-        }
+        self.values.peek().ok().cloned()
     }
 
     /// Push a value to the value stack after veryfing that this will not overflow the stack
     pub fn push_value(&mut self, value: Value) -> Result<(), RuntimeError> {
         // check for value stack exhaustion
-        if self.stack_height >= self.values.len() {
+        if self.values.len() >= self.values.capacity() {
             return Err(RuntimeError::StackExhaustion);
         }
 
@@ -171,14 +142,11 @@ impl Stack {
     /// # Safety
     ///
     /// This will overflow the stack and cause undefined behavior, if the stack is already full. To
-    /// check, before pushing, assure that the [`Self::stack_height`] is smaller than the maximum
-    /// allowed stack size.
+    /// check, before pushing, assure that the [`Self::values`] is not full.
     #[inline(always)]
     unsafe fn push_value_unchecked(&mut self, value: Value) {
-        debug_assert!(self.stack_height < self.values.len());
-
-        *self.values.get_mut(self.stack_height).unwrap_validated() = value;
-        self.stack_height += 1;
+        // SAFETY: safe when called with remaining space on the stack.
+        unsafe { self.values.push_unchecked(value) }
     }
 
     /// Returns a shared reference to a specific local by its index in the current call frame.
@@ -200,8 +168,13 @@ impl Stack {
     }
 
     /// Get a shared reference to the current [`CallFrame`]
+    ///
+    /// # Safety
+    ///
+    /// This will underflow if no active call frame is on the stack.
     pub fn current_call_frame(&self) -> &CallFrame {
-        self.frames.last().unwrap_validated()
+        // SAFETY: must only be called if there is at least one callframe on the stack.
+        unsafe { self.frames.peek_unchecked() }
     }
 
     /// Pop a [`CallFrame`] from the call stack, returning the caller function store address, return address, and the return stp
@@ -218,12 +191,12 @@ impl Stack {
             ..
         } = self.frames.pop().unwrap_validated();
 
-        let remove_count = self.stack_height - call_frame_base_idx - return_value_count;
+        let remove_count = self.values.len() - call_frame_base_idx - return_value_count;
 
         self.remove_in_between(remove_count, return_value_count);
 
         debug_assert_eq!(
-            self.stack_height,
+            self.values.len(),
             call_frame_base_idx + return_value_count,
             "after a function call finished, the stack must have exactly as many values as it had before calling the function plus the number of function return values"
         );
@@ -262,16 +235,16 @@ impl Stack {
         }
 
         debug_assert!(
-            self.stack_height>= func_ty.params.valtypes.len(),
+            self.values.len()>= func_ty.params.valtypes.len(),
             "when pushing a new call frame, at least as many values need to be on the stack as required by the new call frames's function"
         );
 
         // the topmost `param_count` values are transferred into/consumed by this new call frame
         let param_count = func_ty.params.valtypes.len();
-        let call_frame_base_idx = self.stack_height - param_count;
+        let call_frame_base_idx = self.values.len() - param_count;
 
         // verify that enough space is on the stack to push the remaining locals
-        if remaining_locals.len() + self.stack_height >= self.values.len() {
+        if remaining_locals.len() + self.values.len() >= self.values.capacity() {
             return Err(RuntimeError::StackExhaustion);
         }
 
@@ -282,7 +255,7 @@ impl Stack {
         }
 
         // now that the locals are all populated, the actual stack section of this call frame begins
-        let value_stack_base_idx = self.stack_height;
+        let value_stack_base_idx = self.values.len();
 
         self.frames.push(CallFrame {
             return_func_addr: MaybeUninit::new(return_func_addr),
@@ -291,7 +264,7 @@ impl Stack {
             call_frame_base_idx,
             return_value_count: func_ty.returns.valtypes.len(),
             return_stp: MaybeUninit::new(return_stp),
-        });
+        })?;
 
         Ok(())
     }
@@ -307,14 +280,8 @@ impl Stack {
     /// Note that this is providing the values in reverse order compared to popping `n` values
     /// (which would yield the element closest to the **top** of the value stack first).
     pub fn pop_tail_iter(&mut self, n: usize) -> Vec<Value> {
-        let start = self.stack_height - n;
-        // TODO optimize and reconsider
-        let mut tail = Vec::with_capacity(n);
-        tail.extend_from_slice(self.values.get(start..self.stack_height).unwrap_validated());
-
+        let tail = self.values.pop_into_slice(n).unwrap_validated().to_vec();
         debug_assert_eq!(tail.len(), n);
-
-        self.stack_height -= n;
         tail
     }
 
@@ -329,10 +296,7 @@ impl Stack {
     /// - `keep_count` topmost elements will be identical before and after the operation
     /// - all elements below the `remove_count + keep_count` topmost stack entry remain
     pub fn remove_in_between(&mut self, remove_count: usize, keep_count: usize) {
-        let len = self.stack_height;
-        self.values
-            .copy_within(len - keep_count..len, len - keep_count - remove_count);
-        self.stack_height -= remove_count;
+        self.values.remove_in_between(remove_count, keep_count);
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

We found out that popping and pushing values to the value stack makes for a significant part of the assembly instructions emitted for a simple bytecode instruction of the interpreter loop.

This is an attempt at streamlining that overhead, by using a `Box<[Value]>` which never has to reallocate.

### TODO or Help Wanted

~~This still fails for the host functions, I suspect an issue in pop_tail~~ fixed. `pop_tail_iter` gave all the entires (empty, unused) from the stack. That was both a correctness bug and a performance hog. 

### Checks


- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Benchmark Results

> fibonacci_recursive/our/1
>                        time:   [5.0043 ms 5.0789 ms 5.1685 ms]
>                        thrpt:  [193.48  elem/s 196.89  elem/s 199.83  elem/s]
>                 change:
>                        time:   [+2418941% +2454106% +2497274%] (p = 0.00 < 0.05)
>                        thrpt:  [-99.996% -99.996% -99.996%]
>                        Performance has regressed.

~~Yup. I think I still got some homework.~~

~~Still not good, but not terrible either.~~

With [3ba19b52](https://github.com/DLR-FT/wasm-interpreter/pull/342/commits/7569d79f22a00e6d4a6c6b8725f0f03df7968557) we finally see some improvement on performance.

```
group                          benchmark-current.baseline             benchmark-main.baseline
-----                          --------------------------             -----------------------
fibonacci_loop/our/1           1.00    131.7±0.38ns  7.2 MElem/sec    1.32   173.9±10.51ns  5.5 MElem/sec
fibonacci_loop/our/2           1.00    191.1±1.10ns 10.0 MElem/sec    1.32    251.6±1.26ns  7.6 MElem/sec
fibonacci_loop/our/4           1.00    280.9±2.09ns 13.6 MElem/sec    1.29    361.7±2.89ns 10.5 MElem/sec
fibonacci_loop/our/8           1.00    465.2±3.11ns 16.4 MElem/sec    1.27    589.6±4.21ns 12.9 MElem/sec
fibonacci_loop/our/16          1.00    841.8±4.53ns 18.1 MElem/sec    1.25  1049.7±12.01ns 14.5 MElem/sec
fibonacci_loop/our/32          1.00   1571.7±7.79ns 19.4 MElem/sec    1.25  1960.5±16.01ns 15.6 MElem/sec
fibonacci_loop/our/64          1.00      3.1±0.01µs 20.0 MElem/sec    1.24      3.8±0.04µs 16.1 MElem/sec
fibonacci_loop/our/128         1.00      6.0±0.01µs 20.3 MElem/sec    1.24      7.4±0.01µs 16.4 MElem/sec
fibonacci_loop/our/256         1.00     11.9±0.02µs 20.5 MElem/sec    1.24     14.8±0.10µs 16.5 MElem/sec
fibonacci_loop/our/512         1.00     23.7±0.04µs 20.6 MElem/sec    1.24     29.5±0.36µs 16.6 MElem/sec
fibonacci_loop/our/1024        1.00     47.1±0.30µs 20.7 MElem/sec    1.25     58.8±0.72µs 16.6 MElem/sec
fibonacci_loop/our/2048        1.00     94.7±0.23µs 20.6 MElem/sec    1.24    117.0±0.71µs 16.7 MElem/sec
fibonacci_loop/our/4096        1.00    188.5±1.08µs 20.7 MElem/sec    1.24    234.3±2.44µs 16.7 MElem/sec
fibonacci_loop/our/8192        1.00    379.2±1.83µs 20.6 MElem/sec    1.24    470.5±6.67µs 16.6 MElem/sec
fibonacci_loop/our/16384       1.00    760.1±7.32µs 20.6 MElem/sec    1.23    935.3±3.03µs 16.7 MElem/sec
fibonacci_loop/our/32768       1.00   1515.0±4.84µs 20.6 MElem/sec    1.24  1876.7±19.68µs 16.7 MElem/sec
fibonacci_loop/our/65536       1.00      3.0±0.01ms 20.7 MElem/sec    1.25      3.8±0.05ms 16.6 MElem/sec
fibonacci_loop/our/131072      1.00      6.0±0.01ms 20.7 MElem/sec    1.25      7.5±0.11ms 16.6 MElem/sec
fibonacci_loop/our/262144      1.00     12.1±0.05ms 20.6 MElem/sec    1.24     15.1±0.17ms 16.6 MElem/sec
fibonacci_loop/our/524288      1.00     24.1±0.03ms 20.7 MElem/sec    1.24     30.0±0.12ms 16.7 MElem/sec
fibonacci_loop/our/1048576     1.00     48.3±0.12ms 20.7 MElem/sec    1.24     60.0±0.43ms 16.7 MElem/sec
fibonacci_recursive/our/1      1.00    151.5±0.37ns  6.3 MElem/sec    1.22    184.4±3.10ns  5.2 MElem/sec
fibonacci_recursive/our/2      1.00    217.7±3.17ns  8.8 MElem/sec    1.16    253.4±6.71ns  7.5 MElem/sec
fibonacci_recursive/our/4      1.00    310.8±2.11ns 12.3 MElem/sec    1.27   394.8±10.97ns  9.7 MElem/sec
fibonacci_recursive/our/8      1.00    474.5±3.09ns 16.1 MElem/sec    1.38   654.6±23.06ns 11.7 MElem/sec
fibonacci_recursive/our/16     1.00    808.6±3.47ns 18.9 MElem/sec    1.51  1224.8±39.58ns 12.5 MElem/sec
fibonacci_recursive/our/32     1.00   1464.4±7.22ns 20.8 MElem/sec    1.43      2.1±0.06µs 14.6 MElem/sec
fibonacci_recursive/our/64     1.00      2.8±0.02µs 22.1 MElem/sec    1.36      3.8±0.02µs 16.3 MElem/sec
fibonacci_recursive/our/128    1.00      5.4±0.04µs 22.7 MElem/sec    1.31      7.0±0.02µs 17.3 MElem/sec
fibonacci_recursive/our/256    1.00     10.6±0.06µs 23.1 MElem/sec    1.27     13.5±0.04µs 18.1 MElem/sec
fibonacci_recursive/our/512    1.00     21.0±0.08µs 23.2 MElem/sec    1.28     26.8±0.18µs 18.2 MElem/sec
```
