### PR TITLE
Make linear memory `PAGE_SIZE` a field of it

### DIFF
--- a/crates/checked/src/store.rs
+++ b/crates/checked/src/store.rs
@@ -312,7 +312,7 @@ impl<'b, T: Config> Store<'b, T> {
     }
 
     /// This is a safe variant of [`Store::mem_size`](dlr_wasm_interpreter::Store::mem_size).
-    pub fn mem_size(&self, mem_addr: Stored<MemAddr>) -> u32 {
+    pub fn mem_size(&self, mem_addr: Stored<MemAddr>) -> u16 {
         // 1. try unwrap
         let mem_addr = mem_addr.try_unwrap_into_bare(self.id);
         // 2. call
@@ -325,7 +325,7 @@ impl<'b, T: Config> Store<'b, T> {
     }
 
     /// This is a safe variant of [`Store::mem_grow`](dlr_wasm_interpreter::Store::mem_grow).
-    pub fn mem_grow(&mut self, mem_addr: Stored<MemAddr>, n: u32) -> Result<(), RuntimeError> {
+    pub fn mem_grow(&mut self, mem_addr: Stored<MemAddr>, n: u16) -> Result<(), RuntimeError> {
         // 1. try unwrap
         let mem_addr = mem_addr.try_unwrap_into_bare(self.id);
         // 2. call

--- a/src/core/structure/types.rs
+++ b/src/core/structure/types.rs
@@ -98,19 +98,6 @@ pub struct Limits {
     pub max: Option<u32>,
 }
 
-// TODO Find out where these consts come from and document it properly
-impl Limits {
-    // since the maximum amount of bytes is u32::MAX, the page size is 1 << 16
-    // the max no. of pages = max bytes / page size = u32::MAX / (1 << 16) = 1 << 16
-    pub const MAX_MEM_PAGES: u32 = 1 << 16;
-    // https://webassembly.github.io/reference-types/core/syntax/types.html#limits
-    // memtype is defined in terms of limits, which go from 0 to u32::MAX
-    pub const MAX_MEM_BYTES: u32 = u32::MAX;
-    // https://webassembly.github.io/reference-types/core/exec/runtime.html#memory-instances
-    // memory size is 65536 (1 << 16)
-    pub const MEM_PAGE_SIZE: u32 = 1 << 16;
-}
-
 impl fmt::Debug for Limits {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> core::fmt::Result {
         match self.max {

--- a/src/execution/instructions/memory.rs
+++ b/src/execution/instructions/memory.rs
@@ -1885,7 +1885,7 @@ pub unsafe fn memory_size(
     // SAFETY: This memory address was just read from the current
     // store. Therefore, it is valid in the current store.
     let mem = unsafe { state.store_inner.memories.get_mut(mem_addr) };
-    let size = mem.size() as u32;
+    let size = u32::from(mem.len_pages());
     state.resumable.stack.push_value(Value::I32(size))?;
     trace!("Instruction: memory.size [] -> [{}]", size);
     Ok(ControlFlow::Continue(()))
@@ -1912,7 +1912,7 @@ pub unsafe fn memory_grow<T: Config>(
     // store. Therefore, it is valid in the current store.
     let mem = unsafe { state.store_inner.memories.get_mut(mem_addr) };
 
-    let sz: u32 = mem.size() as u32;
+    let sz = u32::from(mem.len_pages());
 
     let n: u32 = state
         .resumable
@@ -1943,7 +1943,10 @@ pub unsafe fn memory_grow<T: Config>(
     // TODO this instruction is non-deterministic w.r.t. spec, and can fail if the embedder wills it.
     // for now we execute it always according to the following match expr.
     // if the grow operation fails, err := Value::I32(2^32-1) is pushed to the stack per spec
-    let pushed_value = match mem.grow(n) {
+    let grow_result = u16::try_from(n)
+        .map_err(|_| RuntimeError::MemoryGrowOverflowed)
+        .and_then(|n| mem.grow(n));
+    let pushed_value = match grow_result {
         Ok(_) => sz,
         Err(RuntimeError::MemoryGrowOverflowed | RuntimeError::MemoryGrowExceededLimit) => u32::MAX,
         Err(_) => unreachable!("growing memory cannot return any other errors"),

--- a/src/execution/runtime_structure/memory_instances/linear_memory.rs
+++ b/src/execution/runtime_structure/memory_instances/linear_memory.rs
@@ -1,8 +1,10 @@
-use core::iter;
+use core::{iter, num::NonZeroUsize};
 
 use alloc::{vec, vec::Vec};
 
 use crate::{execution::numerics::representations::LittleEndianBytes, RuntimeError, TrapError};
+
+pub const DEFAULT_PAGE_SIZE: NonZeroUsize = NonZeroUsize::new(65536).unwrap();
 
 /// A linear memory is the backing data structure for a memory instance[^memory-instances].
 ///
@@ -16,45 +18,44 @@ use crate::{execution::numerics::representations::LittleEndianBytes, RuntimeErro
 ///
 /// [^memory-instances]: [WebAssembly Specification 2.0 - 4.2.9. Memory Instances](https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instances%E2%91%A0).
 /// [^memory-instructions]: [WebAssembly Specification 2.0 - 4.4.7. Memory Instructions](https://www.w3.org/TR/2025/CRD-wasm-core-2-20250616/#memory-instructions%E2%91%A4).
-pub struct LinearMemory<const PAGE_SIZE: usize = { crate::Limits::MEM_PAGE_SIZE as usize }> {
+pub struct LinearMemory {
     pub(crate) data: Vec<u8>,
+    page_size: NonZeroUsize,
 }
 
-/// Type to express the page count
-pub type PageCountTy = u16;
-
-impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
+impl LinearMemory {
     /// Creates a new linear memory of size 0
-    pub fn new() -> Self {
-        Self { data: Vec::new() }
+    pub fn new(page_size: NonZeroUsize) -> Self {
+        Self {
+            data: Vec::new(),
+            page_size,
+        }
     }
 
-    /// Creates a new zero-initialized linear memory. Its size is determined by the given number of
-    /// pages and the `PAGE_SIZE`.
-    pub fn new_with_initial_pages(pages: PageCountTy) -> Self {
-        let size_bytes = PAGE_SIZE * usize::from(pages);
+    /// Creates a new zero-initialized linear memory. Its size is determined by the given page size
+    /// and number of pages.
+    pub fn new_with_initial_pages(page_size: NonZeroUsize, pages: usize) -> Self {
+        let size_bytes = page_size.get() * pages;
         let data = vec![0; size_bytes];
 
-        Self { data }
+        Self { data, page_size }
     }
 
     /// Grows the current linear memory by a number of pages.
-    pub fn grow(&mut self, pages_to_add: PageCountTy) {
+    pub fn grow(&mut self, pages_to_add: usize) {
         let prior_length_bytes = self.data.len();
-        let new_length_bytes = prior_length_bytes + PAGE_SIZE * usize::from(pages_to_add);
+        let new_length_bytes = prior_length_bytes + self.page_size.get() * pages_to_add;
         self.data.resize(new_length_bytes, 0);
     }
 
     /// Returns the size of this linear memory in pages.
-    pub fn pages(&self) -> PageCountTy {
-        PageCountTy::try_from(self.data.len() / PAGE_SIZE).unwrap()
+    pub fn len_pages(&self) -> usize {
+        self.data.len() / self.page_size()
     }
 
-    /// Returns the size of this linear memory in bytes.
-    ///
-    /// This size is always a multiple of `PAGE_SIZE`.
-    pub fn len(&self) -> usize {
-        self.data.len()
+    /// The size of each page in this linear memory in bytes.
+    pub fn page_size(&self) -> NonZeroUsize {
+        self.page_size
     }
 
     /// Stores a `T` starting from the given index into this linear memory.
@@ -267,7 +268,7 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
     }
 }
 
-impl<const PAGE_SIZE: usize> core::fmt::Debug for LinearMemory<PAGE_SIZE> {
+impl core::fmt::Debug for LinearMemory {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         /// A helper struct for formatting, able to detect and format byte repetitions in a compact
         /// way.
@@ -324,9 +325,9 @@ impl<const PAGE_SIZE: usize> core::fmt::Debug for LinearMemory<PAGE_SIZE> {
     }
 }
 
-impl<const PAGE_SIZE: usize> Default for LinearMemory<PAGE_SIZE> {
+impl Default for LinearMemory {
     fn default() -> Self {
-        Self::new()
+        Self::new(DEFAULT_PAGE_SIZE)
     }
 }
 
@@ -341,26 +342,26 @@ mod test {
 
     use super::*;
 
-    const PAGE_SIZE: usize = 1 << 8;
-    const PAGES: PageCountTy = 2;
+    const PAGE_SIZE: NonZeroUsize = NonZeroUsize::new(1 << 8).unwrap();
+    const PAGES: usize = 2;
 
     #[test]
     fn new_constructor() {
-        let lin_mem = LinearMemory::<PAGE_SIZE>::new();
-        assert_eq!(lin_mem.pages(), 0);
+        let lin_mem = LinearMemory::new(PAGE_SIZE);
+        assert_eq!(lin_mem.len_pages(), 0);
     }
 
     #[test]
     fn new_grow() {
-        let mut lin_mem = LinearMemory::<PAGE_SIZE>::new();
+        let mut lin_mem = LinearMemory::new(PAGE_SIZE);
         lin_mem.grow(1);
-        assert_eq!(lin_mem.pages(), 1);
+        assert_eq!(lin_mem.len_pages(), 1);
     }
 
     #[test]
     fn debug_print_simple() {
-        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(1);
-        assert_eq!(lin_mem.pages(), 1);
+        let lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, 1);
+        assert_eq!(lin_mem.len_pages(), 1);
 
         let expected = format!("LinearMemory {{ inner_data: [#{PAGE_SIZE} × 0] }}");
         let debug_repr = format!("{lin_mem:?}");
@@ -371,8 +372,8 @@ mod test {
     #[test]
     fn debug_print_complex() {
         let page_count = 2;
-        let mut lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(page_count);
-        assert_eq!(lin_mem.pages(), page_count);
+        let mut lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, page_count);
+        assert_eq!(lin_mem.len_pages(), page_count);
 
         lin_mem.store(1, 0xffu8).unwrap();
         lin_mem.store(10, 1u8).unwrap();
@@ -386,8 +387,8 @@ mod test {
 
     #[test]
     fn debug_print_empty() {
-        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(0);
-        assert_eq!(lin_mem.pages(), 0);
+        let lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, 0);
+        assert_eq!(lin_mem.len_pages(), 0);
 
         let expected = "LinearMemory { inner_data: [] }";
         let debug_repr = format!("{lin_mem:?}");
@@ -398,9 +399,9 @@ mod test {
     #[test]
     fn roundtrip_normal_range_i8_neg127() {
         let x: i8 = -127;
-        let highest_legal_offset = PAGE_SIZE - mem::size_of::<i8>();
+        let highest_legal_offset = PAGE_SIZE.get() - mem::size_of::<i8>();
         for offset in 0..highest_legal_offset {
-            let mut lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+            let mut lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, PAGES);
 
             lin_mem.store(offset, x).unwrap();
 
@@ -417,9 +418,9 @@ mod test {
     #[test]
     fn roundtrip_normal_range_f32_13() {
         let x = F32(13.0);
-        let highest_legal_offset = PAGE_SIZE - mem::size_of::<F32>();
+        let highest_legal_offset = PAGE_SIZE.get() - mem::size_of::<F32>();
         for offset in 0..highest_legal_offset {
-            let mut lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+            let mut lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, PAGES);
 
             lin_mem.store(offset, x).unwrap();
 
@@ -436,9 +437,9 @@ mod test {
     #[test]
     fn roundtrip_normal_range_f64_min() {
         let x = F64(f64::MIN);
-        let highest_legal_offset = PAGE_SIZE - mem::size_of::<F64>();
+        let highest_legal_offset = PAGE_SIZE.get() - mem::size_of::<F64>();
         for offset in 0..highest_legal_offset {
-            let mut lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+            let mut lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, PAGES);
 
             lin_mem.store(offset, x).unwrap();
 
@@ -455,9 +456,9 @@ mod test {
     #[test]
     fn roundtrip_normal_range_f64_nan() {
         let x = F64(f64::NAN);
-        let highest_legal_offset = PAGE_SIZE - mem::size_of::<f64>();
+        let highest_legal_offset = PAGE_SIZE.get() - mem::size_of::<f64>();
         for offset in 0..highest_legal_offset {
-            let mut lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(PAGES);
+            let mut lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, PAGES);
 
             lin_mem.store(offset, x).unwrap();
 
@@ -478,8 +479,8 @@ mod test {
     fn store_out_of_range_u128_max() {
         let x: u128 = u128::MAX;
         let pages = 1;
-        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u128>() + 1;
-        let mut lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+        let lowest_illegal_offset = PAGE_SIZE.get() - mem::size_of::<u128>() + 1;
+        let mut lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, pages);
 
         lin_mem.store(lowest_illegal_offset, x).unwrap();
     }
@@ -491,8 +492,8 @@ mod test {
     fn store_empty_lineaer_memory_u8() {
         let x: u8 = u8::MAX;
         let pages = 0;
-        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u8>() + 1;
-        let mut lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+        let lowest_illegal_offset = PAGE_SIZE.get() - mem::size_of::<u8>() + 1;
+        let mut lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, pages);
 
         lin_mem.store(lowest_illegal_offset, x).unwrap();
     }
@@ -503,8 +504,8 @@ mod test {
     )]
     fn load_out_of_range_u128_max() {
         let pages = 1;
-        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u128>() + 1;
-        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+        let lowest_illegal_offset = PAGE_SIZE.get() - mem::size_of::<u128>() + 1;
+        let lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, pages);
 
         let _x: u128 = lin_mem.load(lowest_illegal_offset).unwrap();
     }
@@ -515,8 +516,8 @@ mod test {
     )]
     fn load_empty_lineaer_memory_u8() {
         let pages = 0;
-        let lowest_illegal_offset = PAGE_SIZE - mem::size_of::<u8>() + 1;
-        let lin_mem = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(pages);
+        let lowest_illegal_offset = PAGE_SIZE.get() - mem::size_of::<u8>() + 1;
+        let lin_mem = LinearMemory::new_with_initial_pages(PAGE_SIZE, pages);
 
         let _x: u8 = lin_mem.load(lowest_illegal_offset).unwrap();
     }
@@ -524,7 +525,9 @@ mod test {
     #[test]
     #[should_panic]
     fn copy_out_of_bounds() {
-        let mut lin_mem_0 = LinearMemory::<PAGE_SIZE>::new_with_initial_pages(2);
-        lin_mem_0.copy_within(0, PAGE_SIZE, PAGE_SIZE + 1).unwrap();
+        let mut lin_mem_0 = LinearMemory::new_with_initial_pages(PAGE_SIZE, 2);
+        lin_mem_0
+            .copy_within(0, PAGE_SIZE.get(), PAGE_SIZE.get() + 1)
+            .unwrap();
     }
 }

--- a/src/execution/runtime_structure/memory_instances/mod.rs
+++ b/src/execution/runtime_structure/memory_instances/mod.rs
@@ -1,4 +1,4 @@
-use crate::{core::utils::ToUsizeExt, Limits, MemType, RuntimeError};
+use crate::{Limits, MemType, RuntimeError};
 
 pub mod linear_memory;
 
@@ -16,31 +16,43 @@ impl core::fmt::Debug for MemInst {
 
 impl MemInst {
     /// <https://webassembly.github.io/spec/core/exec/modules.html#growing-memories>
-    pub fn grow(&mut self, n: u32) -> Result<(), RuntimeError> {
-        let len = n + self.mem.pages() as u32;
-        if len > Limits::MAX_MEM_PAGES {
-            return Err(RuntimeError::MemoryGrowOverflowed);
-        }
+    pub fn grow(&mut self, n: u16) -> Result<(), RuntimeError> {
+        // step 2
+        let len_pages = self.len_pages();
 
-        // roughly matches step 4,5,6
+        // step 3,4
+        let Some(new_len_pages) = len_pages.checked_add(n) else {
+            return Err(RuntimeError::MemoryGrowOverflowed);
+        };
+
+        // roughly matches step 5, 6, 7
         // checks limits_prime.valid() for limits_prime := { min: len, max: self.ty.lim.max }
         // https://webassembly.github.io/spec/core/valid/types.html#limits
-        if self.ty.limits.max.is_some_and(|max| len > max) {
+        if self
+            .ty
+            .limits
+            .max
+            .is_some_and(|max| u32::from(new_len_pages) > max)
+        {
             return Err(RuntimeError::MemoryGrowExceededLimit);
         }
         let limits_prime = Limits {
-            min: len,
+            min: u32::from(new_len_pages),
             max: self.ty.limits.max,
         };
 
-        self.mem.grow(n.try_into().unwrap());
+        // step 8
+        self.mem.grow(usize::from(n));
 
+        // step 9
         self.ty.limits = limits_prime;
         Ok(())
     }
 
-    /// Can never be bigger than 65,356 pages
-    pub fn size(&self) -> usize {
-        self.mem.len() / (crate::Limits::MEM_PAGE_SIZE.into_usize())
+    /// The length of this memory in pages.
+    pub fn len_pages(&self) -> u16 {
+        self.mem.len_pages().try_into().expect(
+            "we always use the default page size thereby limiting the number of pages to < 2^16",
+        )
     }
 }

--- a/src/execution/runtime_structure/store.rs
+++ b/src/execution/runtime_structure/store.rs
@@ -30,7 +30,10 @@ use crate::{
             external_values::ExternFilterable,
             function_instances::{FuncInst, HostFuncInst, WasmFuncInst},
             global_instances::GlobalInst,
-            memory_instances::{linear_memory::LinearMemory, MemInst},
+            memory_instances::{
+                linear_memory::{self, LinearMemory},
+                MemInst,
+            },
             module_instances::ModuleInst,
             table_instances::TableInst,
             value_stack::Stack,
@@ -1011,16 +1014,11 @@ impl<'b, T: Config> Store<'b, T> {
     ///
     /// The caller has to guarantee that the given [`MemAddr`] came from the
     /// current [`Store`] object.
-    pub unsafe fn mem_size(&self, mem_addr: MemAddr) -> u32 {
+    pub unsafe fn mem_size(&self, mem_addr: MemAddr) -> u16 {
         // 1. Return the length of `store.mems[memaddr].data` divided by the page size.
-        // SAFETY: The caller ensures that the given memory address is valid in
-        // the current store.
+        // SAFETY: The caller ensures that the given memory address is valid in the current store.
         let memory = unsafe { self.inner.memories.get(mem_addr) };
-        let length = memory.size();
-
-        // In addition we have to convert the length back to a `u32`
-        length.try_into().expect(
-            "the maximum memory length to be smaller than u32::MAX because thats what the specification allows for indexing into the memory. Also the memory size is measured in pages, not bytes.")
+        memory.len_pages()
     }
 
     /// Grows some memory by its memory address by `n` pages.
@@ -1031,7 +1029,7 @@ impl<'b, T: Config> Store<'b, T> {
     ///
     /// The caller has to guarantee that the given [`MemAddr`] came from the
     /// current [`Store`] object.
-    pub unsafe fn mem_grow(&mut self, mem_addr: MemAddr, n: u32) -> Result<(), RuntimeError> {
+    pub unsafe fn mem_grow(&mut self, mem_addr: MemAddr, n: u16) -> Result<(), RuntimeError> {
         // 1. Try growing the memory instance `store.mems[memaddr]` by `n` pages:
         //   a. If it succeeds, then return the updated store.
         //   b. Else, return `error`.
@@ -1224,6 +1222,7 @@ impl<'b, T: Config> Store<'b, T> {
         let mem_inst = MemInst {
             ty: mem_type,
             mem: LinearMemory::new_with_initial_pages(
+                linear_memory::DEFAULT_PAGE_SIZE,
                 mem_type.limits.min.try_into().unwrap_validated(),
             ),
         };

--- a/tests/memory_grow.rs
+++ b/tests/memory_grow.rs
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */
-use dlr_wasm_interpreter::{decode_and_validate, Limits, MemType, RuntimeError, TrapError};
+use dlr_wasm_interpreter::{decode_and_validate, RuntimeError, TrapError};
 use dlr_wasm_interpreter_checked::Store;
 
 #[test_log::test]
@@ -186,28 +186,4 @@ fn memory_grow_test_3() {
     assert_eq!(store.invoke_simple_typed(grow, 0), Ok(10));
     assert_eq!(store.invoke_simple_typed(grow, 1), Ok(-1));
     assert_eq!(store.invoke_simple_typed(grow, 0x10000), Ok(-1));
-}
-
-#[test_log::test]
-fn try_grow_past_limit() {
-    let mut store = Store::new(());
-
-    let mem = store.mem_alloc(MemType {
-        limits: Limits {
-            min: 1,
-            max: Some(3),
-        },
-    });
-
-    assert_eq!(store.mem_grow(mem, 1), Ok(()));
-    assert_eq!(store.mem_grow(mem, 1), Ok(()));
-    assert_eq!(
-        store.mem_grow(mem, 1),
-        Err(RuntimeError::MemoryGrowExceededLimit)
-    );
-
-    assert_eq!(
-        store.mem_grow(mem, 1 << 17),
-        Err(RuntimeError::MemoryGrowOverflowed)
-    );
 }


### PR DESCRIPTION
<!--
Describe your changes here in detail, for example:

- What problem does this PR solve?
- How has behavior changed?
- Are the changes tested accordingly?
-->

<!-- TODO -->
See commit message

# Open Questions / TODOs

<!-- This pull request still needs... -->

<!-- TODO -->

# Benchmark Results

<!-- If you expect performance to be affected, put your benchmark results here -->

<!-- TODO -->

# References

<!--
Put all your references and footnotes here, for example:

- Automatically close an issue: `Closes <ISSUE>`.
- Markdown footnote: `[^my-footnote]: A description for my footnote.`
-->

<!-- TODO -->

# Checks

<!-- Please tick off what you did -->

- Using Nix
  - [x] Ran `nix fmt`
  - [x] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [ ] Ran `cargo fmt`
  - [ ] Ran `cargo test`
  - [ ] Ran `cargo check`
  - [ ] Ran `cargo build`
  - [ ] Ran `cargo clippy --workspace`
  - [ ] Ran `cargo doc --document-private-items --workspace`
