### PR TITLE
Fix FixedCapacityVec

### DIFF
--- a/src/core/fixed_capacity_vec.rs
+++ b/src/core/fixed_capacity_vec.rs
@@ -340,3 +340,18 @@ unsafe fn slice_assume_init<T>(slice: &[MaybeUninit<T>]) -> &[T] {
     // reference and thus guaranteed to be valid for reads.
     unsafe { &*(slice as *const _ as *const [T]) }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn pop_into_slice_rejects_more_than_len() {
+        let mut vec = FixedCapacityVec::<u32>::with_capacity(4);
+        vec.push_from_slice(&[1, 2]).unwrap();
+
+        // requesting more elements than present must fail, even while within capacity
+        assert!(vec.pop_into_slice(3).is_err());
+        assert_eq!(vec.len(), 2);
+    }
+}

--- a/src/core/fixed_capacity_vec.rs
+++ b/src/core/fixed_capacity_vec.rs
@@ -241,14 +241,14 @@ impl<T: Clone> FixedCapacityVec<T> {
         n: usize,
     ) -> Result<impl core::ops::Deref<Target = [T]> + '_, EmptyContainerError> {
         // verify at least `n` elements are still one the stack
-        if n > self.elements.len() {
+        if n > self.len() {
             return Err(EmptyContainerError);
         }
 
         let old_len = self.len();
 
         // SAFETY: the previous if statement ensure that `n` is smaller than or equal to
-        // `self.elements.len()`, hence this subtraction is guaranteed to not underflow
+        // `self.len()`, hence this subtraction is guaranteed to not underflow
         self.len = unsafe { self.len.unchecked_sub(n) };
 
         // SAFETY: the prior if statement checks that `stack_height - n` wont underflow. And the

--- a/src/core/fixed_capacity_vec.rs
+++ b/src/core/fixed_capacity_vec.rs
@@ -221,7 +221,7 @@ impl<T: Clone> FixedCapacityVec<T> {
     /// Push from a slice into [`Self`], appending after the last/topmost element
     pub fn push_from_slice(&mut self, values: &[T]) -> Result<(), FullContainerError> {
         // verify `values` fits into the new self
-        if values.len() > (self.elements.len() - self.len) {
+        if values.len() > (self.capacity() - self.len) {
             return Err(FullContainerError);
         }
 


### PR DESCRIPTION
`FixedCapacityVec::pop_into_slice` has the potential for a memory violation due to an improper bounds check. Instead of checking against the number of contained elements, it checks against the length of the container.

This case is caught by running an offending example in debug mode, e.g. in test mode.

The test is included as a single patch.

Another patch consistently makes sure that capacity checks are using the `capacity()` accessor and `elements.len()`.

# Open Questions

Few.

# Benchmark Results

Benchmarks should now complete.

# References

Now all legal.

# Checks

I added a test.

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [x] Ran `cargo build`
  - [ ] Ran `cargo clippy --workspace`
  - [ ] Ran `cargo doc --document-private-items --workspace`
