### PR TITLE
Improve Criterion Benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,6 @@ name = "benchmark"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "interop",
  "wasm-interpreter",
  "wasmi",
  "wasmtime",

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -9,7 +9,6 @@ criterion = { version = "0.5.1", default-features = false, features = [
   "cargo_bench_support",
   "plotters",
 ] }
-interop.workspace = true
 wasm-interpreter = { path = "../..", default-features = false }
 wasmi = "0.40.0"
 wasmtime = { version = "27.0.0", default-features = false, features = [

--- a/crates/benchmark/benches/general_purpose.rs
+++ b/crates/benchmark/benches/general_purpose.rs
@@ -1,11 +1,10 @@
 use std::time::Duration;
 
 use criterion::{
-    criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
-    Throughput,
+    criterion_group, criterion_main, AxisScale, BatchSize, BenchmarkId, Criterion,
+    PlotConfiguration, Throughput,
 };
 
-use interop::StoreTypedInvocationExt;
 use wasm::{validate, Store};
 
 macro_rules! bench_wasm {
@@ -138,11 +137,14 @@ macro_rules! bench_wasm {
 
                 let bid = BenchmarkId::new("our", n);
                 group.bench_with_input(bid, &n, |b, &s| {
-                    b.iter(|| {
+                    let resumable = unsafe { store.create_resumable(our_fn, vec![wasm::Value::I32(s as u32)], None) }.unwrap().as_wasm().unwrap();
+                    b.iter_batched(|| {
+                        resumable.clone()
+                    }, |resumable| {
                         // SAFETY: Only one store is used. Therefore, this must always be
                         // the correct one.
-                        unsafe { store.invoke_simple_typed::<$arg_type, $return_type>(our_fn, s) }.unwrap();
-                    })
+                        unsafe { store.resume_wasm(resumable) }.unwrap()
+                    }, BatchSize::PerIteration)
                 });
             }
             group.finish();

--- a/src/core/fixed_capacity_vec.rs
+++ b/src/core/fixed_capacity_vec.rs
@@ -41,6 +41,24 @@ pub struct FixedCapacityVec<T> {
     len: usize,
 }
 
+// TODO Optimize Clone impl by using unsafe code
+impl<T: Clone> Clone for FixedCapacityVec<T> {
+    fn clone(&self) -> Self {
+        let mut cloned = Self::with_capacity(self.elements.len());
+
+        for index in 0..self.len {
+            let element = self
+                .get(index)
+                .expect("that this index is valid because it is less that self.len");
+            cloned
+                .push(element.clone())
+                .expect("that the new cloned vec has the same length as self and cannot overflow");
+        }
+
+        cloned
+    }
+}
+
 impl<T> FixedCapacityVec<T> {
     /// Construct new [`Self`], holding up to `capacity` elements of type `T`
     pub fn with_capacity(capacity: usize) -> Self {

--- a/src/execution/resumable.rs
+++ b/src/execution/resumable.rs
@@ -16,7 +16,7 @@ use crate::{addrs::FuncAddr, value_stack::Stack, Hostcode, Value};
 ///   referenced by function address
 /// - program counter must be valid for the bytecode of function referenced by the function address
 /// - stp must point to the correct sidetable entry for the function referenced by function address
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WasmResumable {
     pub(crate) stack: Stack,
     pub(crate) pc: usize,

--- a/src/execution/value_stack.rs
+++ b/src/execution/value_stack.rs
@@ -18,7 +18,7 @@ use crate::RuntimeError;
 /// 3. Activations
 ///
 /// See <https://webassembly.github.io/spec/core/exec/runtime.html#stack>
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Stack {
     /// WASM values on the stack, i.e. the actual data that instructions operate on
     values: FixedCapacityVec<Value>,
@@ -301,7 +301,7 @@ impl Stack {
 }
 
 /// The [WASM spec](https://webassembly.github.io/spec/core/exec/runtime.html#stack) calls this `Activations`, however it refers to the call frames of functions.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct CallFrame {
     /// Store address of the function that called this [`CallFrame`]'s function
     ///


### PR DESCRIPTION
### Pull Request Overview

<!--
This pull request adds/changes/fixes...
-->

### TODO or Help Wanted

<!--
This pull request still needs...
-->

### Checks

<!--
Please tick off what you did
-->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo doc`

### Benchmark Results

```
fibonacci_recursive/1: 190ns -> 160ns (-30ns)
fibonacci_recursive/2: 266ns -> 203ns (-63ns)
fibonacci_recursive/4: 391ns -> 326ns (-65ns)
fibonacci_recursive/8: 592ns -> 527ns (-65ns)
```

It is apparent that the previously measured initialization and cleanup took a flat amout of time (~60ns). It makes sense for this to be independent of which n-th fibonacci number is being calculated.