### PR TITLE
fix: missing comma in readme bibtex citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Multi-memory proposal, GC proposal
   volume={},
   number={},
   pages={1-10},
-  url={https://elib.dlr.de/201323/}
+  url={https://elib.dlr.de/201323/},
   keywords={Couplings;Virtual machine monitors;Full stack;Aerospace electronics;Webassembly;Software;Hardware;Virtual machines;Certification;Application programming interfaces;Avionics;Wasm;ARINC 653;Software},
   doi={10.1109/DASC58513.2023.10311207}
 }


### PR DESCRIPTION
<!--
Describe your changes here in detail, for example:

- What problem does this PR solve?
- How has behavior changed?
- Are the changes tested accordingly?
-->

<!-- TODO -->

# Open Questions / TODOs

<!-- This pull request still needs... -->

<!-- TODO -->

# Benchmark Results

<!-- If you expect performance to be affected, put your benchmark results here -->

<!-- TODO -->

# References

<!--
Put all your references and footnotes here, for example:

- Automatically close an issue: `Closes <ISSUE>`.
- Markdown footnote: `[^my-footnote]: A description for my footnote.`
-->

<!-- TODO -->

# Checks

<!-- Please tick off what you did -->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo clippy --workspace`
  - [ ] Ran `cargo doc --document-private-items --workspace`
