### PR TITLE
refactor: clean up old "beautiful" instruction logging

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,38 +1,3 @@
-// TODO Reconsider the importance of this module. All of its functions do the same?
-
-#[cfg(feature = "log")]
-pub fn print_beautiful_instruction_name_1_byte(first_byte: u8, pc: usize) {
-    use crate::core::structure::instructions::instruction_byte_to_str;
-
-    trace!(
-        "Read instruction {} at wasm_binary[{}]",
-        instruction_byte_to_str(first_byte),
-        pc
-    );
-}
-
-#[cfg(feature = "log")]
-pub fn print_beautiful_fc_extension(second_byte: u32, pc: usize) {
-    use crate::core::structure::instructions::fc_extension_instruction_to_str;
-
-    trace!(
-        "Read instruction {} at wasm_binary[{}]",
-        fc_extension_instruction_to_str(second_byte),
-        pc,
-    );
-}
-
-#[cfg(feature = "log")]
-pub fn print_beautiful_fd_extension(second_byte: u32, pc: usize) {
-    use crate::core::structure::instructions::fd_extension_instruction_to_str;
-
-    trace!(
-        "Read instruction {} at wasm_binary[{}]",
-        fd_extension_instruction_to_str(second_byte),
-        pc,
-    );
-}
-
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 pub trait ToUsizeExt {
     fn into_usize(self) -> usize;

--- a/src/execution/instructions/const_interpreter_loop.rs
+++ b/src/execution/instructions/const_interpreter_loop.rs
@@ -35,8 +35,11 @@ pub(crate) unsafe fn run_const<'wasm, T: Config>(
     loop {
         let first_instr_byte = wasm.decode_u8().unwrap_validated();
 
-        #[cfg(feature = "log")]
-        crate::core::utils::print_beautiful_instruction_name_1_byte(first_instr_byte, wasm.pc);
+        trace!(
+            "Executing const instruction {} at pc={}",
+            instruction_byte_to_str(first_instr_byte),
+            wasm.pc
+        );
 
         let instruction_fn = match first_instr_byte {
             END => end::<T>,
@@ -253,8 +256,17 @@ define_instruction!(
     instructions::FD_EXTENSIONS,
     |Args { wasm, stack, .. }| {
         use crate::core::structure::instructions::fd_extensions::*;
+        let second_instruction_part = wasm.decode_var_u32().unwrap_validated();
 
-        match wasm.decode_var_u32().unwrap_validated() {
+        trace!(
+            "Executing const FD instruction {} at pc={}",
+            crate::core::structure::instructions::fd_extension_instruction_to_str(
+                second_instruction_part
+            ),
+            wasm.pc
+        );
+
+        match second_instruction_part {
             V128_CONST => {
                 let mut data = [0; 16];
                 for byte_ref in &mut data {

--- a/src/execution/instructions/mod.rs
+++ b/src/execution/instructions/mod.rs
@@ -141,10 +141,10 @@ pub(super) unsafe fn run<T: Config>(
 
         let first_instr_byte = wasm.decode_u8().unwrap_validated();
 
-        #[cfg(debug_assertions)]
         trace!(
-            "Executing instruction {}",
-            crate::instructions::instruction_byte_to_str(first_instr_byte)
+            "Executing instruction {} at pc={}",
+            crate::core::structure::instructions::instruction_byte_to_str(first_instr_byte),
+            wasm.pc
         );
 
         let instruction_fn = T::DISPATCH_TABLE
@@ -533,6 +533,12 @@ define_instruction_fn! {fc_extensions, fuel_check = omit, |args: Args| {
     // should we call instruction hook here as well? multibyte instruction
     let second_instr = args.wasm.decode_var_u32().unwrap_validated();
 
+    trace!(
+        "Executing FC instruction {} at pc={}",
+        crate::core::structure::instructions::fc_extension_instruction_to_str(second_instr),
+        args.wasm.pc
+    );
+
     let instruction_fn = T::FC_DISPATCH_TABLE
         .get(second_instr.into_usize())
         .expect("the instruction to be valid because the code is validated");
@@ -557,6 +563,12 @@ define_instruction_fn! {fc_extensions, fuel_check = omit, |args: Args| {
 define_instruction_fn! {fd_extensions, fuel_check = omit, |args: Args| {
     // Should we call instruction hook here as well? Multibyte instruction
     let second_instr = args.wasm.decode_var_u32().unwrap_validated();
+
+    trace!(
+        "Executing FD instruction {} at pc={}",
+        crate::core::structure::instructions::fd_extension_instruction_to_str(second_instr),
+        args.wasm.pc
+    );
 
     let instruction_fn = T::FD_DISPATCH_TABLE
         .get(second_instr.into_usize())

--- a/src/validation/instructions/constant_expressions.rs
+++ b/src/validation/instructions/constant_expressions.rs
@@ -111,13 +111,10 @@ pub fn decode_and_validate_constant_expression(
             return Err(ValidationError::ExprMissingEnd);
         };
 
-        #[cfg(not(debug_assertions))]
-        trace!("Read constant instruction byte {first_instr_byte:#X?} ({first_instr_byte})");
-
-        #[cfg(debug_assertions)]
         trace!(
-            "Validation - Executing instruction {}",
-            instruction_byte_to_str(first_instr_byte)
+            "Validating const instruction {} at pc={}",
+            instruction_byte_to_str(first_instr_byte),
+            wasm.pc
         );
 
         use crate::core::structure::instructions::*;
@@ -177,6 +174,13 @@ pub fn decode_and_validate_constant_expression(
                 let Ok(second_instr) = wasm.decode_var_u32() else {
                     return Err(ValidationError::ExprMissingEnd);
                 };
+
+                trace!(
+                    "Validating const FD instruction {} at pc={}",
+                    fd_extension_instruction_to_str(second_instr),
+                    wasm.pc
+                );
+
                 match second_instr {
                     V128_CONST => {
                         for _ in 0..16 {

--- a/src/validation/instructions/expressions.rs
+++ b/src/validation/instructions/expressions.rs
@@ -120,8 +120,10 @@ pub unsafe fn decode_and_validate_expr(
             return Err(ValidationError::ExprMissingEnd);
         };
 
-        #[cfg(feature = "log")]
-        crate::core::utils::print_beautiful_instruction_name_1_byte(first_instr_byte, wasm.pc);
+        trace!(
+            "Validating instruction {first_instr_byte:#x} at pc={}",
+            wasm.pc
+        );
 
         use crate::core::structure::instructions::*;
         match first_instr_byte {
@@ -1010,12 +1012,9 @@ pub unsafe fn decode_and_validate_expr(
                     return Err(ValidationError::ExprMissingEnd);
                 };
 
-                #[cfg(feature = "log")]
-                crate::core::utils::print_beautiful_fc_extension(second_instr, wasm.pc);
-
-                #[cfg(feature = "log")]
                 trace!(
-                    "Read instruction byte {second_instr} at wasm_binary[{}]",
+                    "Validating FC instruction {} at pc={}",
+                    fc_extension_instruction_to_str(second_instr),
                     wasm.pc
                 );
 
@@ -1240,8 +1239,11 @@ pub unsafe fn decode_and_validate_expr(
                     return Err(ValidationError::ExprMissingEnd);
                 };
 
-                #[cfg(feature = "log")]
-                crate::core::utils::print_beautiful_fd_extension(second_instr, wasm.pc);
+                trace!(
+                    "Validating FD instruction {} at pc={}",
+                    fd_extension_instruction_to_str(second_instr),
+                    wasm.pc
+                );
 
                 use crate::core::structure::instructions::fd_extensions::*;
 


### PR DESCRIPTION
<!--
Describe your changes here in detail, for example:

- What problem does this PR solve?
- How has behavior changed?
- Are the changes tested accordingly?
-->

<!-- TODO -->

# Open Questions / TODOs

<!-- This pull request still needs... -->

<!-- TODO -->

# Benchmark Results

<!-- If you expect performance to be affected, put your benchmark results here -->

<!-- TODO -->

# References

<!--
Put all your references and footnotes here, for example:

- Automatically close an issue: `Closes <ISSUE>`.
- Markdown footnote: `[^my-footnote]: A description for my footnote.`
-->

<!-- TODO -->

# Checks

<!-- Please tick off what you did -->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo clippy --workspace`
  - [ ] Ran `cargo doc --document-private-items --workspace`
