### PR TITLE
feat: add immutable memory data accessor

### DIFF
--- a/crates/checked/src/store.rs
+++ b/crates/checked/src/store.rs
@@ -509,6 +509,14 @@ impl<'b, T: Config> Store<'b, T> {
         Ok(stored_return_values)
     }
 
+    /// This is a safe variant of [`Store::mem_data`](dlr_wasm_interpreter::Store::mem_data).
+    pub fn mem_data(&self, memory: Stored<MemAddr>) -> &[u8] {
+        let memory = memory.try_unwrap_into_bare(self.id);
+        // SAFETY: It was just checked that the `MemAddr` came from the current
+        // store through its store id.
+        unsafe { self.inner.mem_data(memory) }
+    }
+
     /// This is a safe variant of [`Store::mem_data_mut`](dlr_wasm_interpreter::Store::mem_data_mut).
     pub fn mem_data_mut(&mut self, memory: Stored<MemAddr>) -> &mut [u8] {
         // 1. try unwrap

--- a/src/execution/runtime_structure/memory_instances/linear_memory.rs
+++ b/src/execution/runtime_structure/memory_instances/linear_memory.rs
@@ -256,6 +256,12 @@ impl<const PAGE_SIZE: usize> LinearMemory<PAGE_SIZE> {
 
     /// Returns the data in this memory as a byte slice. The length of this slice is always a
     /// multiple of `PAGE_SIZE`.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Returns the data in this memory as a mutable byte slice. The length of this slice is always
+    /// a multiple of `PAGE_SIZE`.
     pub fn data_mut(&mut self) -> &mut [u8] {
         &mut self.data
     }

--- a/src/execution/runtime_structure/store.rs
+++ b/src/execution/runtime_structure/store.rs
@@ -1492,6 +1492,19 @@ impl<'b, T: Config> Store<'b, T> {
     ///
     /// The caller has to guarantee that the given [`MemAddr`] came from the current [`Store`]
     /// object.
+    pub unsafe fn mem_data(&self, memory: MemAddr) -> &[u8] {
+        // SAFETY: The caller ensures that the given memory address is valid in
+        // the current store.
+        let memory = unsafe { self.inner.memories.get(memory) };
+        memory.mem.data()
+    }
+
+    /// Returns the inner data of a specific memory instance as a mutable byte slice.
+    ///
+    /// # Safety
+    ///
+    /// The caller has to guarantee that the given [`MemAddr`] came from the current [`Store`]
+    /// object.
     pub unsafe fn mem_data_mut(&mut self, memory: MemAddr) -> &mut [u8] {
         // SAFETY: The caller ensures that the given memory address is valid in
         // the current store.

--- a/tests/memory_as_slice.rs
+++ b/tests/memory_as_slice.rs
@@ -32,7 +32,7 @@ fn interpret_as_str() {
     let bytes_written = mem_as_slice.write(STR_TO_WRITE.as_bytes()).unwrap();
     assert_eq!(bytes_written, 12);
 
-    let mem_as_slice = store.mem_data_mut(mem);
+    let mem_as_slice = store.mem_data(mem);
     // Read the string again and check if it is equal to the original one
     let bytes = &mem_as_slice[0..STR_TO_WRITE.len()];
     let as_str = std::str::from_utf8(bytes).unwrap();


### PR DESCRIPTION
Adds immutable memory access to `LinearMemory` and exposes it through the core and checked `Store` APIs. The existing memory-as-slice test now exercises the read-only path.

# Open Questions / TODOs

None.

# Benchmark Results

Not applicable.

# References

Part of #374. The wasmi-benchmarks update will follow once this API is available.

# Checks

- Using Nix
  - [ ] Ran `nix fmt`
  - [ ] Ran `nix flake check '.?submodules=1'`
- Using Rust tooling
  - [x] Ran `cargo fmt`
  - [x] Ran `cargo test`
  - [x] Ran `cargo check`
  - [x] Ran `cargo build`
  - [x] Ran `cargo clippy --workspace`
  - [x] Ran `cargo doc --document-private-items --workspace`