### PR TITLE
Add BMF JSON output format to coremark benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -46,15 +61,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -118,6 +142,7 @@ version = "0.3.0"
 dependencies = [
  "criterion",
  "dlr-wasm-interpreter",
+ "envconfig",
  "wasmi",
  "wasmtime",
  "wat",
@@ -186,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -196,11 +221,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -208,21 +233,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -525,7 +550,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "log",
@@ -936,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -966,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1211,6 +1236,17 @@ name = "syn"
 version = "2.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -24,6 +24,7 @@ criterion = { version = "0.5.1", default-features = false, features = [
   "cargo_bench_support",
   "plotters",
 ] }
+envconfig = "0.11.1"
 wasmi = "0.40.0"
 wasmtime = { version = "27.0.0", default-features = false, features = [
   "runtime",

--- a/crates/benchmark/benches/coremark_minimal/main.rs
+++ b/crates/benchmark/benches/coremark_minimal/main.rs
@@ -1,13 +1,52 @@
 use dlr_wasm_interpreter::{
     decode_and_validate, ExternVal, FuncType, NumType, ResultType, RunState, Store, ValType, Value,
 };
-use std::time::UNIX_EPOCH;
+use envconfig::Envconfig;
+use std::{str::FromStr, time::UNIX_EPOCH};
 
 const COREMARK_MINIMAL_BYTECODE: &[u8] = include_bytes!("coremark-minimal.wasm");
 
+#[derive(Debug, Clone, Default)]
+enum OutputFormat {
+    #[default]
+    HumanReadable,
+    /// Bencher Metric Format: https://bencher.dev/docs/reference/bencher-metric-format/
+    Bmf,
+}
+
+impl FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bmf" => Ok(Self::Bmf),
+            "human" => Ok(Self::HumanReadable),
+            other => Err(format!("invalid output format: {other}")),
+        }
+    }
+}
+
+#[derive(Envconfig, Debug, Default)]
+struct Config {
+    /// Output format
+    #[envconfig(from = "BENCH_OUTPUT_FORMAT")]
+    format: Option<OutputFormat>,
+}
+
 fn main() {
+    let config = Config::init_from_env().unwrap();
+
     let score = run();
-    println!("{score}");
+
+    let format = config.format.unwrap_or_default();
+    match format {
+        OutputFormat::HumanReadable => {
+            println!("Score: {score}");
+        }
+        OutputFormat::Bmf => {
+            println!(r#"{{ "coremark_minimal": {{ "score": {{ "value": {score} }} }} }}"#)
+        }
+    }
 }
 
 pub fn run() -> f32 {


### PR DESCRIPTION
<!--
Describe your changes here in detail, for example:

- What problem does this PR solve?
- How has behavior changed?
- Are the changes tested accordingly?
-->

By default, the benchmark behaves the same. But when BENCH_OUTPUT_FORMAT=bmf is set, the benchmark outputs its score using the BMF JSON format.

This will be useful if we decide to use bencher.dev for tracking our performance

# Open Questions / TODOs

<!-- This pull request still needs... -->

<!-- TODO -->

# Benchmark Results

<!-- If you expect performance to be affected, put your benchmark results here -->

<!-- TODO -->

# References

<!--
Put all your references and footnotes here, for example:

- Automatically close an issue: `Closes <ISSUE>`.
- Markdown footnote: `[^my-footnote]: A description for my footnote.`
-->

<!-- TODO -->

# Checks

<!-- Please tick off what you did -->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo clippy --workspace`
  - [ ] Ran `cargo doc --document-private-items --workspace`
